### PR TITLE
fix(validator): prevent stack overflow on circular type refs and Validatable re-entrancy

### DIFF
--- a/validator.go
+++ b/validator.go
@@ -39,6 +39,11 @@ type Validator[T any] struct {
 
 	// Extra fields support (nil when ExtraAllow disabled)
 	extraFieldInfo *deserialize.ExtraFieldInfo
+
+	// Re-entrancy guard for Validatable.Validate() calls (#15)
+	// Tracks object pointers currently being validated to prevent infinite recursion
+	// when a user's Validate() method calls back into pedantigo.
+	validating sync.Map
 }
 
 // New creates a new Validator for type T with optional configuration.
@@ -79,7 +84,8 @@ func New[T any](opts ...ValidatorOptions) *Validator[T] {
 	validator.validateDiveTags(typ, tagName)
 
 	// Build field constraints at creation time (the key optimization)
-	validator.fieldCache = validator.buildFieldConstraints(typ, tagName)
+	// Pass visited set to detect circular type references (#15)
+	validator.fieldCache = validator.buildFieldConstraints(typ, tagName, make(map[reflect.Type]bool))
 
 	// Detect extra_fields for ExtraAllow mode
 	if options.ExtraFields == ExtraAllow {
@@ -93,7 +99,8 @@ func New[T any](opts ...ValidatorOptions) *Validator[T] {
 }
 
 // buildFieldConstraints builds and caches all field constraints at creation time.
-func (v *Validator[T]) buildFieldConstraints(typ reflect.Type, tagName string) *constraints.FieldCache {
+// visited tracks types already being processed to detect circular references (#15).
+func (v *Validator[T]) buildFieldConstraints(typ reflect.Type, tagName string, visited map[reflect.Type]bool) *constraints.FieldCache {
 	// Handle pointer types
 	if typ.Kind() == reflect.Ptr {
 		typ = typ.Elem()
@@ -102,6 +109,15 @@ func (v *Validator[T]) buildFieldConstraints(typ reflect.Type, tagName string) *
 	if typ.Kind() != reflect.Struct {
 		return nil
 	}
+
+	// Detect circular type references: if we're already building constraints
+	// for this type, return nil to break the cycle. At validation time, nil
+	// NestedCache means "don't recurse" which is correct — the parent type's
+	// validator already covers its own fields.
+	if visited[typ] {
+		return nil
+	}
+	visited[typ] = true
 
 	cache := constraints.NewFieldCache()
 
@@ -166,17 +182,17 @@ func (v *Validator[T]) buildFieldConstraints(typ reflect.Type, tagName string) *
 			cached.HasSkipConstraints = len(cached.SkipConstraints) > 0
 		}
 
-		// Recurse for nested structs
+		// Recurse for nested structs (passing visited set for cycle detection)
 		switch fieldType.Kind() {
 		case reflect.Struct:
-			cached.NestedCache = v.buildFieldConstraints(fieldType, tagName)
+			cached.NestedCache = v.buildFieldConstraints(fieldType, tagName, visited)
 		case reflect.Slice, reflect.Map:
 			elemType := fieldType.Elem()
 			if elemType.Kind() == reflect.Ptr {
 				elemType = elemType.Elem()
 			}
 			if elemType.Kind() == reflect.Struct {
-				cached.NestedCache = v.buildFieldConstraints(elemType, tagName)
+				cached.NestedCache = v.buildFieldConstraints(elemType, tagName, visited)
 			}
 		}
 
@@ -291,19 +307,25 @@ func (v *Validator[T]) Validate(obj *T) error {
 	// Validate all fields using struct tags (required is skipped via buildConstraints)
 	v.validateWithCache(reflect.ValueOf(obj).Elem(), nil, ctx, v.fieldCache)
 
-	// Check if struct implements Validatable for cross-field validation
+	// Check if struct implements Validatable for cross-field validation.
+	// Use re-entrancy guard to prevent infinite recursion when user's
+	// Validate() method calls back into pedantigo (#15).
 	if validatable, ok := any(obj).(Validatable); ok {
-		if err := validatable.Validate(); err != nil {
-			// Check if it's a ValidationError with multiple errors
-			var ve *ValidationError
-			if errors.As(err, &ve) {
-				ctx.errs = append(ctx.errs, ve.Errors...)
-			} else {
-				// Single error or custom error type
-				ctx.errs = append(ctx.errs, FieldError{
-					Field:   "root",
-					Message: err.Error(),
-				})
+		key := reflect.ValueOf(obj).Pointer()
+		if _, alreadyValidating := v.validating.LoadOrStore(key, true); !alreadyValidating {
+			defer v.validating.Delete(key)
+			if err := validatable.Validate(); err != nil {
+				// Check if it's a ValidationError with multiple errors
+				var ve *ValidationError
+				if errors.As(err, &ve) {
+					ctx.errs = append(ctx.errs, ve.Errors...)
+				} else {
+					// Single error or custom error type
+					ctx.errs = append(ctx.errs, FieldError{
+						Field:   "root",
+						Message: err.Error(),
+					})
+				}
 			}
 		}
 	}

--- a/validator_test.go
+++ b/validator_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -2398,4 +2399,152 @@ func TestStringTransformations_WithValidation(t *testing.T) {
 		}
 	}
 	assert.True(t, foundEmailError, "expected email validation error")
+}
+
+// ============================================================
+// Circular reference types (must be package-level for cross-ref)
+// ============================================================
+
+// circularConversation references circularMessage, which references back.
+type circularConversation struct {
+	ID       string            `json:"id" pedantigo:"required"`
+	Messages []circularMessage `json:"messages" pedantigo:"dive"`
+}
+
+type circularMessage struct {
+	ID           string                `json:"id" pedantigo:"required"`
+	Conversation *circularConversation `json:"conversation"`
+}
+
+// TestCircularReference_Construction tests that New[T]() does not stack overflow
+// on circular type references. Regression test for #15.
+func TestCircularReference_Construction(t *testing.T) {
+	// This should NOT panic with stack overflow
+	require.NotPanics(t, func() {
+		_ = New[circularConversation]()
+	}, "New[T]() should handle circular type references without stack overflow")
+}
+
+// TestCircularReference_Validation tests that validation works on circular structs.
+func TestCircularReference_Validation(t *testing.T) {
+	v := New[circularConversation]()
+
+	conv := &circularConversation{
+		ID: "conv-1",
+		Messages: []circularMessage{
+			{
+				ID:           "msg-1",
+				Conversation: nil, // nil back-reference is fine
+			},
+		},
+	}
+
+	err := v.Validate(conv)
+	require.NoError(t, err)
+}
+
+// TestCircularReference_ValidationWithBackRef tests validation when the back-reference is populated.
+func TestCircularReference_ValidationWithBackRef(t *testing.T) {
+	v := New[circularConversation]()
+
+	conv := &circularConversation{
+		ID: "conv-1",
+	}
+	conv.Messages = []circularMessage{
+		{
+			ID:           "msg-1",
+			Conversation: conv, // circular back-reference
+		},
+	}
+
+	// Should not infinite loop during validation
+	err := v.Validate(conv)
+	require.NoError(t, err)
+}
+
+// TestCircularReference_Unmarshal tests that Unmarshal works with circular types.
+func TestCircularReference_Unmarshal(t *testing.T) {
+	v := New[circularConversation]()
+
+	result, err := v.Unmarshal([]byte(`{
+		"id": "conv-1",
+		"messages": [
+			{"id": "msg-1"}
+		]
+	}`))
+	require.NoError(t, err)
+	assert.Equal(t, "conv-1", result.ID)
+	require.Len(t, result.Messages, 1)
+	assert.Equal(t, "msg-1", result.Messages[0].ID)
+}
+
+// Self-referencing type (tree structure).
+type circularTreeNode struct {
+	Name     string              `json:"name" pedantigo:"required"`
+	Children []*circularTreeNode `json:"children" pedantigo:"dive"`
+}
+
+// TestCircularReference_SelfReferencing tests self-referencing types (trees).
+func TestCircularReference_SelfReferencing(t *testing.T) {
+	require.NotPanics(t, func() {
+		_ = New[circularTreeNode]()
+	}, "New[T]() should handle self-referencing types without stack overflow")
+
+	v := New[circularTreeNode]()
+	tree := &circularTreeNode{
+		Name: "root",
+		Children: []*circularTreeNode{
+			{Name: "child1"},
+			{Name: "child2", Children: []*circularTreeNode{
+				{Name: "grandchild"},
+			}},
+		},
+	}
+	err := v.Validate(tree)
+	require.NoError(t, err)
+}
+
+// validatableApp is a type that implements Validatable by calling back into pedantigo.
+type validatableApp struct {
+	Name string `json:"name" pedantigo:"required"`
+}
+
+var (
+	validatableAppValidator     *Validator[validatableApp]
+	validatableAppValidatorOnce sync.Once
+)
+
+func getValidatableAppValidator() *Validator[validatableApp] {
+	validatableAppValidatorOnce.Do(func() {
+		validatableAppValidator = New[validatableApp]()
+	})
+	return validatableAppValidator
+}
+
+func (a *validatableApp) Validate() error {
+	return getValidatableAppValidator().Validate(a)
+}
+
+// TestValidatable_ReentrancyGuard tests that Validatable.Validate() does not
+// cause infinite recursion when it calls back into pedantigo. Regression test for #15.
+func TestValidatable_ReentrancyGuard(t *testing.T) {
+	app := &validatableApp{Name: "my-app"}
+
+	// This should NOT cause stack overflow
+	err := getValidatableAppValidator().Validate(app)
+	require.NoError(t, err)
+}
+
+// TestValidatable_ReentrancyGuard_Unmarshal tests re-entrancy through Unmarshal path.
+// Unmarshal checks 'required' (unlike Validate), so a missing field triggers an error
+// while also exercising the Validatable → re-entrancy guard path.
+func TestValidatable_ReentrancyGuard_Unmarshal(t *testing.T) {
+	// Missing required "name" field → should return validation error, not stack overflow
+	_, err := getValidatableAppValidator().Unmarshal([]byte(`{}`))
+	require.Error(t, err)
+
+	// Valid JSON with name present → should succeed without stack overflow
+	app, err := getValidatableAppValidator().Unmarshal([]byte(`{"name":"my-app"}`))
+	require.NoError(t, err)
+	assert.Equal(t, "my-app", app.Name)
 }


### PR DESCRIPTION
## Summary

Fixes stack overflow crashes caused by circular type references during validator construction and infinite recursion when a user's `Validatable.Validate()` method calls back into pedantigo.

### Circular Type Reference Detection
- Added `visited map[reflect.Type]bool` parameter to `buildFieldConstraints` to track types already being processed
- When a circular reference is detected, returns `nil` to break the cycle — at validation time this means "don't recurse into already-covered fields"
- Handles both mutual references (A → B → A) and self-referencing types (tree nodes)

### Validatable Re-entrancy Guard
- Added `sync.Map` field (`validating`) to `Validator[T]` to track object pointers currently being validated
- Uses `LoadOrStore` to detect re-entrant calls — if an object is already being validated, the nested `Validatable.Validate()` call is skipped
- Cleaned up via `defer Delete` to ensure the guard is released after validation completes

### Tests
- `TestCircularReference_Construction` — verifies `New[T]()` doesn't panic on circular types
- `TestCircularReference_Validation` — validates circular structs with nil back-references
- `TestCircularReference_ValidationWithBackRef` — validates with populated circular back-references
- `TestCircularReference_Unmarshal` — unmarshal works correctly with circular types
- `TestCircularReference_SelfReferencing` — tree/self-referencing type handling
- `TestValidatable_ReentrancyGuard` — no infinite recursion when `Validate()` calls pedantigo
- `TestValidatable_ReentrancyGuard_Unmarshal` — re-entrancy through the Unmarshal path with required field errors

## Test Plan
- [x] All 7 new regression tests pass
- [x] Full test suite passes (all packages)
- [x] golangci-lint passes
- [x] Pre-commit hooks pass (gofmt, vet, lint, build, tests)

Closes #15