### PR TITLE
fix(constraints): support decimal values in min/max constraints

### DIFF
--- a/internal/constraints/numeric.go
+++ b/internal/constraints/numeric.go
@@ -10,8 +10,8 @@ import (
 
 // Numeric constraint types.
 type (
-	minConstraint            struct{ min int }
-	maxConstraint            struct{ max int }
+	minConstraint            struct{ min float64 }
+	maxConstraint            struct{ max float64 }
 	minLengthConstraint      struct{ minLength int }
 	maxLengthConstraint      struct{ maxLength int }
 	gtConstraint             struct{ threshold float64 }
@@ -36,7 +36,7 @@ const (
 
 // validateBound is a helper that validates numeric bounds (min or max).
 // For min: value must be >= bound. For max: value must be <= bound.
-func validateBound(value any, bound int, mode boundMode) error {
+func validateBound(value any, bound float64, mode boundMode) error {
 	v, ok := derefValue(value)
 	if !ok {
 		return nil // Skip validation for invalid/nil values
@@ -60,35 +60,35 @@ func validateBound(value any, bound int, mode boundMode) error {
 	return formatBoundError(v.Kind(), bound, mode, constraintName)
 }
 
-func checkMinViolation(v reflect.Value, bound int) bool {
+func checkMinViolation(v reflect.Value, bound float64) bool {
 	switch v.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return v.Int() < int64(bound)
+		return float64(v.Int()) < bound
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return bound >= 0 && v.Uint() < uint64(bound) //nolint:gosec // bounds checked
+		return float64(v.Uint()) < bound
 	case reflect.Float32, reflect.Float64:
-		return v.Float() < float64(bound)
+		return v.Float() < bound
 	case reflect.String:
-		return len(v.String()) < bound
+		return float64(len(v.String())) < bound
 	}
 	return true // unsupported type is a violation
 }
 
-func checkMaxViolation(v reflect.Value, bound int) bool {
+func checkMaxViolation(v reflect.Value, bound float64) bool {
 	switch v.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return v.Int() > int64(bound)
+		return float64(v.Int()) > bound
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return bound >= 0 && v.Uint() > uint64(bound) //nolint:gosec // bounds checked
+		return float64(v.Uint()) > bound
 	case reflect.Float32, reflect.Float64:
-		return v.Float() > float64(bound)
+		return v.Float() > bound
 	case reflect.String:
-		return len(v.String()) > bound
+		return float64(len(v.String())) > bound
 	}
 	return true // unsupported type is a violation
 }
 
-func formatBoundError(kind reflect.Kind, bound int, mode boundMode, constraintName string) error {
+func formatBoundError(kind reflect.Kind, bound float64, mode boundMode, constraintName string) error {
 	msgWord := "at least"
 	code := CodeMinValue
 	if mode == boundMax {
@@ -99,9 +99,9 @@ func formatBoundError(kind reflect.Kind, bound int, mode boundMode, constraintNa
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
 		reflect.Float32, reflect.Float64:
-		return NewConstraintErrorf(code, "must be %s %d", msgWord, bound)
+		return NewConstraintErrorf(code, "must be %s %v", msgWord, bound)
 	case reflect.String:
-		return NewConstraintErrorf(code, "must be %s %d characters", msgWord, bound)
+		return NewConstraintErrorf(code, "must be %s %v characters", msgWord, bound)
 	default:
 		return NewConstraintErrorf(CodeUnsupportedType, "%s constraint not supported for type %s", constraintName, kind)
 	}
@@ -407,8 +407,9 @@ func (c disallowInfNanConstraint) Validate(value any) error {
 
 // buildMinConstraint creates a min constraint, handling context-aware type checking.
 // Returns (constraint, true) on success or (nil, false) if parsing fails.
+// Supports both integer (min=5) and decimal (min=0.5) values.
 func buildMinConstraint(value string, fieldType reflect.Type) (Constraint, bool) {
-	minVal, err := strconv.Atoi(value)
+	minVal, err := strconv.ParseFloat(value, 64)
 	if err != nil {
 		return nil, false
 	}
@@ -420,15 +421,17 @@ func buildMinConstraint(value string, fieldType reflect.Type) (Constraint, bool)
 	}
 	kind := checkType.Kind()
 	if kind == reflect.String || kind == reflect.Slice || kind == reflect.Array || kind == reflect.Map {
-		return minLengthConstraint{minLength: minVal}, true
+		// For length constraints, truncate to int (length must be integer)
+		return minLengthConstraint{minLength: int(minVal)}, true
 	}
 	return minConstraint{min: minVal}, true
 }
 
 // buildMaxConstraint creates a max constraint, handling context-aware type checking.
 // Returns (constraint, true) on success or (nil, false) if parsing fails.
+// Supports both integer (max=100) and decimal (max=1.0) values.
 func buildMaxConstraint(value string, fieldType reflect.Type) (Constraint, bool) {
-	maxVal, err := strconv.Atoi(value)
+	maxVal, err := strconv.ParseFloat(value, 64)
 	if err != nil {
 		return nil, false
 	}
@@ -440,7 +443,8 @@ func buildMaxConstraint(value string, fieldType reflect.Type) (Constraint, bool)
 	}
 	kind := checkType.Kind()
 	if kind == reflect.String || kind == reflect.Slice || kind == reflect.Array || kind == reflect.Map {
-		return maxLengthConstraint{maxLength: maxVal}, true
+		// For length constraints, truncate to int (length must be integer)
+		return maxLengthConstraint{maxLength: int(maxVal)}, true
 	}
 	return maxConstraint{max: maxVal}, true
 }

--- a/internal/constraints/numeric_test.go
+++ b/internal/constraints/numeric_test.go
@@ -13,7 +13,7 @@ func TestMaxConstraint(t *testing.T) {
 	tests := []struct {
 		name    string
 		value   any
-		max     int
+		max     float64
 		wantErr bool
 	}{
 		// Valid cases - below max
@@ -51,6 +51,12 @@ func TestMaxConstraint(t *testing.T) {
 		{name: "float32 exceeds max", value: float32(10.5), max: 10, wantErr: true},
 		{name: "float64 below max", value: float64(3.5), max: 10, wantErr: false},
 		{name: "float64 exceeds max", value: float64(10.5), max: 10, wantErr: true},
+
+		// Decimal max values (float bounds)
+		{name: "float below decimal max", value: 0.5, max: 1.0, wantErr: false},
+		{name: "float at decimal max", value: 1.0, max: 1.0, wantErr: false},
+		{name: "float exceeds decimal max", value: 1.5, max: 1.0, wantErr: true},
+		{name: "float within 0-1 range", value: 0.75, max: 1.0, wantErr: false},
 
 		// String (length check)
 		{name: "string below max length", value: "hello", max: 10, wantErr: false},
@@ -232,7 +238,7 @@ func TestMinConstraint(t *testing.T) {
 	tests := []struct {
 		name    string
 		value   any
-		min     int
+		min     float64
 		wantErr bool
 	}{
 		// Valid cases - above min
@@ -253,6 +259,13 @@ func TestMinConstraint(t *testing.T) {
 		{name: "int8 above min", value: int8(50), min: 10, wantErr: false},
 		{name: "uint above min", value: uint(50), min: 10, wantErr: false},
 		{name: "float32 above min", value: float32(5.0), min: 3, wantErr: false},
+
+		// Decimal min values (float bounds)
+		{name: "float above decimal min", value: 0.5, min: 0.0, wantErr: false},
+		{name: "float at decimal min", value: 0.0, min: 0.0, wantErr: false},
+		{name: "float below decimal min", value: -0.1, min: 0.0, wantErr: true},
+		{name: "float within 0-1 range at 0.5 min", value: 0.75, min: 0.5, wantErr: false},
+		{name: "float below 0.5 min", value: 0.3, min: 0.5, wantErr: true},
 
 		// String (length check)
 		{name: "string above min length", value: "hello", min: 3, wantErr: false},

--- a/minmax_dive_test.go
+++ b/minmax_dive_test.go
@@ -1,0 +1,194 @@
+package pedantigo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMinMaxNumericInNestedDiveStruct tests that min/max constraints work correctly
+// on numeric fields inside nested structs accessed via dive.
+func TestMinMaxNumericInNestedDiveStruct(t *testing.T) {
+	type Fact struct {
+		Content    string  `json:"content" pedantigo:"required"`
+		Importance float32 `json:"importance" pedantigo:"required,min=0,max=1"`
+	}
+	type Schema struct {
+		Facts []Fact `json:"facts" pedantigo:"required,dive"`
+	}
+
+	validator := New[Schema]()
+
+	t.Run("value exceeds max should fail", func(t *testing.T) {
+		jsonData := []byte(`{"facts":[{"content":"test","importance":1.5}]}`)
+
+		_, err := validator.Unmarshal(jsonData)
+		require.Error(t, err, "value exceeding max should error")
+
+		var ve *ValidationError
+		require.ErrorAs(t, err, &ve)
+
+		found := false
+		for _, fieldErr := range ve.Errors {
+			if fieldErr.Field == "Facts[0].Importance" {
+				found = true
+				assert.Contains(t, fieldErr.Message, "at most 1")
+			}
+		}
+		assert.True(t, found, "expected error for Facts[0].Importance, got: %v", ve.Errors)
+	})
+
+	t.Run("value below min should fail", func(t *testing.T) {
+		jsonData := []byte(`{"facts":[{"content":"test","importance":-0.1}]}`)
+
+		_, err := validator.Unmarshal(jsonData)
+		require.Error(t, err, "value below min should error")
+
+		var ve *ValidationError
+		require.ErrorAs(t, err, &ve)
+
+		found := false
+		for _, fieldErr := range ve.Errors {
+			if fieldErr.Field == "Facts[0].Importance" {
+				found = true
+				assert.Contains(t, fieldErr.Message, "at least 0")
+			}
+		}
+		assert.True(t, found, "expected error for Facts[0].Importance, got: %v", ve.Errors)
+	})
+
+	t.Run("value in range should pass", func(t *testing.T) {
+		jsonData := []byte(`{"facts":[{"content":"test","importance":0.5}]}`)
+
+		result, err := validator.Unmarshal(jsonData)
+		require.NoError(t, err, "value in range should not error")
+		assert.InDelta(t, float32(0.5), result.Facts[0].Importance, 0.0001)
+	})
+
+	t.Run("zero value (min boundary) should pass", func(t *testing.T) {
+		jsonData := []byte(`{"facts":[{"content":"test","importance":0}]}`)
+
+		result, err := validator.Unmarshal(jsonData)
+		require.NoError(t, err, "zero value at min boundary should not error")
+		assert.InDelta(t, float32(0.0), result.Facts[0].Importance, 0.0001)
+	})
+
+	t.Run("max boundary value should pass", func(t *testing.T) {
+		jsonData := []byte(`{"facts":[{"content":"test","importance":1}]}`)
+
+		result, err := validator.Unmarshal(jsonData)
+		require.NoError(t, err, "max boundary value should not error")
+		assert.InDelta(t, float32(1.0), result.Facts[0].Importance, 0.0001)
+	})
+
+	t.Run("multiple facts with mixed validity", func(t *testing.T) {
+		// First fact valid, second fact exceeds max
+		jsonData := []byte(`{"facts":[{"content":"good","importance":0.5},{"content":"bad","importance":2.0}]}`)
+
+		_, err := validator.Unmarshal(jsonData)
+		require.Error(t, err, "second fact exceeding max should error")
+
+		var ve *ValidationError
+		require.ErrorAs(t, err, &ve)
+
+		found := false
+		for _, fieldErr := range ve.Errors {
+			if fieldErr.Field == "Facts[1].Importance" {
+				found = true
+				assert.Contains(t, fieldErr.Message, "at most 1")
+			}
+		}
+		assert.True(t, found, "expected error for Facts[1].Importance, got: %v", ve.Errors)
+	})
+}
+
+// TestMinMaxIntInNestedDiveStruct tests min/max on int fields in nested structs.
+func TestMinMaxIntInNestedDiveStruct(t *testing.T) {
+	type Item struct {
+		Name     string `json:"name" pedantigo:"required"`
+		Quantity int    `json:"quantity" pedantigo:"required,min=0,max=100"`
+	}
+	type Order struct {
+		Items []Item `json:"items" pedantigo:"required,dive"`
+	}
+
+	validator := New[Order]()
+
+	t.Run("quantity exceeds max should fail", func(t *testing.T) {
+		jsonData := []byte(`{"items":[{"name":"widget","quantity":150}]}`)
+
+		_, err := validator.Unmarshal(jsonData)
+		require.Error(t, err)
+
+		var ve *ValidationError
+		require.ErrorAs(t, err, &ve)
+		assert.NotEmpty(t, ve.Errors)
+	})
+
+	t.Run("negative quantity should fail", func(t *testing.T) {
+		jsonData := []byte(`{"items":[{"name":"widget","quantity":-5}]}`)
+
+		_, err := validator.Unmarshal(jsonData)
+		require.Error(t, err)
+	})
+
+	t.Run("zero quantity should pass", func(t *testing.T) {
+		jsonData := []byte(`{"items":[{"name":"widget","quantity":0}]}`)
+
+		result, err := validator.Unmarshal(jsonData)
+		require.NoError(t, err)
+		assert.Equal(t, 0, result.Items[0].Quantity)
+	})
+
+	t.Run("valid quantity should pass", func(t *testing.T) {
+		jsonData := []byte(`{"items":[{"name":"widget","quantity":50}]}`)
+
+		result, err := validator.Unmarshal(jsonData)
+		require.NoError(t, err)
+		assert.Equal(t, 50, result.Items[0].Quantity)
+	})
+}
+
+// TestMinMaxInNestedMapStruct tests min/max on fields in map value structs.
+func TestMinMaxInNestedMapStruct(t *testing.T) {
+	type Score struct {
+		Value float64 `json:"value" pedantigo:"required,min=0,max=100"`
+	}
+	type Scores struct {
+		BySubject map[string]Score `json:"by_subject" pedantigo:"dive"`
+	}
+
+	validator := New[Scores]()
+
+	t.Run("score exceeds max should fail", func(t *testing.T) {
+		jsonData := []byte(`{"by_subject":{"math":{"value":105}}}`)
+
+		_, err := validator.Unmarshal(jsonData)
+		require.Error(t, err)
+	})
+
+	t.Run("negative score should fail", func(t *testing.T) {
+		jsonData := []byte(`{"by_subject":{"math":{"value":-10}}}`)
+
+		_, err := validator.Unmarshal(jsonData)
+		require.Error(t, err)
+	})
+
+	t.Run("valid scores should pass", func(t *testing.T) {
+		jsonData := []byte(`{"by_subject":{"math":{"value":95},"english":{"value":88}}}`)
+
+		result, err := validator.Unmarshal(jsonData)
+		require.NoError(t, err)
+		assert.InDelta(t, 95.0, result.BySubject["math"].Value, 0.0001)
+		assert.InDelta(t, 88.0, result.BySubject["english"].Value, 0.0001)
+	})
+
+	t.Run("zero score should pass", func(t *testing.T) {
+		jsonData := []byte(`{"by_subject":{"failed":{"value":0}}}`)
+
+		result, err := validator.Unmarshal(jsonData)
+		require.NoError(t, err)
+		assert.InDelta(t, 0.0, result.BySubject["failed"].Value, 0.0001)
+	})
+}


### PR DESCRIPTION
- Change minConstraint and maxConstraint to use float64 bounds
- Update buildMinConstraint/buildMaxConstraint to use ParseFloat
- Preserve string length checking behavior
- Add tests for decimal min/max values (e.g., min=0.0,max=1.0)
- Add comprehensive tests for min/max in nested dive structs

This fixes the bug where min=0.0,max=1.0 was silently ignored because strconv.Atoi cannot parse decimal values.