### PR TITLE
fix: flaky test due to map iteration order

### DIFF
--- a/internal/schemagen/schemagen.go
+++ b/internal/schemagen/schemagen.go
@@ -259,10 +259,19 @@ func EnhanceNestedTypes(schema *jsonschema.Schema, typ reflect.Type, parseTagFun
 
 // ApplyConstraints applies validation constraints to a JSON Schema.
 func ApplyConstraints(schema *jsonschema.Schema, constraintsMap map[string]string, fieldType reflect.Type) {
+	// Process description first (before deprecated can append to it)
+	if desc, ok := constraintsMap[metaDescription]; ok {
+		schema.Description = desc
+	}
+
 	for name, value := range constraintsMap {
 		switch name {
 		case "required":
 			// Already handled in EnhanceSchema
+			continue
+
+		case metaDescription:
+			// Already processed above to ensure order
 			continue
 
 		case "min":
@@ -387,9 +396,6 @@ func ApplyConstraints(schema *jsonschema.Schema, constraintsMap map[string]strin
 
 		case metaTitle:
 			schema.Title = value
-
-		case metaDescription:
-			schema.Description = value
 
 		case metaExamples:
 			// Split by pipe delimiter for multiple examples


### PR DESCRIPTION
## Summary

Fix flaky test `TestApplyConstraints/deprecated_with_existing_description` that fails intermittently due to Go's non-deterministic map iteration order.

## Root Cause

When both `description` and `deprecated` constraints are provided, the `deprecated` handler needs to append to the existing description. However, `ApplyConstraints` iterates over a map, and Go randomizes map iteration order. If `description` was processed after `deprecated`, it would overwrite the appended value.

## Fix

Process `description` constraint first (before the loop) to guarantee it's set before `deprecated` can append to it.

## Test Plan

- [x] Run test 10 times to verify no flakiness