### PR TITLE
feat!: pedantigo v2 — default tag validate, module path /v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           go install golang.org/x/tools/cmd/goimports@latest
 
           # golangci-lint v2.x (for make lint - matches local version)
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.7.2
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2
 
           # pre-commit (gitleaks installed automatically by pre-commit)
           pip install pre-commit

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,11 @@ fmt: ## Format code with goimports + gofmt
 lint: ## Run golangci-lint
 	@echo "Running golangci-lint..."
 	@which golangci-lint > /dev/null || (echo "golangci-lint not installed. Install with: brew install golangci-lint" && exit 1)
-	golangci-lint run ./...
+	# golangci-lint's binary is built with go1.25 and doesn't yet support go1.26
+	# (tracked upstream: golangci/golangci-lint#6272). Force its internal `go`
+	# subprocess calls to use go1.25 so package analysis doesn't panic, while
+	# the rest of the toolchain (build, vet, test) stays on go1.26.
+	GOTOOLCHAIN=go1.25.12 golangci-lint run ./...
 
 deps: ## Download and tidy Go dependencies
 	@echo "Tidying dependencies..."

--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@
 
 Type-safe JSON validation and schema generation for Go.
 
+> **v2 breaking change:** the default struct tag changed from `pedantigo` to `validate`. If you're upgrading from v1, see the [migration guide](docs/migration/v1-to-v2.md) before you update.
+
 ## Installation
 
 ```bash
-go get github.com/SmrutAI/pedantigo
+go get github.com/SmrutAI/pedantigo/v2
 ```
 
 Requires Go 1.21+

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Requires Go 1.21+
 
 ```go
 type User struct {
-    Email string `json:"email" pedantigo:"required,email"`
-    Age   int    `json:"age" pedantigo:"min=18"`
+    Email string `json:"email" validate:"required,email"`
+    Age   int    `json:"age" validate:"min=18"`
 }
 
 // Parse and validate JSON

--- a/TESTING.md
+++ b/TESTING.md
@@ -21,7 +21,7 @@ Table-driven tests are the standard pattern in Go. They reduce code duplication 
 ```go
 func TestMin(t *testing.T) {
 	type MinTest struct {
-		Age int `pedantigo:"min=18"`
+		Age int `validate:"min=18"`
 	}
 
 	tests := []struct {
@@ -75,13 +75,13 @@ When testing multiple types, use type switches:
 ```go
 func TestCrossFieldConstraints(t *testing.T) {
 	type StructA struct {
-		Field1 string `pedantigo:"required"`
-		Field2 string `pedantigo:"eqfield=Field1"`
+		Field1 string `validate:"required"`
+		Field2 string `validate:"eqfield=Field1"`
 	}
 
 	type StructB struct {
-		Age    int `pedantigo:"required"`
-		MinAge int `pedantigo:"ltfield=Age"`
+		Age    int `validate:"required"`
+		MinAge int `validate:"ltfield=Age"`
 	}
 
 	tests := []struct {
@@ -129,8 +129,8 @@ func TestCrossFieldConstraints(t *testing.T) {
 func TestFeatureName(t *testing.T) {
 	// 1. Define test structs
 	type TestStruct struct {
-		Field1 string `pedantigo:"required"`
-		Field2 int    `pedantigo:"min=0"`
+		Field1 string `validate:"required"`
+		Field2 int    `validate:"min=0"`
 	}
 
 	// 2. Create reusable validators (optional)
@@ -436,7 +436,7 @@ See `internal/constraints/constraints_test.go`:
 ```go
 func TestEmail(t *testing.T) {
 	type EmailTest struct {
-		Email string `pedantigo:"email"`
+		Email string `validate:"email"`
 	}
 
 	tests := []struct {
@@ -471,8 +471,8 @@ See `internal/constraints/crossfield_comparison_test.go`:
 ```go
 func TestEqField(t *testing.T) {
 	type PasswordConfirm struct {
-		Password        string `pedantigo:"required"`
-		PasswordConfirm string `pedantigo:"eqfield=Password"`
+		Password        string `validate:"required"`
+		PasswordConfirm string `validate:"eqfield=Password"`
 	}
 
 	tests := []struct {

--- a/collections_test.go
+++ b/collections_test.go
@@ -27,7 +27,7 @@ const (
 // TestSlice_ValidEmails tests slice element email validation with dive.
 func TestSlice_ValidEmails(t *testing.T) {
 	type Config struct {
-		Admins []string `json:"admins" pedantigo:"dive,email"`
+		Admins []string `json:"admins" validate:"dive,email"`
 	}
 
 	validator := New[Config]()
@@ -40,7 +40,7 @@ func TestSlice_ValidEmails(t *testing.T) {
 
 func TestSlice_InvalidEmail_SingleElement(t *testing.T) {
 	type Config struct {
-		Admins []string `json:"admins" pedantigo:"dive,email"`
+		Admins []string `json:"admins" validate:"dive,email"`
 	}
 
 	validator := New[Config]()
@@ -64,7 +64,7 @@ func TestSlice_InvalidEmail_SingleElement(t *testing.T) {
 
 func TestSlice_InvalidEmail_MultipleElements(t *testing.T) {
 	type Config struct {
-		Admins []string `json:"admins" pedantigo:"dive,email"`
+		Admins []string `json:"admins" validate:"dive,email"`
 	}
 
 	validator := New[Config]()
@@ -100,7 +100,7 @@ func TestSlice_ElementMinLength(t *testing.T) {
 	// WITH dive: min=3 applies to each element's length (must be >= 3 chars)
 	t.Run("with_dive_element_length", func(t *testing.T) {
 		type User struct {
-			Tags []string `json:"tags" pedantigo:"dive,min=3"`
+			Tags []string `json:"tags" validate:"dive,min=3"`
 		}
 
 		validator := New[User]()
@@ -119,7 +119,7 @@ func TestSlice_ElementMinLength(t *testing.T) {
 	// WITHOUT dive: min=3 applies to slice length (must have >= 3 elements)
 	t.Run("without_dive_collection_length", func(t *testing.T) {
 		type User struct {
-			Tags []string `json:"tags" pedantigo:"min=3"`
+			Tags []string `json:"tags" validate:"min=3"`
 		}
 
 		validator := New[User]()
@@ -142,12 +142,12 @@ func TestSlice_ElementMinLength(t *testing.T) {
 
 func TestSlice_NestedStructValidation(t *testing.T) {
 	type Address struct {
-		City string `json:"city" pedantigo:"required"`
-		Zip  string `json:"zip" pedantigo:"min=5"`
+		City string `json:"city" validate:"required"`
+		Zip  string `json:"zip" validate:"min=5"`
 	}
 
 	type User struct {
-		Addresses []Address `json:"addresses" pedantigo:"dive"` // dive required to recurse into elements (like playground)
+		Addresses []Address `json:"addresses" validate:"dive"` // dive required to recurse into elements (like playground)
 	}
 
 	validator := New[User]()
@@ -183,7 +183,7 @@ func TestSlice_EmptySlice(t *testing.T) {
 	// WITH dive: empty slice passes (no elements to validate)
 	t.Run("with_dive_passes", func(t *testing.T) {
 		type Config struct {
-			Admins []string `json:"admins" pedantigo:"dive,email"`
+			Admins []string `json:"admins" validate:"dive,email"`
 		}
 
 		validator := New[Config]()
@@ -195,7 +195,7 @@ func TestSlice_EmptySlice(t *testing.T) {
 	// WITHOUT dive with min constraint: empty slice FAILS collection constraint
 	t.Run("without_dive_fails_min", func(t *testing.T) {
 		type Config struct {
-			Admins []string `json:"admins" pedantigo:"min=1"`
+			Admins []string `json:"admins" validate:"min=1"`
 		}
 
 		validator := New[Config]()
@@ -212,7 +212,7 @@ func TestSlice_NilSlice(t *testing.T) {
 	// WITH dive: nil slice passes (no elements to validate)
 	t.Run("with_dive_passes", func(t *testing.T) {
 		type Config struct {
-			Admins []string `json:"admins" pedantigo:"dive,email"`
+			Admins []string `json:"admins" validate:"dive,email"`
 		}
 
 		validator := New[Config]()
@@ -224,7 +224,7 @@ func TestSlice_NilSlice(t *testing.T) {
 	// WITHOUT dive with min constraint: nil slice has length 0, FAILS min constraint
 	t.Run("without_dive_fails_min", func(t *testing.T) {
 		type Config struct {
-			Admins []string `json:"admins" pedantigo:"min=1"`
+			Admins []string `json:"admins" validate:"min=1"`
 		}
 
 		validator := New[Config]()
@@ -245,7 +245,7 @@ func TestSlice_NilSlice(t *testing.T) {
 // TestMap_ValidEmails tests map value email validation with dive.
 func TestMap_ValidEmails(t *testing.T) {
 	type Config struct {
-		Contacts map[string]string `json:"contacts" pedantigo:"dive,email"`
+		Contacts map[string]string `json:"contacts" validate:"dive,email"`
 	}
 
 	validator := New[Config]()
@@ -258,7 +258,7 @@ func TestMap_ValidEmails(t *testing.T) {
 
 func TestMap_InvalidEmail_SingleValue(t *testing.T) {
 	type Config struct {
-		Contacts map[string]string `json:"contacts" pedantigo:"dive,email"`
+		Contacts map[string]string `json:"contacts" validate:"dive,email"`
 	}
 
 	validator := New[Config]()
@@ -282,7 +282,7 @@ func TestMap_InvalidEmail_SingleValue(t *testing.T) {
 
 func TestMap_InvalidEmail_MultipleValues(t *testing.T) {
 	type Config struct {
-		Contacts map[string]string `json:"contacts" pedantigo:"dive,email"`
+		Contacts map[string]string `json:"contacts" validate:"dive,email"`
 	}
 
 	validator := New[Config]()
@@ -316,7 +316,7 @@ func TestMap_ElementMinLength(t *testing.T) {
 	// WITH dive: min=3 applies to each value's length (must be >= 3 chars)
 	t.Run("with_dive_value_length", func(t *testing.T) {
 		type Config struct {
-			Tags map[string]string `json:"tags" pedantigo:"dive,min=3"`
+			Tags map[string]string `json:"tags" validate:"dive,min=3"`
 		}
 
 		validator := New[Config]()
@@ -335,7 +335,7 @@ func TestMap_ElementMinLength(t *testing.T) {
 	// WITHOUT dive: min=3 applies to map entry count (must have >= 3 entries)
 	t.Run("without_dive_entry_count", func(t *testing.T) {
 		type Config struct {
-			Tags map[string]string `json:"tags" pedantigo:"min=3"`
+			Tags map[string]string `json:"tags" validate:"min=3"`
 		}
 
 		validator := New[Config]()
@@ -358,12 +358,12 @@ func TestMap_ElementMinLength(t *testing.T) {
 
 func TestMap_NestedStructValidation(t *testing.T) {
 	type Address struct {
-		City string `json:"city" pedantigo:"required"`
-		Zip  string `json:"zip" pedantigo:"min=5"`
+		City string `json:"city" validate:"required"`
+		Zip  string `json:"zip" validate:"min=5"`
 	}
 
 	type Company struct {
-		Offices map[string]Address `json:"offices" pedantigo:"dive"` // dive required to recurse into elements (like playground)
+		Offices map[string]Address `json:"offices" validate:"dive"` // dive required to recurse into elements (like playground)
 	}
 
 	validator := New[Company]()
@@ -399,7 +399,7 @@ func TestMap_EmptyMap(t *testing.T) {
 	// WITH dive: empty map passes (no entries to validate)
 	t.Run("with_dive_passes", func(t *testing.T) {
 		type Config struct {
-			Contacts map[string]string `json:"contacts" pedantigo:"dive,email"`
+			Contacts map[string]string `json:"contacts" validate:"dive,email"`
 		}
 
 		validator := New[Config]()
@@ -411,7 +411,7 @@ func TestMap_EmptyMap(t *testing.T) {
 	// WITHOUT dive with min constraint: empty map FAILS collection constraint
 	t.Run("without_dive_fails_min", func(t *testing.T) {
 		type Config struct {
-			Contacts map[string]string `json:"contacts" pedantigo:"min=1"`
+			Contacts map[string]string `json:"contacts" validate:"min=1"`
 		}
 
 		validator := New[Config]()
@@ -428,7 +428,7 @@ func TestMap_NilMap(t *testing.T) {
 	// WITH dive: nil map passes (no entries to validate)
 	t.Run("with_dive_passes", func(t *testing.T) {
 		type Config struct {
-			Contacts map[string]string `json:"contacts" pedantigo:"dive,email"`
+			Contacts map[string]string `json:"contacts" validate:"dive,email"`
 		}
 
 		validator := New[Config]()
@@ -440,7 +440,7 @@ func TestMap_NilMap(t *testing.T) {
 	// WITHOUT dive with min constraint: nil map has length 0, FAILS min constraint
 	t.Run("without_dive_fails_min", func(t *testing.T) {
 		type Config struct {
-			Contacts map[string]string `json:"contacts" pedantigo:"min=1"`
+			Contacts map[string]string `json:"contacts" validate:"min=1"`
 		}
 
 		validator := New[Config]()
@@ -457,7 +457,7 @@ func TestMap_NilMap(t *testing.T) {
 // TestSlice_CollectionMinElements tests that without dive, min applies to slice length.
 func TestSlice_CollectionMinElements(t *testing.T) {
 	type Config struct {
-		Tags []string `json:"tags" pedantigo:"min=3"` // NO dive = collection constraint
+		Tags []string `json:"tags" validate:"min=3"` // NO dive = collection constraint
 	}
 	validator := New[Config]()
 
@@ -479,7 +479,7 @@ func TestSlice_CollectionMinElements(t *testing.T) {
 // TestSlice_CollectionMaxElements tests that without dive, max applies to slice length.
 func TestSlice_CollectionMaxElements(t *testing.T) {
 	type Config struct {
-		Tags []string `json:"tags" pedantigo:"max=2"` // NO dive = collection constraint
+		Tags []string `json:"tags" validate:"max=2"` // NO dive = collection constraint
 	}
 	validator := New[Config]()
 
@@ -501,7 +501,7 @@ func TestSlice_CollectionMaxElements(t *testing.T) {
 func TestSlice_MixedConstraints(t *testing.T) {
 	type Config struct {
 		// Collection: min 2 elements; Elements: each min 5 chars
-		Tags []string `json:"tags" pedantigo:"min=2,dive,min=5"`
+		Tags []string `json:"tags" validate:"min=2,dive,min=5"`
 	}
 	validator := New[Config]()
 
@@ -527,7 +527,7 @@ func TestSlice_MixedConstraints(t *testing.T) {
 // TestMap_CollectionMinEntries tests that without dive, min applies to entry count.
 func TestMap_CollectionMinEntries(t *testing.T) {
 	type Config struct {
-		Tags map[string]string `json:"tags" pedantigo:"min=2"` // NO dive = entry count
+		Tags map[string]string `json:"tags" validate:"min=2"` // NO dive = entry count
 	}
 	validator := New[Config]()
 
@@ -551,7 +551,7 @@ func TestMap_CollectionMinEntries(t *testing.T) {
 func TestMap_KeyValidation(t *testing.T) {
 	type Config struct {
 		// Keys: min 3 chars; Values: must be emails
-		Contacts map[string]string `json:"contacts" pedantigo:"dive,keys,min=3,endkeys,email"`
+		Contacts map[string]string `json:"contacts" validate:"dive,keys,min=3,endkeys,email"`
 	}
 	validator := New[Config]()
 
@@ -580,7 +580,7 @@ func TestMap_KeyValidation(t *testing.T) {
 func TestMap_KeyOnlyValidation(t *testing.T) {
 	type Config struct {
 		// Only key constraints, no value constraints
-		Data map[string]int `json:"data" pedantigo:"dive,keys,min=2,endkeys"`
+		Data map[string]int `json:"data" validate:"dive,keys,min=2,endkeys"`
 	}
 	validator := New[Config]()
 
@@ -599,7 +599,7 @@ func TestMap_KeyOnlyValidation(t *testing.T) {
 // TestDive_PanicOnNonCollection tests that dive on a non-collection field panics.
 func TestDive_PanicOnNonCollection(t *testing.T) {
 	type Config struct {
-		Name string `json:"name" pedantigo:"dive,min=3"` // ERROR: dive on string
+		Name string `json:"name" validate:"dive,min=3"` // ERROR: dive on string
 	}
 
 	// Should panic at validator creation time
@@ -612,7 +612,7 @@ func TestDive_PanicOnNonCollection(t *testing.T) {
 func TestKeys_RequiresDive(t *testing.T) {
 	type Config struct {
 		// ERROR: keys without dive
-		Contacts map[string]string `json:"contacts" pedantigo:"keys,min=3,endkeys,email"`
+		Contacts map[string]string `json:"contacts" validate:"keys,min=3,endkeys,email"`
 	}
 
 	// Should panic at validator creation time
@@ -625,7 +625,7 @@ func TestKeys_RequiresDive(t *testing.T) {
 func TestEndKeys_RequiresKeys(t *testing.T) {
 	type Config struct {
 		// ERROR: endkeys without keys
-		Contacts map[string]string `json:"contacts" pedantigo:"dive,endkeys,email"`
+		Contacts map[string]string `json:"contacts" validate:"dive,endkeys,email"`
 	}
 
 	// Should panic at validator creation time
@@ -638,7 +638,7 @@ func TestEndKeys_RequiresKeys(t *testing.T) {
 func TestKeys_OnlyValidForMaps(t *testing.T) {
 	type Config struct {
 		// ERROR: keys on slice
-		Tags []string `json:"tags" pedantigo:"dive,keys,min=3,endkeys,email"`
+		Tags []string `json:"tags" validate:"dive,keys,min=3,endkeys,email"`
 	}
 
 	// Should panic at validator creation time
@@ -653,7 +653,7 @@ func TestKeys_OnlyValidForMaps(t *testing.T) {
 func TestSlice_Unique(t *testing.T) {
 	t.Run("unique_strings", func(t *testing.T) {
 		type Config struct {
-			Tags []string `json:"tags" pedantigo:"unique"`
+			Tags []string `json:"tags" validate:"unique"`
 		}
 		validator := New[Config]()
 
@@ -673,7 +673,7 @@ func TestSlice_Unique(t *testing.T) {
 
 	t.Run("unique_ints", func(t *testing.T) {
 		type Config struct {
-			IDs []int `json:"ids" pedantigo:"unique"`
+			IDs []int `json:"ids" validate:"unique"`
 		}
 		validator := New[Config]()
 
@@ -688,7 +688,7 @@ func TestSlice_Unique(t *testing.T) {
 
 	t.Run("empty_slice_passes", func(t *testing.T) {
 		type Config struct {
-			Tags []string `json:"tags" pedantigo:"unique"`
+			Tags []string `json:"tags" validate:"unique"`
 		}
 		validator := New[Config]()
 
@@ -699,7 +699,7 @@ func TestSlice_Unique(t *testing.T) {
 
 	t.Run("nil_slice_passes", func(t *testing.T) {
 		type Config struct {
-			Tags []string `json:"tags" pedantigo:"unique"`
+			Tags []string `json:"tags" validate:"unique"`
 		}
 		validator := New[Config]()
 
@@ -710,7 +710,7 @@ func TestSlice_Unique(t *testing.T) {
 
 	t.Run("single_element_passes", func(t *testing.T) {
 		type Config struct {
-			Tags []string `json:"tags" pedantigo:"unique"`
+			Tags []string `json:"tags" validate:"unique"`
 		}
 		validator := New[Config]()
 
@@ -724,7 +724,7 @@ func TestSlice_Unique(t *testing.T) {
 func TestMap_UniqueValues(t *testing.T) {
 	t.Run("unique_values", func(t *testing.T) {
 		type Config struct {
-			Scores map[string]int `json:"scores" pedantigo:"unique"`
+			Scores map[string]int `json:"scores" validate:"unique"`
 		}
 		validator := New[Config]()
 
@@ -744,7 +744,7 @@ func TestMap_UniqueValues(t *testing.T) {
 
 	t.Run("empty_map_passes", func(t *testing.T) {
 		type Config struct {
-			Scores map[string]int `json:"scores" pedantigo:"unique"`
+			Scores map[string]int `json:"scores" validate:"unique"`
 		}
 		validator := New[Config]()
 
@@ -763,7 +763,7 @@ func TestSlice_UniqueByField(t *testing.T) {
 
 	t.Run("unique_by_id", func(t *testing.T) {
 		type Config struct {
-			Users []User `json:"users" pedantigo:"unique=ID"`
+			Users []User `json:"users" validate:"unique=ID"`
 		}
 		validator := New[Config]()
 
@@ -783,7 +783,7 @@ func TestSlice_UniqueByField(t *testing.T) {
 
 	t.Run("unique_by_name", func(t *testing.T) {
 		type Config struct {
-			Users []User `json:"users" pedantigo:"unique=Name"`
+			Users []User `json:"users" validate:"unique=Name"`
 		}
 		validator := New[Config]()
 
@@ -798,7 +798,7 @@ func TestSlice_UniqueByField(t *testing.T) {
 
 	t.Run("empty_struct_slice_passes", func(t *testing.T) {
 		type Config struct {
-			Users []User `json:"users" pedantigo:"unique=ID"`
+			Users []User `json:"users" validate:"unique=ID"`
 		}
 		validator := New[Config]()
 
@@ -811,7 +811,7 @@ func TestSlice_UniqueByField(t *testing.T) {
 // TestUnique_PanicOnNonCollection tests that unique on non-collection panics.
 func TestUnique_PanicOnNonCollection(t *testing.T) {
 	type Config struct {
-		Name string `json:"name" pedantigo:"unique"`
+		Name string `json:"name" validate:"unique"`
 	}
 
 	assert.Panics(t, func() {
@@ -823,7 +823,7 @@ func TestUnique_PanicOnNonCollection(t *testing.T) {
 func TestSlice_UniqueWithOtherConstraints(t *testing.T) {
 	t.Run("unique_and_min", func(t *testing.T) {
 		type Config struct {
-			Tags []string `json:"tags" pedantigo:"unique,min=2"`
+			Tags []string `json:"tags" validate:"unique,min=2"`
 		}
 		validator := New[Config]()
 
@@ -851,10 +851,10 @@ func TestSlice_UniqueWithOtherConstraints(t *testing.T) {
 // TestDive_GT tests greater than constraint in nested structs via dive.
 func TestDive_GT(t *testing.T) {
 	type Item struct {
-		Value int `json:"value" pedantigo:"gt=10"`
+		Value int `json:"value" validate:"gt=10"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -895,10 +895,10 @@ func TestDive_GT(t *testing.T) {
 // TestDive_GT_Map tests greater than constraint in map values via dive.
 func TestDive_GT_Map(t *testing.T) {
 	type Item struct {
-		Score int `json:"score" pedantigo:"gt=50"`
+		Score int `json:"score" validate:"gt=50"`
 	}
 	type Container struct {
-		Scores map[string]Item `json:"scores" pedantigo:"dive"`
+		Scores map[string]Item `json:"scores" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -930,10 +930,10 @@ func TestDive_GT_Map(t *testing.T) {
 // TestDive_GTE tests greater than or equal constraint in nested structs via dive.
 func TestDive_GTE(t *testing.T) {
 	type Item struct {
-		Age int `json:"age" pedantigo:"gte=18"`
+		Age int `json:"age" validate:"gte=18"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -974,10 +974,10 @@ func TestDive_GTE(t *testing.T) {
 // TestDive_GTE_Map tests greater than or equal constraint in map values via dive.
 func TestDive_GTE_Map(t *testing.T) {
 	type Item struct {
-		Rating float64 `json:"rating" pedantigo:"gte=0.0"`
+		Rating float64 `json:"rating" validate:"gte=0.0"`
 	}
 	type Container struct {
-		Ratings map[string]Item `json:"ratings" pedantigo:"dive"`
+		Ratings map[string]Item `json:"ratings" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -1006,10 +1006,10 @@ func TestDive_GTE_Map(t *testing.T) {
 // TestDive_LT tests less than constraint in nested structs via dive.
 func TestDive_LT(t *testing.T) {
 	type Item struct {
-		Discount int `json:"discount" pedantigo:"lt=100"`
+		Discount int `json:"discount" validate:"lt=100"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -1050,10 +1050,10 @@ func TestDive_LT(t *testing.T) {
 // TestDive_LT_Map tests less than constraint in map values via dive.
 func TestDive_LT_Map(t *testing.T) {
 	type Item struct {
-		Temperature float64 `json:"temp" pedantigo:"lt=100.0"`
+		Temperature float64 `json:"temp" validate:"lt=100.0"`
 	}
 	type Container struct {
-		Readings map[string]Item `json:"readings" pedantigo:"dive"`
+		Readings map[string]Item `json:"readings" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -1082,10 +1082,10 @@ func TestDive_LT_Map(t *testing.T) {
 // TestDive_LTE tests less than or equal constraint in nested structs via dive.
 func TestDive_LTE(t *testing.T) {
 	type Item struct {
-		Capacity int `json:"capacity" pedantigo:"lte=1000"`
+		Capacity int `json:"capacity" validate:"lte=1000"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -1126,10 +1126,10 @@ func TestDive_LTE(t *testing.T) {
 // TestDive_LTE_Map tests less than or equal constraint in map values via dive.
 func TestDive_LTE_Map(t *testing.T) {
 	type Item struct {
-		Percentage float64 `json:"pct" pedantigo:"lte=100.0"`
+		Percentage float64 `json:"pct" validate:"lte=100.0"`
 	}
 	type Container struct {
-		Stats map[string]Item `json:"stats" pedantigo:"dive"`
+		Stats map[string]Item `json:"stats" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -1158,10 +1158,10 @@ func TestDive_LTE_Map(t *testing.T) {
 // TestDive_Positive tests positive constraint in nested structs via dive.
 func TestDive_Positive(t *testing.T) {
 	type Item struct {
-		Amount int `json:"amount" pedantigo:"positive"`
+		Amount int `json:"amount" validate:"positive"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -1205,10 +1205,10 @@ func TestDive_Positive(t *testing.T) {
 // TestDive_Positive_Map tests positive constraint in map values via dive.
 func TestDive_Positive_Map(t *testing.T) {
 	type Item struct {
-		Price float64 `json:"price" pedantigo:"positive"`
+		Price float64 `json:"price" validate:"positive"`
 	}
 	type Container struct {
-		Products map[string]Item `json:"products" pedantigo:"dive"`
+		Products map[string]Item `json:"products" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -1237,10 +1237,10 @@ func TestDive_Positive_Map(t *testing.T) {
 // TestDive_Negative tests negative constraint in nested structs via dive.
 func TestDive_Negative(t *testing.T) {
 	type Item struct {
-		Delta int `json:"delta" pedantigo:"negative"`
+		Delta int `json:"delta" validate:"negative"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -1284,10 +1284,10 @@ func TestDive_Negative(t *testing.T) {
 // TestDive_Negative_Map tests negative constraint in map values via dive.
 func TestDive_Negative_Map(t *testing.T) {
 	type Item struct {
-		Adjustment float64 `json:"adj" pedantigo:"negative"`
+		Adjustment float64 `json:"adj" validate:"negative"`
 	}
 	type Container struct {
-		Adjustments map[string]Item `json:"adjustments" pedantigo:"dive"`
+		Adjustments map[string]Item `json:"adjustments" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -1316,10 +1316,10 @@ func TestDive_Negative_Map(t *testing.T) {
 // TestDive_MultipleOf tests multiple_of constraint in nested structs via dive.
 func TestDive_MultipleOf(t *testing.T) {
 	type Item struct {
-		Quantity int `json:"quantity" pedantigo:"multiple_of=5"`
+		Quantity int `json:"quantity" validate:"multiple_of=5"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -1360,10 +1360,10 @@ func TestDive_MultipleOf(t *testing.T) {
 // TestDive_MultipleOf_Map tests multiple_of constraint in map values via dive.
 func TestDive_MultipleOf_Map(t *testing.T) {
 	type Item struct {
-		Price float64 `json:"price" pedantigo:"multiple_of=0.25"`
+		Price float64 `json:"price" validate:"multiple_of=0.25"`
 	}
 	type Container struct {
-		Products map[string]Item `json:"products" pedantigo:"dive"`
+		Products map[string]Item `json:"products" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -1387,10 +1387,10 @@ func TestDive_MultipleOf_Map(t *testing.T) {
 // TestDive_MaxDigits tests max_digits constraint in nested structs via dive.
 func TestDive_MaxDigits(t *testing.T) {
 	type Item struct {
-		Code int `json:"code" pedantigo:"max_digits=4"`
+		Code int `json:"code" validate:"max_digits=4"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -1432,10 +1432,10 @@ func TestDive_MaxDigits(t *testing.T) {
 // TestDive_MaxDigits_Map tests max_digits constraint in map values via dive.
 func TestDive_MaxDigits_Map(t *testing.T) {
 	type Item struct {
-		PIN int `json:"pin" pedantigo:"max_digits=6"`
+		PIN int `json:"pin" validate:"max_digits=6"`
 	}
 	type Container struct {
-		Users map[string]Item `json:"users" pedantigo:"dive"`
+		Users map[string]Item `json:"users" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -1459,10 +1459,10 @@ func TestDive_MaxDigits_Map(t *testing.T) {
 // TestDive_DecimalPlaces tests decimal_places constraint in nested structs via dive.
 func TestDive_DecimalPlaces(t *testing.T) {
 	type Item struct {
-		Price float64 `json:"price" pedantigo:"decimal_places=2"`
+		Price float64 `json:"price" validate:"decimal_places=2"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -1503,10 +1503,10 @@ func TestDive_DecimalPlaces(t *testing.T) {
 // TestDive_DecimalPlaces_Map tests decimal_places constraint in map values via dive.
 func TestDive_DecimalPlaces_Map(t *testing.T) {
 	type Item struct {
-		Rate float64 `json:"rate" pedantigo:"decimal_places=3"`
+		Rate float64 `json:"rate" validate:"decimal_places=3"`
 	}
 	type Container struct {
-		Rates map[string]Item `json:"rates" pedantigo:"dive"`
+		Rates map[string]Item `json:"rates" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -1530,10 +1530,10 @@ func TestDive_DecimalPlaces_Map(t *testing.T) {
 // TestDive_DisallowInfNan tests disallow_inf_nan constraint in nested structs via dive.
 func TestDive_DisallowInfNan(t *testing.T) {
 	type Item struct {
-		Value float64 `json:"value" pedantigo:"disallow_inf_nan"`
+		Value float64 `json:"value" validate:"disallow_inf_nan"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -1587,10 +1587,10 @@ func TestDive_DisallowInfNan(t *testing.T) {
 // TestDive_DisallowInfNan_Map tests disallow_inf_nan constraint in map values via dive.
 func TestDive_DisallowInfNan_Map(t *testing.T) {
 	type Item struct {
-		Measurement float64 `json:"measurement" pedantigo:"disallow_inf_nan"`
+		Measurement float64 `json:"measurement" validate:"disallow_inf_nan"`
 	}
 	type Container struct {
-		Readings map[string]Item `json:"readings" pedantigo:"dive"`
+		Readings map[string]Item `json:"readings" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -1622,10 +1622,10 @@ func TestDive_DisallowInfNan_Map(t *testing.T) {
 // TestDive_Oneof tests oneof constraint in nested structs via dive.
 func TestDive_Oneof(t *testing.T) {
 	type Item struct {
-		Status string `json:"status" pedantigo:"oneof=pending approved rejected"`
+		Status string `json:"status" validate:"oneof=pending approved rejected"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -1667,10 +1667,10 @@ func TestDive_Oneof(t *testing.T) {
 // TestDive_Oneof_Map tests oneof constraint in map values via dive.
 func TestDive_Oneof_Map(t *testing.T) {
 	type Item struct {
-		Priority string `json:"priority" pedantigo:"oneof=low medium high"`
+		Priority string `json:"priority" validate:"oneof=low medium high"`
 	}
 	type Container struct {
-		Tasks map[string]Item `json:"tasks" pedantigo:"dive"`
+		Tasks map[string]Item `json:"tasks" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -1699,10 +1699,10 @@ func TestDive_Oneof_Map(t *testing.T) {
 // TestDive_Oneof_Numeric tests oneof constraint with numeric values via dive.
 func TestDive_Oneof_Numeric(t *testing.T) {
 	type Item struct {
-		Level int `json:"level" pedantigo:"oneof=1 2 3 5 8"`
+		Level int `json:"level" validate:"oneof=1 2 3 5 8"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -1729,10 +1729,10 @@ func TestDive_Oneof_Numeric(t *testing.T) {
 // TestDive_OneofCI tests oneofci (case-insensitive) constraint in nested structs via dive.
 func TestDive_OneofCI(t *testing.T) {
 	type Item struct {
-		Role string `json:"role" pedantigo:"oneofci=admin user guest"`
+		Role string `json:"role" validate:"oneofci=admin user guest"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -1778,10 +1778,10 @@ func TestDive_OneofCI(t *testing.T) {
 // TestDive_OneofCI_Map tests oneofci constraint in map values via dive.
 func TestDive_OneofCI_Map(t *testing.T) {
 	type Item struct {
-		Permission string `json:"permission" pedantigo:"oneofci=read write execute"`
+		Permission string `json:"permission" validate:"oneofci=read write execute"`
 	}
 	type Container struct {
-		Files map[string]Item `json:"files" pedantigo:"dive"`
+		Files map[string]Item `json:"files" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -1815,10 +1815,10 @@ func TestDive_OneofCI_Map(t *testing.T) {
 // TestDive_CombinedNumericConstraints tests multiple numeric constraints on same field via dive.
 func TestDive_CombinedNumericConstraints(t *testing.T) {
 	type Item struct {
-		Price float64 `json:"price" pedantigo:"positive,lte=9999.99,decimal_places=2"`
+		Price float64 `json:"price" validate:"positive,lte=9999.99,decimal_places=2"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -1852,14 +1852,14 @@ func TestDive_CombinedNumericConstraints(t *testing.T) {
 // TestDive_NumericConstraintsOnIntTypes tests numeric constraints work across different int types.
 func TestDive_NumericConstraintsOnIntTypes(t *testing.T) {
 	type Item struct {
-		Int8Val  int8  `json:"int8" pedantigo:"gt=-100,lt=100"`
-		Int16Val int16 `json:"int16" pedantigo:"gte=0"`
-		Int32Val int32 `json:"int32" pedantigo:"positive"`
-		Int64Val int64 `json:"int64" pedantigo:"multiple_of=10"`
-		UintVal  uint  `json:"uint" pedantigo:"lte=1000"`
+		Int8Val  int8  `json:"int8" validate:"gt=-100,lt=100"`
+		Int16Val int16 `json:"int16" validate:"gte=0"`
+		Int32Val int32 `json:"int32" validate:"positive"`
+		Int64Val int64 `json:"int64" validate:"multiple_of=10"`
+		UintVal  uint  `json:"uint" validate:"lte=1000"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -1897,11 +1897,11 @@ func TestDive_NumericConstraintsOnIntTypes(t *testing.T) {
 // TestDive_NumericConstraintsOnFloatTypes tests numeric constraints work across different float types.
 func TestDive_NumericConstraintsOnFloatTypes(t *testing.T) {
 	type Item struct {
-		Float32Val float32 `json:"float32" pedantigo:"gt=0.0,lt=100.0"`
-		Float64Val float64 `json:"float64" pedantigo:"gte=0.0,lte=1.0,decimal_places=3"`
+		Float32Val float32 `json:"float32" validate:"gt=0.0,lt=100.0"`
+		Float64Val float64 `json:"float64" validate:"gte=0.0,lte=1.0,decimal_places=3"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -1945,10 +1945,10 @@ func TestDive_NumericConstraintsOnFloatTypes(t *testing.T) {
 // url accepts any scheme (http, https, ftp, file, mailto, etc.)
 func TestDive_URL(t *testing.T) {
 	type Link struct {
-		URL string `json:"url" pedantigo:"url"`
+		URL string `json:"url" validate:"url"`
 	}
 	type Container struct {
-		Links []Link `json:"links" pedantigo:"dive"`
+		Links []Link `json:"links" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -2002,10 +2002,10 @@ func TestDive_URL(t *testing.T) {
 // TestDive_URLMap tests URL constraint in map values via dive.
 func TestDive_URLMap(t *testing.T) {
 	type Link struct {
-		URL string `json:"url" pedantigo:"url"`
+		URL string `json:"url" validate:"url"`
 	}
 	type Registry struct {
-		Links map[string]Link `json:"links" pedantigo:"dive"`
+		Links map[string]Link `json:"links" validate:"dive"`
 	}
 
 	validator := New[Registry]()
@@ -2044,10 +2044,10 @@ func TestDive_URLMap(t *testing.T) {
 // uri accepts any scheme, similar to url but slightly different validation.
 func TestDive_URI(t *testing.T) {
 	type Resource struct {
-		URI string `json:"uri" pedantigo:"uri"`
+		URI string `json:"uri" validate:"uri"`
 	}
 	type Container struct {
-		Resources []Resource `json:"resources" pedantigo:"dive"`
+		Resources []Resource `json:"resources" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -2092,10 +2092,10 @@ func TestDive_URI(t *testing.T) {
 // TestDive_URIMap tests URI constraint in map values via dive.
 func TestDive_URIMap(t *testing.T) {
 	type Resource struct {
-		URI string `json:"uri" pedantigo:"uri"`
+		URI string `json:"uri" validate:"uri"`
 	}
 	type Registry struct {
-		Resources map[string]Resource `json:"resources" pedantigo:"dive"`
+		Resources map[string]Resource `json:"resources" validate:"dive"`
 	}
 
 	validator := New[Registry]()
@@ -2123,10 +2123,10 @@ func TestDive_URIMap(t *testing.T) {
 // http_url only accepts http:// or https:// schemes.
 func TestDive_HTTPURL(t *testing.T) {
 	type Endpoint struct {
-		URL string `json:"url" pedantigo:"http_url"`
+		URL string `json:"url" validate:"http_url"`
 	}
 	type Container struct {
-		Endpoints []Endpoint `json:"endpoints" pedantigo:"dive"`
+		Endpoints []Endpoint `json:"endpoints" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -2183,10 +2183,10 @@ func TestDive_HTTPURL(t *testing.T) {
 // TestDive_HTTPURLMap tests HTTP/HTTPS URL constraint in map values via dive.
 func TestDive_HTTPURLMap(t *testing.T) {
 	type Endpoint struct {
-		URL string `json:"url" pedantigo:"http_url"`
+		URL string `json:"url" validate:"http_url"`
 	}
 	type Registry struct {
-		Endpoints map[string]Endpoint `json:"endpoints" pedantigo:"dive"`
+		Endpoints map[string]Endpoint `json:"endpoints" validate:"dive"`
 	}
 
 	validator := New[Registry]()
@@ -2214,10 +2214,10 @@ func TestDive_HTTPURLMap(t *testing.T) {
 // https_url only accepts https:// scheme (rejects http://).
 func TestDive_HTTPSURL(t *testing.T) {
 	type SecureEndpoint struct {
-		URL string `json:"url" pedantigo:"https_url"`
+		URL string `json:"url" validate:"https_url"`
 	}
 	type Container struct {
-		Endpoints []SecureEndpoint `json:"endpoints" pedantigo:"dive"`
+		Endpoints []SecureEndpoint `json:"endpoints" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -2261,10 +2261,10 @@ func TestDive_HTTPSURL(t *testing.T) {
 // TestDive_HTTPSURLMap tests HTTPS-only URL constraint in map values via dive.
 func TestDive_HTTPSURLMap(t *testing.T) {
 	type SecureEndpoint struct {
-		URL string `json:"url" pedantigo:"https_url"`
+		URL string `json:"url" validate:"https_url"`
 	}
 	type Registry struct {
-		Endpoints map[string]SecureEndpoint `json:"endpoints" pedantigo:"dive"`
+		Endpoints map[string]SecureEndpoint `json:"endpoints" validate:"dive"`
 	}
 
 	validator := New[Registry]()
@@ -2291,10 +2291,10 @@ func TestDive_HTTPSURLMap(t *testing.T) {
 // TestDive_UUID tests UUID constraint (any version) in nested structs via dive.
 func TestDive_UUID(t *testing.T) {
 	type Entity struct {
-		ID string `json:"id" pedantigo:"uuid"`
+		ID string `json:"id" validate:"uuid"`
 	}
 	type Container struct {
-		Entities []Entity `json:"entities" pedantigo:"dive"`
+		Entities []Entity `json:"entities" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -2351,10 +2351,10 @@ func TestDive_UUID(t *testing.T) {
 // TestDive_UUIDMap tests UUID constraint in map values via dive.
 func TestDive_UUIDMap(t *testing.T) {
 	type Entity struct {
-		ID string `json:"id" pedantigo:"uuid"`
+		ID string `json:"id" validate:"uuid"`
 	}
 	type Registry struct {
-		Entities map[string]Entity `json:"entities" pedantigo:"dive"`
+		Entities map[string]Entity `json:"entities" validate:"dive"`
 	}
 
 	validator := New[Registry]()
@@ -2382,10 +2382,10 @@ func TestDive_UUIDMap(t *testing.T) {
 // uuid3 requires version byte (position 14) to be '3'.
 func TestDive_UUID3(t *testing.T) {
 	type Entity struct {
-		ID string `json:"id" pedantigo:"uuid3"`
+		ID string `json:"id" validate:"uuid3"`
 	}
 	type Container struct {
-		Entities []Entity `json:"entities" pedantigo:"dive"`
+		Entities []Entity `json:"entities" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -2435,10 +2435,10 @@ func TestDive_UUID3(t *testing.T) {
 // TestDive_UUID3Map tests UUID version 3 constraint in map values via dive.
 func TestDive_UUID3Map(t *testing.T) {
 	type Entity struct {
-		ID string `json:"id" pedantigo:"uuid3"`
+		ID string `json:"id" validate:"uuid3"`
 	}
 	type Registry struct {
-		Entities map[string]Entity `json:"entities" pedantigo:"dive"`
+		Entities map[string]Entity `json:"entities" validate:"dive"`
 	}
 
 	validator := New[Registry]()
@@ -2466,10 +2466,10 @@ func TestDive_UUID3Map(t *testing.T) {
 // uuid4 requires version byte (position 14) to be '4'.
 func TestDive_UUID4(t *testing.T) {
 	type Entity struct {
-		ID string `json:"id" pedantigo:"uuid4"`
+		ID string `json:"id" validate:"uuid4"`
 	}
 	type Container struct {
-		Entities []Entity `json:"entities" pedantigo:"dive"`
+		Entities []Entity `json:"entities" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -2524,10 +2524,10 @@ func TestDive_UUID4(t *testing.T) {
 // TestDive_UUID4Map tests UUID version 4 constraint in map values via dive.
 func TestDive_UUID4Map(t *testing.T) {
 	type Entity struct {
-		ID string `json:"id" pedantigo:"uuid4"`
+		ID string `json:"id" validate:"uuid4"`
 	}
 	type Registry struct {
-		Entities map[string]Entity `json:"entities" pedantigo:"dive"`
+		Entities map[string]Entity `json:"entities" validate:"dive"`
 	}
 
 	validator := New[Registry]()
@@ -2555,10 +2555,10 @@ func TestDive_UUID4Map(t *testing.T) {
 // uuid5 requires version byte (position 14) to be '5'.
 func TestDive_UUID5(t *testing.T) {
 	type Entity struct {
-		ID string `json:"id" pedantigo:"uuid5"`
+		ID string `json:"id" validate:"uuid5"`
 	}
 	type Container struct {
-		Entities []Entity `json:"entities" pedantigo:"dive"`
+		Entities []Entity `json:"entities" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -2608,10 +2608,10 @@ func TestDive_UUID5(t *testing.T) {
 // TestDive_UUID5Map tests UUID version 5 constraint in map values via dive.
 func TestDive_UUID5Map(t *testing.T) {
 	type Entity struct {
-		ID string `json:"id" pedantigo:"uuid5"`
+		ID string `json:"id" validate:"uuid5"`
 	}
 	type Registry struct {
-		Entities map[string]Entity `json:"entities" pedantigo:"dive"`
+		Entities map[string]Entity `json:"entities" validate:"dive"`
 	}
 
 	validator := New[Registry]()
@@ -2638,17 +2638,17 @@ func TestDive_UUID5Map(t *testing.T) {
 // TestDive_AllFormatsSlice tests all format constraints in a single slice dive scenario.
 func TestDive_AllFormatsSlice(t *testing.T) {
 	type Resource struct {
-		URL      string `json:"url" pedantigo:"url"`
-		URI      string `json:"uri" pedantigo:"uri"`
-		HTTPURL  string `json:"http_url" pedantigo:"http_url"`
-		HTTPSURL string `json:"https_url" pedantigo:"https_url"`
-		UUID     string `json:"uuid" pedantigo:"uuid"`
-		UUID3    string `json:"uuid3" pedantigo:"uuid3"`
-		UUID4    string `json:"uuid4" pedantigo:"uuid4"`
-		UUID5    string `json:"uuid5" pedantigo:"uuid5"`
+		URL      string `json:"url" validate:"url"`
+		URI      string `json:"uri" validate:"uri"`
+		HTTPURL  string `json:"http_url" validate:"http_url"`
+		HTTPSURL string `json:"https_url" validate:"https_url"`
+		UUID     string `json:"uuid" validate:"uuid"`
+		UUID3    string `json:"uuid3" validate:"uuid3"`
+		UUID4    string `json:"uuid4" validate:"uuid4"`
+		UUID5    string `json:"uuid5" validate:"uuid5"`
 	}
 	type Container struct {
-		Resources []Resource `json:"resources" pedantigo:"dive"`
+		Resources []Resource `json:"resources" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -2714,12 +2714,12 @@ func TestDive_AllFormatsSlice(t *testing.T) {
 // TestDive_AllFormatsMap tests all format constraints in a single map dive scenario.
 func TestDive_AllFormatsMap(t *testing.T) {
 	type Resource struct {
-		URL      string `json:"url" pedantigo:"url"`
-		UUID     string `json:"uuid" pedantigo:"uuid"`
-		HTTPSURL string `json:"https_url" pedantigo:"https_url"`
+		URL      string `json:"url" validate:"url"`
+		UUID     string `json:"uuid" validate:"uuid"`
+		HTTPSURL string `json:"https_url" validate:"https_url"`
 	}
 	type Registry struct {
-		Resources map[string]Resource `json:"resources" pedantigo:"dive"`
+		Resources map[string]Resource `json:"resources" validate:"dive"`
 	}
 
 	validator := New[Registry]()
@@ -2762,10 +2762,10 @@ func TestDive_AllFormatsMap(t *testing.T) {
 // TestDive_IP tests IP constraint in nested structs via dive.
 func TestDive_IP(t *testing.T) {
 	type Server struct {
-		Address string `json:"address" pedantigo:"ip"`
+		Address string `json:"address" validate:"ip"`
 	}
 	type Container struct {
-		Servers []Server `json:"servers" pedantigo:"dive"`
+		Servers []Server `json:"servers" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -2808,7 +2808,7 @@ func TestDive_IP(t *testing.T) {
 
 	t.Run("map_valid_ipv4", func(t *testing.T) {
 		type MapContainer struct {
-			Servers map[string]Server `json:"servers" pedantigo:"dive"`
+			Servers map[string]Server `json:"servers" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"servers":{"primary":{"address":"192.168.1.1"},"secondary":{"address":"10.0.0.1"}}}`))
@@ -2817,7 +2817,7 @@ func TestDive_IP(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Servers map[string]Server `json:"servers" pedantigo:"dive"`
+			Servers map[string]Server `json:"servers" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"servers":{"primary":{"address":"invalid-ip"}}}`))
@@ -2831,10 +2831,10 @@ func TestDive_IP(t *testing.T) {
 // TestDive_IPv4 tests IPv4 constraint in nested structs via dive.
 func TestDive_IPv4(t *testing.T) {
 	type Server struct {
-		Address string `json:"address" pedantigo:"ipv4"`
+		Address string `json:"address" validate:"ipv4"`
 	}
 	type Container struct {
-		Servers []Server `json:"servers" pedantigo:"dive"`
+		Servers []Server `json:"servers" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -2880,7 +2880,7 @@ func TestDive_IPv4(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Servers map[string]Server `json:"servers" pedantigo:"dive"`
+			Servers map[string]Server `json:"servers" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"servers":{"primary":{"address":"192.168.1.1"},"secondary":{"address":"10.0.0.1"}}}`))
@@ -2889,7 +2889,7 @@ func TestDive_IPv4(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Servers map[string]Server `json:"servers" pedantigo:"dive"`
+			Servers map[string]Server `json:"servers" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"servers":{"primary":{"address":"2001:db8::1"}}}`))
@@ -2903,10 +2903,10 @@ func TestDive_IPv4(t *testing.T) {
 // TestDive_IPv6 tests IPv6 constraint in nested structs via dive.
 func TestDive_IPv6(t *testing.T) {
 	type Server struct {
-		Address string `json:"address" pedantigo:"ipv6"`
+		Address string `json:"address" validate:"ipv6"`
 	}
 	type Container struct {
-		Servers []Server `json:"servers" pedantigo:"dive"`
+		Servers []Server `json:"servers" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -2957,7 +2957,7 @@ func TestDive_IPv6(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Servers map[string]Server `json:"servers" pedantigo:"dive"`
+			Servers map[string]Server `json:"servers" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"servers":{"primary":{"address":"2001:db8::1"},"secondary":{"address":"::1"}}}`))
@@ -2966,7 +2966,7 @@ func TestDive_IPv6(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Servers map[string]Server `json:"servers" pedantigo:"dive"`
+			Servers map[string]Server `json:"servers" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"servers":{"primary":{"address":"192.168.1.1"}}}`))
@@ -2980,10 +2980,10 @@ func TestDive_IPv6(t *testing.T) {
 // TestDive_CIDR tests CIDR constraint in nested structs via dive.
 func TestDive_CIDR(t *testing.T) {
 	type Network struct {
-		Subnet string `json:"subnet" pedantigo:"cidr"`
+		Subnet string `json:"subnet" validate:"cidr"`
 	}
 	type Container struct {
-		Networks []Network `json:"networks" pedantigo:"dive"`
+		Networks []Network `json:"networks" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -3034,7 +3034,7 @@ func TestDive_CIDR(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Networks map[string]Network `json:"networks" pedantigo:"dive"`
+			Networks map[string]Network `json:"networks" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"networks":{"lan":{"subnet":"192.168.1.0/24"},"wan":{"subnet":"2001:db8::/32"}}}`))
@@ -3043,7 +3043,7 @@ func TestDive_CIDR(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Networks map[string]Network `json:"networks" pedantigo:"dive"`
+			Networks map[string]Network `json:"networks" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"networks":{"lan":{"subnet":"invalid-cidr"}}}`))
@@ -3057,10 +3057,10 @@ func TestDive_CIDR(t *testing.T) {
 // TestDive_CIDRv4 tests CIDRv4 constraint in nested structs via dive.
 func TestDive_CIDRv4(t *testing.T) {
 	type Network struct {
-		Subnet string `json:"subnet" pedantigo:"cidrv4"`
+		Subnet string `json:"subnet" validate:"cidrv4"`
 	}
 	type Container struct {
-		Networks []Network `json:"networks" pedantigo:"dive"`
+		Networks []Network `json:"networks" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -3106,7 +3106,7 @@ func TestDive_CIDRv4(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Networks map[string]Network `json:"networks" pedantigo:"dive"`
+			Networks map[string]Network `json:"networks" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"networks":{"lan":{"subnet":"192.168.1.0/24"},"wan":{"subnet":"10.0.0.0/8"}}}`))
@@ -3115,7 +3115,7 @@ func TestDive_CIDRv4(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Networks map[string]Network `json:"networks" pedantigo:"dive"`
+			Networks map[string]Network `json:"networks" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"networks":{"lan":{"subnet":"2001:db8::/32"}}}`))
@@ -3129,10 +3129,10 @@ func TestDive_CIDRv4(t *testing.T) {
 // TestDive_CIDRv6 tests CIDRv6 constraint in nested structs via dive.
 func TestDive_CIDRv6(t *testing.T) {
 	type Network struct {
-		Subnet string `json:"subnet" pedantigo:"cidrv6"`
+		Subnet string `json:"subnet" validate:"cidrv6"`
 	}
 	type Container struct {
-		Networks []Network `json:"networks" pedantigo:"dive"`
+		Networks []Network `json:"networks" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -3178,7 +3178,7 @@ func TestDive_CIDRv6(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Networks map[string]Network `json:"networks" pedantigo:"dive"`
+			Networks map[string]Network `json:"networks" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"networks":{"lan":{"subnet":"2001:db8::/32"},"wan":{"subnet":"fe80::/10"}}}`))
@@ -3187,7 +3187,7 @@ func TestDive_CIDRv6(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Networks map[string]Network `json:"networks" pedantigo:"dive"`
+			Networks map[string]Network `json:"networks" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"networks":{"lan":{"subnet":"192.168.1.0/24"}}}`))
@@ -3201,10 +3201,10 @@ func TestDive_CIDRv6(t *testing.T) {
 // TestDive_MAC tests MAC constraint in nested structs via dive.
 func TestDive_MAC(t *testing.T) {
 	type Device struct {
-		MACAddress string `json:"mac_address" pedantigo:"mac"`
+		MACAddress string `json:"mac_address" validate:"mac"`
 	}
 	type Container struct {
-		Devices []Device `json:"devices" pedantigo:"dive"`
+		Devices []Device `json:"devices" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -3255,7 +3255,7 @@ func TestDive_MAC(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Devices map[string]Device `json:"devices" pedantigo:"dive"`
+			Devices map[string]Device `json:"devices" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"devices":{"eth0":{"mac_address":"00:1B:44:11:3A:B7"},"eth1":{"mac_address":"AA-BB-CC-DD-EE-FF"}}}`))
@@ -3264,7 +3264,7 @@ func TestDive_MAC(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Devices map[string]Device `json:"devices" pedantigo:"dive"`
+			Devices map[string]Device `json:"devices" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"devices":{"eth0":{"mac_address":"invalid-mac"}}}`))
@@ -3278,10 +3278,10 @@ func TestDive_MAC(t *testing.T) {
 // TestDive_Hostname tests hostname constraint in nested structs via dive.
 func TestDive_Hostname(t *testing.T) {
 	type Host struct {
-		Name string `json:"name" pedantigo:"hostname"`
+		Name string `json:"name" validate:"hostname"`
 	}
 	type Container struct {
-		Hosts []Host `json:"hosts" pedantigo:"dive"`
+		Hosts []Host `json:"hosts" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -3333,7 +3333,7 @@ func TestDive_Hostname(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Hosts map[string]Host `json:"hosts" pedantigo:"dive"`
+			Hosts map[string]Host `json:"hosts" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"hosts":{"primary":{"name":"server1"},"secondary":{"name":"server2"}}}`))
@@ -3342,7 +3342,7 @@ func TestDive_Hostname(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Hosts map[string]Host `json:"hosts" pedantigo:"dive"`
+			Hosts map[string]Host `json:"hosts" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"hosts":{"primary":{"name":"server.example.com"}}}`))
@@ -3356,10 +3356,10 @@ func TestDive_Hostname(t *testing.T) {
 // TestDive_HostnameRFC1123 tests hostname_rfc1123 constraint in nested structs via dive.
 func TestDive_HostnameRFC1123(t *testing.T) {
 	type Host struct {
-		Name string `json:"name" pedantigo:"hostname_rfc1123"`
+		Name string `json:"name" validate:"hostname_rfc1123"`
 	}
 	type Container struct {
-		Hosts []Host `json:"hosts" pedantigo:"dive"`
+		Hosts []Host `json:"hosts" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -3403,7 +3403,7 @@ func TestDive_HostnameRFC1123(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Hosts map[string]Host `json:"hosts" pedantigo:"dive"`
+			Hosts map[string]Host `json:"hosts" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"hosts":{"primary":{"name":"1server"},"secondary":{"name":"server-01"}}}`))
@@ -3412,7 +3412,7 @@ func TestDive_HostnameRFC1123(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Hosts map[string]Host `json:"hosts" pedantigo:"dive"`
+			Hosts map[string]Host `json:"hosts" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"hosts":{"primary":{"name":"server.example.com"}}}`))
@@ -3426,10 +3426,10 @@ func TestDive_HostnameRFC1123(t *testing.T) {
 // TestDive_FQDN tests fqdn constraint in nested structs via dive.
 func TestDive_FQDN(t *testing.T) {
 	type Domain struct {
-		Name string `json:"name" pedantigo:"fqdn"`
+		Name string `json:"name" validate:"fqdn"`
 	}
 	type Container struct {
-		Domains []Domain `json:"domains" pedantigo:"dive"`
+		Domains []Domain `json:"domains" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -3480,7 +3480,7 @@ func TestDive_FQDN(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Domains map[string]Domain `json:"domains" pedantigo:"dive"`
+			Domains map[string]Domain `json:"domains" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"domains":{"web":{"name":"www.example.com"},"mail":{"name":"mail.example.com"}}}`))
@@ -3489,7 +3489,7 @@ func TestDive_FQDN(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Domains map[string]Domain `json:"domains" pedantigo:"dive"`
+			Domains map[string]Domain `json:"domains" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"domains":{"web":{"name":"localhost"}}}`))
@@ -3503,10 +3503,10 @@ func TestDive_FQDN(t *testing.T) {
 // TestDive_Port tests port constraint in nested structs via dive.
 func TestDive_Port(t *testing.T) {
 	type Service struct {
-		Port int `json:"port" pedantigo:"port"`
+		Port int `json:"port" validate:"port"`
 	}
 	type Container struct {
-		Services []Service `json:"services" pedantigo:"dive"`
+		Services []Service `json:"services" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -3562,7 +3562,7 @@ func TestDive_Port(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Services map[string]Service `json:"services" pedantigo:"dive"`
+			Services map[string]Service `json:"services" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"services":{"http":{"port":80},"https":{"port":443}}}`))
@@ -3571,7 +3571,7 @@ func TestDive_Port(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Services map[string]Service `json:"services" pedantigo:"dive"`
+			Services map[string]Service `json:"services" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"services":{"http":{"port":70000}}}`))
@@ -3585,10 +3585,10 @@ func TestDive_Port(t *testing.T) {
 // TestDive_TCPAddr tests tcp_addr constraint in nested structs via dive.
 func TestDive_TCPAddr(t *testing.T) {
 	type Endpoint struct {
-		Address string `json:"address" pedantigo:"tcp_addr"`
+		Address string `json:"address" validate:"tcp_addr"`
 	}
 	type Container struct {
-		Endpoints []Endpoint `json:"endpoints" pedantigo:"dive"`
+		Endpoints []Endpoint `json:"endpoints" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -3644,7 +3644,7 @@ func TestDive_TCPAddr(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Endpoints map[string]Endpoint `json:"endpoints" pedantigo:"dive"`
+			Endpoints map[string]Endpoint `json:"endpoints" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"endpoints":{"primary":{"address":"192.168.1.1:8080"},"secondary":{"address":"localhost:443"}}}`))
@@ -3653,7 +3653,7 @@ func TestDive_TCPAddr(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Endpoints map[string]Endpoint `json:"endpoints" pedantigo:"dive"`
+			Endpoints map[string]Endpoint `json:"endpoints" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"endpoints":{"primary":{"address":"192.168.1.1"}}}`))
@@ -3667,10 +3667,10 @@ func TestDive_TCPAddr(t *testing.T) {
 // TestDive_TCP4Addr tests tcp4_addr constraint in nested structs via dive.
 func TestDive_TCP4Addr(t *testing.T) {
 	type Endpoint struct {
-		Address string `json:"address" pedantigo:"tcp4_addr"`
+		Address string `json:"address" validate:"tcp4_addr"`
 	}
 	type Container struct {
-		Endpoints []Endpoint `json:"endpoints" pedantigo:"dive"`
+		Endpoints []Endpoint `json:"endpoints" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -3724,7 +3724,7 @@ func TestDive_TCP4Addr(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Endpoints map[string]Endpoint `json:"endpoints" pedantigo:"dive"`
+			Endpoints map[string]Endpoint `json:"endpoints" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"endpoints":{"primary":{"address":"192.168.1.1:8080"},"secondary":{"address":"10.0.0.1:443"}}}`))
@@ -3733,7 +3733,7 @@ func TestDive_TCP4Addr(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Endpoints map[string]Endpoint `json:"endpoints" pedantigo:"dive"`
+			Endpoints map[string]Endpoint `json:"endpoints" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"endpoints":{"primary":{"address":"localhost:8080"}}}`))
@@ -3747,10 +3747,10 @@ func TestDive_TCP4Addr(t *testing.T) {
 // TestDive_UDPAddr tests udp_addr constraint in nested structs via dive.
 func TestDive_UDPAddr(t *testing.T) {
 	type Endpoint struct {
-		Address string `json:"address" pedantigo:"udp_addr"`
+		Address string `json:"address" validate:"udp_addr"`
 	}
 	type Container struct {
-		Endpoints []Endpoint `json:"endpoints" pedantigo:"dive"`
+		Endpoints []Endpoint `json:"endpoints" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -3806,7 +3806,7 @@ func TestDive_UDPAddr(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Endpoints map[string]Endpoint `json:"endpoints" pedantigo:"dive"`
+			Endpoints map[string]Endpoint `json:"endpoints" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"endpoints":{"dns":{"address":"192.168.1.1:53"},"ntp":{"address":"localhost:123"}}}`))
@@ -3815,7 +3815,7 @@ func TestDive_UDPAddr(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Endpoints map[string]Endpoint `json:"endpoints" pedantigo:"dive"`
+			Endpoints map[string]Endpoint `json:"endpoints" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"endpoints":{"dns":{"address":"192.168.1.1"}}}`))
@@ -3829,10 +3829,10 @@ func TestDive_UDPAddr(t *testing.T) {
 // TestDive_HostnamePort tests hostname_port constraint in nested structs via dive.
 func TestDive_HostnamePort(t *testing.T) {
 	type Endpoint struct {
-		Address string `json:"address" pedantigo:"hostname_port"`
+		Address string `json:"address" validate:"hostname_port"`
 	}
 	type Container struct {
-		Endpoints []Endpoint `json:"endpoints" pedantigo:"dive"`
+		Endpoints []Endpoint `json:"endpoints" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -3897,7 +3897,7 @@ func TestDive_HostnamePort(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Endpoints map[string]Endpoint `json:"endpoints" pedantigo:"dive"`
+			Endpoints map[string]Endpoint `json:"endpoints" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"endpoints":{"web":{"address":"localhost:8080"},"api":{"address":"example.com:443"}}}`))
@@ -3906,7 +3906,7 @@ func TestDive_HostnamePort(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Endpoints map[string]Endpoint `json:"endpoints" pedantigo:"dive"`
+			Endpoints map[string]Endpoint `json:"endpoints" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"endpoints":{"web":{"address":"localhost"}}}`))
@@ -3925,10 +3925,10 @@ func TestDive_HostnamePort(t *testing.T) {
 // on fields inside nested structs accessed via dive.
 func TestOneOf_NestedDive(t *testing.T) {
 	type Item struct {
-		Status string `json:"status" pedantigo:"oneof=pending active completed"`
+		Status string `json:"status" validate:"oneof=pending active completed"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -4023,10 +4023,10 @@ func TestOneOf_NestedDive(t *testing.T) {
 // on fields inside nested structs accessed via dive.
 func TestOneOfCI_NestedDive(t *testing.T) {
 	type Item struct {
-		Role string `json:"role" pedantigo:"oneofci=admin user guest"`
+		Role string `json:"role" validate:"oneofci=admin user guest"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -4118,10 +4118,10 @@ func TestOneOfCI_NestedDive(t *testing.T) {
 // in map value structs accessed via dive.
 func TestOneOf_NestedMapDive(t *testing.T) {
 	type Config struct {
-		Environment string `json:"environment" pedantigo:"oneof=dev staging production"`
+		Environment string `json:"environment" validate:"oneof=dev staging production"`
 	}
 	type Configs struct {
-		ByRegion map[string]Config `json:"by_region" pedantigo:"dive"`
+		ByRegion map[string]Config `json:"by_region" validate:"dive"`
 	}
 
 	validator := New[Configs]()
@@ -4182,10 +4182,10 @@ func TestOneOf_NestedMapDive(t *testing.T) {
 // in map value structs accessed via dive.
 func TestOneOfCI_NestedMapDive(t *testing.T) {
 	type Permission struct {
-		Level string `json:"level" pedantigo:"oneofci=read write admin"`
+		Level string `json:"level" validate:"oneofci=read write admin"`
 	}
 	type Permissions struct {
-		ByUser map[string]Permission `json:"by_user" pedantigo:"dive"`
+		ByUser map[string]Permission `json:"by_user" validate:"dive"`
 	}
 
 	validator := New[Permissions]()
@@ -4252,10 +4252,10 @@ func TestOneOfCI_NestedMapDive(t *testing.T) {
 // TestDive_Alpha tests alpha constraint in nested structs via dive.
 func TestDive_Alpha(t *testing.T) {
 	type Item struct {
-		Code string `json:"code" pedantigo:"alpha"`
+		Code string `json:"code" validate:"alpha"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -4285,7 +4285,7 @@ func TestDive_Alpha(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"code":"ABC"},"b":{"code":"XYZ"}}}`))
@@ -4294,7 +4294,7 @@ func TestDive_Alpha(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"code":"ABC123"}}}`))
@@ -4305,10 +4305,10 @@ func TestDive_Alpha(t *testing.T) {
 // TestDive_Alphanum tests alphanum constraint in nested structs via dive.
 func TestDive_Alphanum(t *testing.T) {
 	type Item struct {
-		Code string `json:"code" pedantigo:"alphanum"`
+		Code string `json:"code" validate:"alphanum"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -4333,7 +4333,7 @@ func TestDive_Alphanum(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"code":"ABC123"}}}`))
@@ -4342,7 +4342,7 @@ func TestDive_Alphanum(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"code":"ABC-123"}}}`))
@@ -4353,10 +4353,10 @@ func TestDive_Alphanum(t *testing.T) {
 // TestDive_ASCII tests ascii constraint in nested structs via dive.
 func TestDive_ASCII(t *testing.T) {
 	type Item struct {
-		Text string `json:"text" pedantigo:"ascii"`
+		Text string `json:"text" validate:"ascii"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -4381,7 +4381,7 @@ func TestDive_ASCII(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"text":"ASCII only"}}}`))
@@ -4390,7 +4390,7 @@ func TestDive_ASCII(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"text":"café"}}}`))
@@ -4401,10 +4401,10 @@ func TestDive_ASCII(t *testing.T) {
 // TestDive_Contains tests contains constraint in nested structs via dive.
 func TestDive_Contains(t *testing.T) {
 	type Item struct {
-		Text string `json:"text" pedantigo:"contains=@"`
+		Text string `json:"text" validate:"contains=@"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -4429,7 +4429,7 @@ func TestDive_Contains(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"text":"test@test"}}}`))
@@ -4438,7 +4438,7 @@ func TestDive_Contains(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"text":"no at symbol"}}}`))
@@ -4449,10 +4449,10 @@ func TestDive_Contains(t *testing.T) {
 // TestDive_StartsWith tests startswith constraint in nested structs via dive.
 func TestDive_StartsWith(t *testing.T) {
 	type Item struct {
-		Path string `json:"path" pedantigo:"startswith=/api/"`
+		Path string `json:"path" validate:"startswith=/api/"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -4477,7 +4477,7 @@ func TestDive_StartsWith(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"path":"/api/test"}}}`))
@@ -4486,7 +4486,7 @@ func TestDive_StartsWith(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"path":"/v1/test"}}}`))
@@ -4497,10 +4497,10 @@ func TestDive_StartsWith(t *testing.T) {
 // TestDive_EndsWith tests endswith constraint in nested structs via dive.
 func TestDive_EndsWith(t *testing.T) {
 	type Item struct {
-		Filename string `json:"filename" pedantigo:"endswith=.json"`
+		Filename string `json:"filename" validate:"endswith=.json"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -4525,7 +4525,7 @@ func TestDive_EndsWith(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"filename":"test.json"}}}`))
@@ -4534,7 +4534,7 @@ func TestDive_EndsWith(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"filename":"test.xml"}}}`))
@@ -4545,10 +4545,10 @@ func TestDive_EndsWith(t *testing.T) {
 // TestDive_Lowercase tests lowercase constraint in nested structs via dive.
 func TestDive_Lowercase(t *testing.T) {
 	type Item struct {
-		Tag string `json:"tag" pedantigo:"lowercase"`
+		Tag string `json:"tag" validate:"lowercase"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -4573,7 +4573,7 @@ func TestDive_Lowercase(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"tag":"lowercase"}}}`))
@@ -4582,7 +4582,7 @@ func TestDive_Lowercase(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"tag":"UPPERCASE"}}}`))
@@ -4593,10 +4593,10 @@ func TestDive_Lowercase(t *testing.T) {
 // TestDive_Uppercase tests uppercase constraint in nested structs via dive.
 func TestDive_Uppercase(t *testing.T) {
 	type Item struct {
-		Code string `json:"code" pedantigo:"uppercase"`
+		Code string `json:"code" validate:"uppercase"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -4621,7 +4621,7 @@ func TestDive_Uppercase(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"code":"UPPERCASE"}}}`))
@@ -4630,7 +4630,7 @@ func TestDive_Uppercase(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"code":"lowercase"}}}`))
@@ -4641,10 +4641,10 @@ func TestDive_Uppercase(t *testing.T) {
 // TestDive_Len tests len constraint in nested structs via dive.
 func TestDive_Len(t *testing.T) {
 	type Item struct {
-		Code string `json:"code" pedantigo:"len=5"`
+		Code string `json:"code" validate:"len=5"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -4674,7 +4674,7 @@ func TestDive_Len(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"code":"ABCDE"}}}`))
@@ -4683,7 +4683,7 @@ func TestDive_Len(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"code":"AB"}}}`))
@@ -4694,10 +4694,10 @@ func TestDive_Len(t *testing.T) {
 // TestDive_MinLen tests min constraint on strings in nested structs via dive.
 func TestDive_MinLen(t *testing.T) {
 	type Item struct {
-		Name string `json:"name" pedantigo:"min=3"`
+		Name string `json:"name" validate:"min=3"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -4727,7 +4727,7 @@ func TestDive_MinLen(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"name":"John"}}}`))
@@ -4736,7 +4736,7 @@ func TestDive_MinLen(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"name":"Jo"}}}`))
@@ -4747,10 +4747,10 @@ func TestDive_MinLen(t *testing.T) {
 // TestDive_MaxLen tests max constraint on strings in nested structs via dive.
 func TestDive_MaxLen(t *testing.T) {
 	type Item struct {
-		Code string `json:"code" pedantigo:"max=5"`
+		Code string `json:"code" validate:"max=5"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -4780,7 +4780,7 @@ func TestDive_MaxLen(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"code":"ABC"}}}`))
@@ -4789,7 +4789,7 @@ func TestDive_MaxLen(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"code":"TOOLONGCODE"}}}`))
@@ -4800,10 +4800,10 @@ func TestDive_MaxLen(t *testing.T) {
 // TestDive_Regexp tests regexp constraint in nested structs via dive.
 func TestDive_Regexp(t *testing.T) {
 	type Item struct {
-		SKU string `json:"sku" pedantigo:"regexp=^[A-Z]{3}-[0-9]{4}$"`
+		SKU string `json:"sku" validate:"regexp=^[A-Z]{3}-[0-9]{4}$"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -4833,7 +4833,7 @@ func TestDive_Regexp(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"sku":"ABC-1234"}}}`))
@@ -4842,7 +4842,7 @@ func TestDive_Regexp(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"sku":"invalid"}}}`))
@@ -4853,10 +4853,10 @@ func TestDive_Regexp(t *testing.T) {
 // TestDive_Excludes tests excludes constraint in nested structs via dive.
 func TestDive_Excludes(t *testing.T) {
 	type Item struct {
-		Text string `json:"text" pedantigo:"excludes=<script>"`
+		Text string `json:"text" validate:"excludes=<script>"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -4881,7 +4881,7 @@ func TestDive_Excludes(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"text":"safe text"}}}`))
@@ -4890,7 +4890,7 @@ func TestDive_Excludes(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"text":"has <script> tag"}}}`))
@@ -4901,10 +4901,10 @@ func TestDive_Excludes(t *testing.T) {
 // TestDive_PrintASCII tests printascii constraint in nested structs via dive.
 func TestDive_PrintASCII(t *testing.T) {
 	type Item struct {
-		Text string `json:"text" pedantigo:"printascii"`
+		Text string `json:"text" validate:"printascii"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -4921,7 +4921,7 @@ func TestDive_PrintASCII(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"text":"Printable ASCII"}}}`))
@@ -4932,10 +4932,10 @@ func TestDive_PrintASCII(t *testing.T) {
 // TestDive_Numeric tests numeric constraint in nested structs via dive.
 func TestDive_Numeric(t *testing.T) {
 	type Item struct {
-		Value string `json:"value" pedantigo:"numeric"`
+		Value string `json:"value" validate:"numeric"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -4965,7 +4965,7 @@ func TestDive_Numeric(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"value":"12345"}}}`))
@@ -4974,7 +4974,7 @@ func TestDive_Numeric(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"value":"abc"}}}`))
@@ -4987,10 +4987,10 @@ func TestDive_Numeric(t *testing.T) {
 // Use "numeric" constraint for signed decimals.
 func TestDive_Number(t *testing.T) {
 	type Item struct {
-		Value string `json:"value" pedantigo:"number"`
+		Value string `json:"value" validate:"number"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -5030,7 +5030,7 @@ func TestDive_Number(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"value":"12345"}}}`))
@@ -5039,7 +5039,7 @@ func TestDive_Number(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"value":"not a number"}}}`))
@@ -5054,10 +5054,10 @@ func TestDive_Number(t *testing.T) {
 // TestDive_Base64 tests base64 constraint in nested structs via dive.
 func TestDive_Base64(t *testing.T) {
 	type Item struct {
-		Data string `json:"data" pedantigo:"base64"`
+		Data string `json:"data" validate:"base64"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -5082,7 +5082,7 @@ func TestDive_Base64(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"data":"SGVsbG8="}}}`))
@@ -5091,7 +5091,7 @@ func TestDive_Base64(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"data":"###invalid###"}}}`))
@@ -5102,10 +5102,10 @@ func TestDive_Base64(t *testing.T) {
 // TestDive_Base64URL tests base64url constraint in nested structs via dive.
 func TestDive_Base64URL(t *testing.T) {
 	type Item struct {
-		Data string `json:"data" pedantigo:"base64url"`
+		Data string `json:"data" validate:"base64url"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -5130,7 +5130,7 @@ func TestDive_Base64URL(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"data":"SGVsbG8="}}}`))
@@ -5139,7 +5139,7 @@ func TestDive_Base64URL(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"data":"+++invalid+++"}}}`))
@@ -5150,10 +5150,10 @@ func TestDive_Base64URL(t *testing.T) {
 // TestDive_Hexadecimal tests hexadecimal constraint in nested structs via dive.
 func TestDive_Hexadecimal(t *testing.T) {
 	type Item struct {
-		Hex string `json:"hex" pedantigo:"hexadecimal"`
+		Hex string `json:"hex" validate:"hexadecimal"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -5178,7 +5178,7 @@ func TestDive_Hexadecimal(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"hex":"CAFE"}}}`))
@@ -5187,7 +5187,7 @@ func TestDive_Hexadecimal(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"hex":"ZZZZ"}}}`))
@@ -5198,10 +5198,10 @@ func TestDive_Hexadecimal(t *testing.T) {
 // TestDive_HexColor tests hexcolor constraint in nested structs via dive.
 func TestDive_HexColor(t *testing.T) {
 	type Item struct {
-		Color string `json:"color" pedantigo:"hexcolor"`
+		Color string `json:"color" validate:"hexcolor"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -5231,7 +5231,7 @@ func TestDive_HexColor(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"color":"#123ABC"}}}`))
@@ -5240,7 +5240,7 @@ func TestDive_HexColor(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"color":"red"}}}`))
@@ -5251,10 +5251,10 @@ func TestDive_HexColor(t *testing.T) {
 // TestDive_JSON tests json constraint in nested structs via dive.
 func TestDive_JSON(t *testing.T) {
 	type Item struct {
-		Data string `json:"data" pedantigo:"json"`
+		Data string `json:"data" validate:"json"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -5284,7 +5284,7 @@ func TestDive_JSON(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"data":"{\"valid\":true}"}}}`))
@@ -5293,7 +5293,7 @@ func TestDive_JSON(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"data":"not json"}}}`))
@@ -5304,10 +5304,10 @@ func TestDive_JSON(t *testing.T) {
 // TestDive_JWT tests jwt constraint in nested structs via dive.
 func TestDive_JWT(t *testing.T) {
 	type Item struct {
-		Token string `json:"token" pedantigo:"jwt"`
+		Token string `json:"token" validate:"jwt"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -5339,7 +5339,7 @@ func TestDive_JWT(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		// Test token with valid JWT structure (header.payload.signature)
@@ -5349,7 +5349,7 @@ func TestDive_JWT(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"token":"invalid"}}}`))
@@ -5360,10 +5360,10 @@ func TestDive_JWT(t *testing.T) {
 // TestDive_Alphaspace tests alphaspace constraint in nested structs via dive.
 func TestDive_Alphaspace(t *testing.T) {
 	type Item struct {
-		Value string `json:"value" pedantigo:"alphaspace"`
+		Value string `json:"value" validate:"alphaspace"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -5393,7 +5393,7 @@ func TestDive_Alphaspace(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"value":"hello world"},"b":{"value":"ABC XYZ"}}}`))
@@ -5402,7 +5402,7 @@ func TestDive_Alphaspace(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"value":"hello123"}}}`))
@@ -5413,10 +5413,10 @@ func TestDive_Alphaspace(t *testing.T) {
 // TestDive_Alphanumspace tests alphanumspace constraint in nested structs via dive.
 func TestDive_Alphanumspace(t *testing.T) {
 	type Item struct {
-		Value string `json:"value" pedantigo:"alphanumspace"`
+		Value string `json:"value" validate:"alphanumspace"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -5446,7 +5446,7 @@ func TestDive_Alphanumspace(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"value":"hello world 123"},"b":{"value":"ABC XYZ 789"}}}`))
@@ -5455,7 +5455,7 @@ func TestDive_Alphanumspace(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"value":"hello!world"}}}`))
@@ -5466,10 +5466,10 @@ func TestDive_Alphanumspace(t *testing.T) {
 // TestDive_Alphaunicode tests alphaunicode constraint in nested structs via dive.
 func TestDive_Alphaunicode(t *testing.T) {
 	type Item struct {
-		Value string `json:"value" pedantigo:"alphaunicode"`
+		Value string `json:"value" validate:"alphaunicode"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -5499,7 +5499,7 @@ func TestDive_Alphaunicode(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"value":"héllo"},"b":{"value":"世界"}}}`))
@@ -5508,7 +5508,7 @@ func TestDive_Alphaunicode(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"value":"hello123"}}}`))
@@ -5519,10 +5519,10 @@ func TestDive_Alphaunicode(t *testing.T) {
 // TestDive_Alphanumunicode tests alphanumunicode constraint in nested structs via dive.
 func TestDive_Alphanumunicode(t *testing.T) {
 	type Item struct {
-		Value string `json:"value" pedantigo:"alphanumunicode"`
+		Value string `json:"value" validate:"alphanumunicode"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -5552,7 +5552,7 @@ func TestDive_Alphanumunicode(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"value":"héllo123"},"b":{"value":"世界789"}}}`))
@@ -5561,7 +5561,7 @@ func TestDive_Alphanumunicode(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"value":"hello!world"}}}`))
@@ -5576,10 +5576,10 @@ func TestDive_Alphanumunicode(t *testing.T) {
 // TestDive_Email tests email constraint in nested structs via dive.
 func TestDive_Email(t *testing.T) {
 	type Item struct {
-		Email string `json:"email" pedantigo:"email"`
+		Email string `json:"email" validate:"email"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -5609,7 +5609,7 @@ func TestDive_Email(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"email":"test@test.com"}}}`))
@@ -5618,7 +5618,7 @@ func TestDive_Email(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"email":"invalid-email"}}}`))
@@ -5629,10 +5629,10 @@ func TestDive_Email(t *testing.T) {
 // TestDive_E164 tests e164 constraint in nested structs via dive.
 func TestDive_E164(t *testing.T) {
 	type Item struct {
-		Phone string `json:"phone" pedantigo:"e164"`
+		Phone string `json:"phone" validate:"e164"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -5662,7 +5662,7 @@ func TestDive_E164(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"phone":"+14155552671"}}}`))
@@ -5671,7 +5671,7 @@ func TestDive_E164(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"phone":"555-1234"}}}`))
@@ -5682,10 +5682,10 @@ func TestDive_E164(t *testing.T) {
 // TestDive_ISBN tests isbn constraint in nested structs via dive.
 func TestDive_ISBN(t *testing.T) {
 	type Item struct {
-		ISBN string `json:"isbn" pedantigo:"isbn"`
+		ISBN string `json:"isbn" validate:"isbn"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -5715,7 +5715,7 @@ func TestDive_ISBN(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"isbn":"978-3-16-148410-0"}}}`))
@@ -5724,7 +5724,7 @@ func TestDive_ISBN(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"isbn":"not-an-isbn"}}}`))
@@ -5735,10 +5735,10 @@ func TestDive_ISBN(t *testing.T) {
 // TestDive_ISBN10 tests isbn10 constraint in nested structs via dive.
 func TestDive_ISBN10(t *testing.T) {
 	type Item struct {
-		ISBN string `json:"isbn" pedantigo:"isbn10"`
+		ISBN string `json:"isbn" validate:"isbn10"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -5760,7 +5760,7 @@ func TestDive_ISBN10(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"isbn":"0306406152"}}}`))
@@ -5771,10 +5771,10 @@ func TestDive_ISBN10(t *testing.T) {
 // TestDive_ISBN13 tests isbn13 constraint in nested structs via dive.
 func TestDive_ISBN13(t *testing.T) {
 	type Item struct {
-		ISBN string `json:"isbn" pedantigo:"isbn13"`
+		ISBN string `json:"isbn" validate:"isbn13"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -5796,7 +5796,7 @@ func TestDive_ISBN13(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"isbn":"9783161484100"}}}`))
@@ -5807,10 +5807,10 @@ func TestDive_ISBN13(t *testing.T) {
 // TestDive_ULID tests ulid constraint in nested structs via dive.
 func TestDive_ULID(t *testing.T) {
 	type Item struct {
-		ID string `json:"id" pedantigo:"ulid"`
+		ID string `json:"id" validate:"ulid"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -5840,7 +5840,7 @@ func TestDive_ULID(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"id":"01ARZ3NDEKTSV4RRFFQ69G5FAV"}}}`))
@@ -5849,7 +5849,7 @@ func TestDive_ULID(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"id":"not-a-ulid"}}}`))
@@ -5864,10 +5864,10 @@ func TestDive_ULID(t *testing.T) {
 // TestDive_CreditCard tests credit_card constraint in nested structs via dive.
 func TestDive_CreditCard(t *testing.T) {
 	type Item struct {
-		Card string `json:"card" pedantigo:"credit_card"`
+		Card string `json:"card" validate:"credit_card"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -5902,7 +5902,7 @@ func TestDive_CreditCard(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"card":"4111111111111111"}}}`))
@@ -5911,7 +5911,7 @@ func TestDive_CreditCard(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"card":"1234567890123456"}}}`))
@@ -5922,10 +5922,10 @@ func TestDive_CreditCard(t *testing.T) {
 // TestDive_SSN tests ssn constraint in nested structs via dive.
 func TestDive_SSN(t *testing.T) {
 	type Item struct {
-		SSN string `json:"ssn" pedantigo:"ssn"`
+		SSN string `json:"ssn" validate:"ssn"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -5955,7 +5955,7 @@ func TestDive_SSN(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"ssn":"123-45-6789"}}}`))
@@ -5964,7 +5964,7 @@ func TestDive_SSN(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"ssn":"invalid"}}}`))
@@ -5975,10 +5975,10 @@ func TestDive_SSN(t *testing.T) {
 // TestDive_BtcAddr tests btc_addr constraint in nested structs via dive.
 func TestDive_BtcAddr(t *testing.T) {
 	type Item struct {
-		Address string `json:"address" pedantigo:"btc_addr"`
+		Address string `json:"address" validate:"btc_addr"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -6013,7 +6013,7 @@ func TestDive_BtcAddr(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"address":"1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"}}}`))
@@ -6022,7 +6022,7 @@ func TestDive_BtcAddr(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"address":"invalid-btc-address"}}}`))
@@ -6033,10 +6033,10 @@ func TestDive_BtcAddr(t *testing.T) {
 // TestDive_BtcAddrBech32 tests btc_addr_bech32 constraint in nested structs via dive.
 func TestDive_BtcAddrBech32(t *testing.T) {
 	type Item struct {
-		Address string `json:"address" pedantigo:"btc_addr_bech32"`
+		Address string `json:"address" validate:"btc_addr_bech32"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -6076,7 +6076,7 @@ func TestDive_BtcAddrBech32(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"address":"bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"}}}`))
@@ -6085,7 +6085,7 @@ func TestDive_BtcAddrBech32(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"address":"bc1invalid"}}}`))
@@ -6096,10 +6096,10 @@ func TestDive_BtcAddrBech32(t *testing.T) {
 // TestDive_EthAddr tests eth_addr constraint in nested structs via dive.
 func TestDive_EthAddr(t *testing.T) {
 	type Item struct {
-		Address string `json:"address" pedantigo:"eth_addr"`
+		Address string `json:"address" validate:"eth_addr"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -6144,7 +6144,7 @@ func TestDive_EthAddr(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"address":"0xffffffffffffffffffffffffffffffffffffffff"}}}`))
@@ -6153,7 +6153,7 @@ func TestDive_EthAddr(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"address":"0xinvalid"}}}`))
@@ -6164,10 +6164,10 @@ func TestDive_EthAddr(t *testing.T) {
 // TestDive_LuhnChecksum tests luhn_checksum constraint in nested structs via dive.
 func TestDive_LuhnChecksum(t *testing.T) {
 	type Item struct {
-		CardNumber string `json:"card_number" pedantigo:"luhn_checksum"`
+		CardNumber string `json:"card_number" validate:"luhn_checksum"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -6217,7 +6217,7 @@ func TestDive_LuhnChecksum(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"card_number":"79927398713"}}}`))
@@ -6226,7 +6226,7 @@ func TestDive_LuhnChecksum(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"card_number":"1234567890"}}}`))
@@ -6241,10 +6241,10 @@ func TestDive_LuhnChecksum(t *testing.T) {
 // TestDive_MD5 tests md5 constraint in nested structs via dive.
 func TestDive_MD5(t *testing.T) {
 	type Item struct {
-		Hash string `json:"hash" pedantigo:"md5"`
+		Hash string `json:"hash" validate:"md5"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -6274,7 +6274,7 @@ func TestDive_MD5(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"hash":"d41d8cd98f00b204e9800998ecf8427e"}}}`))
@@ -6285,10 +6285,10 @@ func TestDive_MD5(t *testing.T) {
 // TestDive_SHA256 tests sha256 constraint in nested structs via dive.
 func TestDive_SHA256(t *testing.T) {
 	type Item struct {
-		Hash string `json:"hash" pedantigo:"sha256"`
+		Hash string `json:"hash" validate:"sha256"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -6313,7 +6313,7 @@ func TestDive_SHA256(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"hash":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}}}`))
@@ -6324,10 +6324,10 @@ func TestDive_SHA256(t *testing.T) {
 // TestDive_SHA512 tests sha512 constraint in nested structs via dive.
 func TestDive_SHA512(t *testing.T) {
 	type Item struct {
-		Hash string `json:"hash" pedantigo:"sha512"`
+		Hash string `json:"hash" validate:"sha512"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -6352,7 +6352,7 @@ func TestDive_SHA512(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"hash":"cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"}}}`))
@@ -6367,10 +6367,10 @@ func TestDive_SHA512(t *testing.T) {
 // TestDive_Datetime tests datetime constraint in nested structs via dive.
 func TestDive_Datetime(t *testing.T) {
 	type Item struct {
-		Date string `json:"date" pedantigo:"datetime=2006-01-02"`
+		Date string `json:"date" validate:"datetime=2006-01-02"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -6400,7 +6400,7 @@ func TestDive_Datetime(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"date":"2024-06-15"}}}`))
@@ -6409,7 +6409,7 @@ func TestDive_Datetime(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"date":"invalid"}}}`))
@@ -6420,10 +6420,10 @@ func TestDive_Datetime(t *testing.T) {
 // TestDive_Timezone tests timezone constraint in nested structs via dive.
 func TestDive_Timezone(t *testing.T) {
 	type Item struct {
-		TZ string `json:"tz" pedantigo:"timezone"`
+		TZ string `json:"tz" validate:"timezone"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -6448,7 +6448,7 @@ func TestDive_Timezone(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"tz":"America/Los_Angeles"}}}`))
@@ -6457,7 +6457,7 @@ func TestDive_Timezone(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"tz":"Not/Real"}}}`))
@@ -6472,10 +6472,10 @@ func TestDive_Timezone(t *testing.T) {
 // TestDive_Latitude tests latitude constraint in nested structs via dive.
 func TestDive_Latitude(t *testing.T) {
 	type Item struct {
-		Lat float64 `json:"lat" pedantigo:"latitude"`
+		Lat float64 `json:"lat" validate:"latitude"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -6505,7 +6505,7 @@ func TestDive_Latitude(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"lat":51.5074}}}`))
@@ -6514,7 +6514,7 @@ func TestDive_Latitude(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"lat":200.0}}}`))
@@ -6525,10 +6525,10 @@ func TestDive_Latitude(t *testing.T) {
 // TestDive_Longitude tests longitude constraint in nested structs via dive.
 func TestDive_Longitude(t *testing.T) {
 	type Item struct {
-		Lng float64 `json:"lng" pedantigo:"longitude"`
+		Lng float64 `json:"lng" validate:"longitude"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -6558,7 +6558,7 @@ func TestDive_Longitude(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"lng":-0.1278}}}`))
@@ -6567,7 +6567,7 @@ func TestDive_Longitude(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"lng":200.0}}}`))
@@ -6582,10 +6582,10 @@ func TestDive_Longitude(t *testing.T) {
 // TestDive_RGB tests rgb constraint in nested structs via dive.
 func TestDive_RGB(t *testing.T) {
 	type Item struct {
-		Color string `json:"color" pedantigo:"rgb"`
+		Color string `json:"color" validate:"rgb"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -6610,7 +6610,7 @@ func TestDive_RGB(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"color":"rgb(0, 0, 0)"}}}`))
@@ -6621,10 +6621,10 @@ func TestDive_RGB(t *testing.T) {
 // TestDive_RGBA tests rgba constraint in nested structs via dive.
 func TestDive_RGBA(t *testing.T) {
 	type Item struct {
-		Color string `json:"color" pedantigo:"rgba"`
+		Color string `json:"color" validate:"rgba"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -6649,7 +6649,7 @@ func TestDive_RGBA(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"color":"rgba(0, 0, 0, 0)"}}}`))
@@ -6660,10 +6660,10 @@ func TestDive_RGBA(t *testing.T) {
 // TestDive_HSL tests hsl constraint in nested structs via dive.
 func TestDive_HSL(t *testing.T) {
 	type Item struct {
-		Color string `json:"color" pedantigo:"hsl"`
+		Color string `json:"color" validate:"hsl"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -6688,7 +6688,7 @@ func TestDive_HSL(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"color":"hsl(120, 100%, 50%)"}}}`))
@@ -6699,10 +6699,10 @@ func TestDive_HSL(t *testing.T) {
 // TestDive_HSLA tests hsla constraint in nested structs via dive.
 func TestDive_HSLA(t *testing.T) {
 	type Item struct {
-		Color string `json:"color" pedantigo:"hsla"`
+		Color string `json:"color" validate:"hsla"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -6727,7 +6727,7 @@ func TestDive_HSLA(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"color":"hsla(120, 100%, 50%, 0.5)"}}}`))
@@ -6742,10 +6742,10 @@ func TestDive_HSLA(t *testing.T) {
 // TestDive_Eq tests eq constraint in nested structs via dive.
 func TestDive_Eq(t *testing.T) {
 	type Item struct {
-		Status string `json:"status" pedantigo:"eq=active"`
+		Status string `json:"status" validate:"eq=active"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -6770,7 +6770,7 @@ func TestDive_Eq(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"status":"active"}}}`))
@@ -6779,7 +6779,7 @@ func TestDive_Eq(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"status":"disabled"}}}`))
@@ -6790,10 +6790,10 @@ func TestDive_Eq(t *testing.T) {
 // TestDive_Ne tests ne constraint in nested structs via dive.
 func TestDive_Ne(t *testing.T) {
 	type Item struct {
-		Status string `json:"status" pedantigo:"ne=deleted"`
+		Status string `json:"status" validate:"ne=deleted"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -6818,7 +6818,7 @@ func TestDive_Ne(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"status":"active"}}}`))
@@ -6827,7 +6827,7 @@ func TestDive_Ne(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"status":"deleted"}}}`))
@@ -6838,10 +6838,10 @@ func TestDive_Ne(t *testing.T) {
 // TestDive_EqIgnoreCase tests eq_ignore_case constraint in nested structs via dive.
 func TestDive_EqIgnoreCase(t *testing.T) {
 	type Item struct {
-		Type string `json:"type" pedantigo:"eq_ignore_case=premium"`
+		Type string `json:"type" validate:"eq_ignore_case=premium"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -6876,7 +6876,7 @@ func TestDive_EqIgnoreCase(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"type":"PREMIUM"}}}`))
@@ -6887,10 +6887,10 @@ func TestDive_EqIgnoreCase(t *testing.T) {
 // TestDive_NeIgnoreCase tests ne_ignore_case constraint in nested structs via dive.
 func TestDive_NeIgnoreCase(t *testing.T) {
 	type Item struct {
-		Status string `json:"status" pedantigo:"ne_ignore_case=deleted"`
+		Status string `json:"status" validate:"ne_ignore_case=deleted"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -6925,7 +6925,7 @@ func TestDive_NeIgnoreCase(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"status":"active"}}}`))
@@ -6934,7 +6934,7 @@ func TestDive_NeIgnoreCase(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"status":"DeLeTed"}}}`))
@@ -6945,10 +6945,10 @@ func TestDive_NeIgnoreCase(t *testing.T) {
 // TestDive_ContainsRune tests containsrune constraint in nested structs via dive.
 func TestDive_ContainsRune(t *testing.T) {
 	type Item struct {
-		Value string `json:"value" pedantigo:"containsrune=@"`
+		Value string `json:"value" validate:"containsrune=@"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -6973,7 +6973,7 @@ func TestDive_ContainsRune(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"value":"user@domain"}}}`))
@@ -6982,7 +6982,7 @@ func TestDive_ContainsRune(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"value":"nodomain"}}}`))
@@ -6997,10 +6997,10 @@ func TestDive_ContainsRune(t *testing.T) {
 // TestDive_Semver tests semver constraint in nested structs via dive.
 func TestDive_Semver(t *testing.T) {
 	type Item struct {
-		Version string `json:"version" pedantigo:"semver"`
+		Version string `json:"version" validate:"semver"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -7030,7 +7030,7 @@ func TestDive_Semver(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"version":"1.2.3"}}}`))
@@ -7039,7 +7039,7 @@ func TestDive_Semver(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"version":"v1"}}}`))
@@ -7072,10 +7072,10 @@ func TestDive_Image(t *testing.T) {
 	require.NoError(t, os.WriteFile(invalidFilePath, []byte("not an image"), 0o600))
 
 	type Item struct {
-		Path string `json:"path" pedantigo:"image"`
+		Path string `json:"path" validate:"image"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -7111,7 +7111,7 @@ func TestDive_Image(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		jsonData := []byte(`{"items":{"a":{"path":"` + validImagePath + `"}}}`)
@@ -7121,7 +7121,7 @@ func TestDive_Image(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		jsonData := []byte(`{"items":{"a":{"path":"` + invalidFilePath + `"}}}`)
@@ -7133,10 +7133,10 @@ func TestDive_Image(t *testing.T) {
 // TestDive_Md4 tests md4 constraint in nested structs via dive.
 func TestDive_Md4(t *testing.T) {
 	type Item struct {
-		Hash string `json:"hash" pedantigo:"md4"`
+		Hash string `json:"hash" validate:"md4"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -7170,7 +7170,7 @@ func TestDive_Md4(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"hash":"d41d8cd98f00b204e9800998ecf8427e"}}}`))
@@ -7179,7 +7179,7 @@ func TestDive_Md4(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"hash":"not-a-valid-md4"}}}`))
@@ -7190,10 +7190,10 @@ func TestDive_Md4(t *testing.T) {
 // TestDive_Sha384 tests sha384 constraint in nested structs via dive.
 func TestDive_Sha384(t *testing.T) {
 	type Item struct {
-		Hash string `json:"hash" pedantigo:"sha384"`
+		Hash string `json:"hash" validate:"sha384"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -7227,7 +7227,7 @@ func TestDive_Sha384(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"hash":"38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"}}}`))
@@ -7236,7 +7236,7 @@ func TestDive_Sha384(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"hash":"not-a-valid-sha384"}}}`))
@@ -7248,10 +7248,10 @@ func TestDive_Sha384(t *testing.T) {
 // strip_whitespace validates that a string has no leading/trailing whitespace.
 func TestDive_StripWhitespace(t *testing.T) {
 	type Item struct {
-		Text string `json:"text" pedantigo:"strip_whitespace"`
+		Text string `json:"text" validate:"strip_whitespace"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -7281,7 +7281,7 @@ func TestDive_StripWhitespace(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"text":"trimmed"}}}`))
@@ -7290,7 +7290,7 @@ func TestDive_StripWhitespace(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"text":"  untrimmed  "}}}`))
@@ -7302,10 +7302,10 @@ func TestDive_StripWhitespace(t *testing.T) {
 // to_lower validates that a string is all lowercase.
 func TestDive_ToLower(t *testing.T) {
 	type Item struct {
-		Text string `json:"text" pedantigo:"to_lower"`
+		Text string `json:"text" validate:"to_lower"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -7335,7 +7335,7 @@ func TestDive_ToLower(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"text":"lowercase"}}}`))
@@ -7344,7 +7344,7 @@ func TestDive_ToLower(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"text":"UPPERCASE"}}}`))
@@ -7356,10 +7356,10 @@ func TestDive_ToLower(t *testing.T) {
 // to_upper validates that a string is all uppercase.
 func TestDive_ToUpper(t *testing.T) {
 	type Item struct {
-		Text string `json:"text" pedantigo:"to_upper"`
+		Text string `json:"text" validate:"to_upper"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -7389,7 +7389,7 @@ func TestDive_ToUpper(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"text":"UPPERCASE"}}}`))
@@ -7398,7 +7398,7 @@ func TestDive_ToUpper(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"text":"lowercase"}}}`))
@@ -7409,10 +7409,10 @@ func TestDive_ToUpper(t *testing.T) {
 // TestDive_Base32 tests base32 constraint in nested structs via dive.
 func TestDive_Base32(t *testing.T) {
 	type Item struct {
-		Data string `json:"data" pedantigo:"base32"`
+		Data string `json:"data" validate:"base32"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -7437,7 +7437,7 @@ func TestDive_Base32(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"data":"JBSWY3DPEHPK3PXP"}}}`))
@@ -7446,7 +7446,7 @@ func TestDive_Base32(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"data":"###invalid###"}}}`))
@@ -7457,10 +7457,10 @@ func TestDive_Base32(t *testing.T) {
 // TestDive_Base64rawurl tests base64rawurl constraint in nested structs via dive.
 func TestDive_Base64rawurl(t *testing.T) {
 	type Item struct {
-		Data string `json:"data" pedantigo:"base64rawurl"`
+		Data string `json:"data" validate:"base64rawurl"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -7485,7 +7485,7 @@ func TestDive_Base64rawurl(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"data":"SGVsbG8"}}}`))
@@ -7494,7 +7494,7 @@ func TestDive_Base64rawurl(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"data":"###invalid###"}}}`))
@@ -7505,10 +7505,10 @@ func TestDive_Base64rawurl(t *testing.T) {
 // TestDive_Datauri tests datauri constraint in nested structs via dive.
 func TestDive_Datauri(t *testing.T) {
 	type Item struct {
-		Data string `json:"data" pedantigo:"datauri"`
+		Data string `json:"data" validate:"datauri"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -7533,7 +7533,7 @@ func TestDive_Datauri(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"data":"data:text/plain;base64,SGVsbG8="}}}`))
@@ -7542,7 +7542,7 @@ func TestDive_Datauri(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"data":"invalid-data-uri"}}}`))
@@ -7554,10 +7554,10 @@ func TestDive_Datauri(t *testing.T) {
 // nested structs accessed via dive. Validates presence of multibyte characters.
 func TestDive_Multibyte(t *testing.T) {
 	type Item struct {
-		Text string `json:"text" pedantigo:"multibyte"`
+		Text string `json:"text" validate:"multibyte"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -7592,7 +7592,7 @@ func TestDive_Multibyte(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"text":"привет"}}}`))
@@ -7601,7 +7601,7 @@ func TestDive_Multibyte(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"text":"plain"}}}`))
@@ -7613,10 +7613,10 @@ func TestDive_Multibyte(t *testing.T) {
 // nested structs accessed via dive. Validates URN format per RFC 2141.
 func TestDive_UrnRfc2141(t *testing.T) {
 	type Item struct {
-		URN string `json:"urn" pedantigo:"urn_rfc2141"`
+		URN string `json:"urn" validate:"urn_rfc2141"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -7651,7 +7651,7 @@ func TestDive_UrnRfc2141(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"urn":"urn:ietf:rfc:2141"}}}`))
@@ -7660,7 +7660,7 @@ func TestDive_UrnRfc2141(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"urn":"not-a-urn"}}}`))
@@ -7672,10 +7672,10 @@ func TestDive_UrnRfc2141(t *testing.T) {
 // nested structs accessed via dive. Validates MongoDB ObjectId (24 hex chars).
 func TestDive_Mongodb(t *testing.T) {
 	type Item struct {
-		ObjectID string `json:"object_id" pedantigo:"mongodb"`
+		ObjectID string `json:"object_id" validate:"mongodb"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -7715,7 +7715,7 @@ func TestDive_Mongodb(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"object_id":"000000000000000000000000"}}}`))
@@ -7724,7 +7724,7 @@ func TestDive_Mongodb(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"object_id":"invalid"}}}`))
@@ -7736,10 +7736,10 @@ func TestDive_Mongodb(t *testing.T) {
 // nested structs accessed via dive. Validates presence of HTML tags.
 func TestDive_Html(t *testing.T) {
 	type Item struct {
-		Content string `json:"content" pedantigo:"html"`
+		Content string `json:"content" validate:"html"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -7779,7 +7779,7 @@ func TestDive_Html(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"content":"<p>test</p>"}}}`))
@@ -7788,7 +7788,7 @@ func TestDive_Html(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"content":"no html here"}}}`))
@@ -7800,10 +7800,10 @@ func TestDive_Html(t *testing.T) {
 // nested structs accessed via dive. Validates cron expressions (5 fields).
 func TestDive_Cron(t *testing.T) {
 	type Item struct {
-		Schedule string `json:"schedule" pedantigo:"cron"`
+		Schedule string `json:"schedule" validate:"cron"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -7848,7 +7848,7 @@ func TestDive_Cron(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"schedule":"0 0 1 * *"}}}`))
@@ -7857,7 +7857,7 @@ func TestDive_Cron(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"schedule":"invalid"}}}`))
@@ -7869,10 +7869,10 @@ func TestDive_Cron(t *testing.T) {
 // nested structs accessed via dive. Validates U.S. EIN format (XX-XXXXXXX).
 func TestDive_Ein(t *testing.T) {
 	type Item struct {
-		EIN string `json:"ein" pedantigo:"ein"`
+		EIN string `json:"ein" validate:"ein"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -7912,7 +7912,7 @@ func TestDive_Ein(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"ein":"12-3456789"}}}`))
@@ -7921,7 +7921,7 @@ func TestDive_Ein(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"ein":"invalid"}}}`))
@@ -7933,10 +7933,10 @@ func TestDive_Ein(t *testing.T) {
 // nested structs accessed via dive. Validates ISSN format (ISO 3297).
 func TestDive_Issn(t *testing.T) {
 	type Item struct {
-		ISSN string `json:"issn" pedantigo:"issn"`
+		ISSN string `json:"issn" validate:"issn"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -7976,7 +7976,7 @@ func TestDive_Issn(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"issn":"0317-8471"}}}`))
@@ -7985,7 +7985,7 @@ func TestDive_Issn(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"issn":"1234567890"}}}`))
@@ -7996,10 +7996,10 @@ func TestDive_Issn(t *testing.T) {
 // TestDive_Min tests min constraint in nested structs via dive.
 func TestDive_Min(t *testing.T) {
 	type Item struct {
-		Value int `json:"value" pedantigo:"min=5"`
+		Value int `json:"value" validate:"min=5"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -8025,7 +8025,7 @@ func TestDive_Min(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"value":10}}}`))
@@ -8034,7 +8034,7 @@ func TestDive_Min(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"value":2}}}`))
@@ -8045,10 +8045,10 @@ func TestDive_Min(t *testing.T) {
 // TestDive_Max tests max constraint in nested structs via dive.
 func TestDive_Max(t *testing.T) {
 	type Item struct {
-		Value int `json:"value" pedantigo:"max=100"`
+		Value int `json:"value" validate:"max=100"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -8074,7 +8074,7 @@ func TestDive_Max(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"value":50}}}`))
@@ -8083,7 +8083,7 @@ func TestDive_Max(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"a":{"value":200}}}`))
@@ -8094,10 +8094,10 @@ func TestDive_Max(t *testing.T) {
 // TestDive_ContainsAny tests containsany constraint in nested structs via dive.
 func TestDive_ContainsAny(t *testing.T) {
 	type Item struct {
-		Text string `json:"text" pedantigo:"containsany=abc"`
+		Text string `json:"text" validate:"containsany=abc"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -8127,7 +8127,7 @@ func TestDive_ContainsAny(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"key":{"text":"apple"}}}`))
@@ -8138,10 +8138,10 @@ func TestDive_ContainsAny(t *testing.T) {
 // TestDive_ExcludesAll tests excludesall constraint in nested structs via dive.
 func TestDive_ExcludesAll(t *testing.T) {
 	type Item struct {
-		Text string `json:"text" pedantigo:"excludesall=xyz"`
+		Text string `json:"text" validate:"excludesall=xyz"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -8171,7 +8171,7 @@ func TestDive_ExcludesAll(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"key":{"text":"abc"}}}`))
@@ -8182,10 +8182,10 @@ func TestDive_ExcludesAll(t *testing.T) {
 // TestDive_ExcludesRune tests excludesrune constraint in nested structs via dive.
 func TestDive_ExcludesRune(t *testing.T) {
 	type Item struct {
-		Text string `json:"text" pedantigo:"excludesrune=@"`
+		Text string `json:"text" validate:"excludesrune=@"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -8205,7 +8205,7 @@ func TestDive_ExcludesRune(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"key":{"text":"no at here"}}}`))
@@ -8214,7 +8214,7 @@ func TestDive_ExcludesRune(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"key":{"text":"has@sign"}}}`))
@@ -8225,10 +8225,10 @@ func TestDive_ExcludesRune(t *testing.T) {
 // TestDive_EndsNotWith tests endsnotwith constraint in nested structs via dive.
 func TestDive_EndsNotWith(t *testing.T) {
 	type Item struct {
-		Text string `json:"text" pedantigo:"endsnotwith=.tmp"`
+		Text string `json:"text" validate:"endsnotwith=.tmp"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -8248,7 +8248,7 @@ func TestDive_EndsNotWith(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"key":{"text":"document.pdf"}}}`))
@@ -8257,7 +8257,7 @@ func TestDive_EndsNotWith(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"key":{"text":"cache.tmp"}}}`))
@@ -8268,10 +8268,10 @@ func TestDive_EndsNotWith(t *testing.T) {
 // TestDive_StartsNotWith tests startsnotwith constraint in nested structs via dive.
 func TestDive_StartsNotWith(t *testing.T) {
 	type Item struct {
-		Text string `json:"text" pedantigo:"startsnotwith=_"`
+		Text string `json:"text" validate:"startsnotwith=_"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -8291,7 +8291,7 @@ func TestDive_StartsNotWith(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"key":{"text":"public"}}}`))
@@ -8300,7 +8300,7 @@ func TestDive_StartsNotWith(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"key":{"text":"_hidden"}}}`))
@@ -8311,10 +8311,10 @@ func TestDive_StartsNotWith(t *testing.T) {
 // TestDive_Unique tests unique constraint in nested structs via dive.
 func TestDive_Unique(t *testing.T) {
 	type Item struct {
-		Tags []string `json:"tags" pedantigo:"unique"`
+		Tags []string `json:"tags" validate:"unique"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	validator := New[Container]()
@@ -8339,7 +8339,7 @@ func TestDive_Unique(t *testing.T) {
 
 	t.Run("map_valid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"key":{"tags":["x","y","z"]}}}`))
@@ -8348,7 +8348,7 @@ func TestDive_Unique(t *testing.T) {
 
 	t.Run("map_invalid", func(t *testing.T) {
 		type MapContainer struct {
-			Items map[string]Item `json:"items" pedantigo:"dive"`
+			Items map[string]Item `json:"items" validate:"dive"`
 		}
 		mapValidator := New[MapContainer]()
 		_, err := mapValidator.Unmarshal([]byte(`{"items":{"key":{"tags":["x","x"]}}}`))

--- a/config.go
+++ b/config.go
@@ -4,10 +4,10 @@ import "sync/atomic"
 
 // DefaultTagName is the default struct tag name used by Pedantigo.
 // This is exported for reference but users should use GetTagName() for the current value.
-const DefaultTagName = "pedantigo"
+const DefaultTagName = "validate"
 
 var (
-	// globalTagName stores the current struct tag name (default: "pedantigo").
+	// globalTagName stores the current struct tag name (default: "validate").
 	globalTagName atomic.Value
 
 	// validatorCreated tracks if any validator has been created.
@@ -50,7 +50,7 @@ func SetTagName(name string) {
 }
 
 // GetTagName returns the current global tag name.
-// By default, this is "pedantigo".
+// By default, this is "validate".
 func GetTagName() string {
 	return globalTagName.Load().(string)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -11,13 +11,13 @@ import (
 // Tests for Global Tag Name Configuration
 // ============================================================================
 
-// TestGetTagName_Default verifies the default tag name is "pedantigo".
+// TestGetTagName_Default verifies the default tag name is "validate".
 func TestGetTagName_Default(t *testing.T) {
 	// Reset to default for this test
 	resetTagNameForTesting()
 
 	tagName := GetTagName()
-	assert.Equal(t, "pedantigo", tagName, "default tag name should be 'pedantigo'")
+	assert.Equal(t, "validate", tagName, "default tag name should be 'validate'")
 }
 
 // TestSetTagName_Custom verifies setting a custom tag name.
@@ -25,8 +25,8 @@ func TestSetTagName_Custom(t *testing.T) {
 	resetTagNameForTesting()
 	resetValidatorCreatedForTesting() // Must reset flag for SetTagName to work
 
-	SetTagName("validate")
-	assert.Equal(t, "validate", GetTagName())
+	SetTagName("custom_validate")
+	assert.Equal(t, "custom_validate", GetTagName())
 
 	resetValidatorCreatedForTesting() // Reset again before next SetTagName
 	SetTagName("binding")
@@ -43,7 +43,7 @@ func TestSetTagName_Empty_FallsBack(t *testing.T) {
 	resetValidatorCreatedForTesting()
 
 	SetTagName("")
-	assert.Equal(t, "pedantigo", GetTagName(), "empty tag name should fall back to 'pedantigo'")
+	assert.Equal(t, "validate", GetTagName(), "empty tag name should fall back to 'pedantigo'")
 
 	resetValidatorCreatedForTesting()
 }
@@ -57,7 +57,7 @@ func TestGetTagName_ThreadSafe(t *testing.T) {
 	const numGoroutines = 100
 
 	// Set a known value
-	SetTagName("validate")
+	SetTagName("custom_validate")
 
 	// Concurrent reads
 	for i := 0; i < numGoroutines; i++ {
@@ -65,7 +65,7 @@ func TestGetTagName_ThreadSafe(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			tagName := GetTagName()
-			assert.Equal(t, "validate", tagName)
+			assert.Equal(t, "custom_validate", tagName)
 		}()
 	}
 
@@ -93,7 +93,7 @@ func TestSetTagName_PanicsAfterValidatorCreated(t *testing.T) {
 
 	// Now SetTagName should panic
 	assert.Panics(t, func() {
-		SetTagName("validate")
+		SetTagName("custom_validate")
 	}, "SetTagName should panic when called after validator creation")
 
 	// Reset for other tests

--- a/constraints_test.go
+++ b/constraints_test.go
@@ -235,10 +235,10 @@ func runFormatTest(t *testing.T, tt formatTestCase, fieldName, errMsg string, fv
 // URL format validator types and methods.
 type urlFormatValidator struct{}
 type urlPtrStruct struct {
-	Website *string `json:"website" pedantigo:"url"`
+	Website *string `json:"website" validate:"url"`
 }
 type urlValStruct struct {
-	Website string `json:"website" pedantigo:"url"`
+	Website string `json:"website" validate:"url"`
 }
 
 func (urlFormatValidator) unmarshalPointer(json []byte) (*string, error) {
@@ -255,10 +255,10 @@ func (urlFormatValidator) unmarshalValue(json []byte) (string, error) {
 // UUID format validator types and methods.
 type uuidFormatValidator struct{}
 type uuidPtrStruct struct {
-	ID *string `json:"id" pedantigo:"uuid"`
+	ID *string `json:"id" validate:"uuid"`
 }
 type uuidValStruct struct {
-	ID string `json:"id" pedantigo:"uuid"`
+	ID string `json:"id" validate:"uuid"`
 }
 
 func (uuidFormatValidator) unmarshalPointer(json []byte) (*string, error) {
@@ -275,10 +275,10 @@ func (uuidFormatValidator) unmarshalValue(json []byte) (string, error) {
 // IPv4 format validator types and methods.
 type ipv4FormatValidator struct{}
 type ipv4PtrStruct struct {
-	IP *string `json:"ip" pedantigo:"ipv4"`
+	IP *string `json:"ip" validate:"ipv4"`
 }
 type ipv4ValStruct struct {
-	IP string `json:"ip" pedantigo:"ipv4"`
+	IP string `json:"ip" validate:"ipv4"`
 }
 
 func (ipv4FormatValidator) unmarshalPointer(json []byte) (*string, error) {
@@ -295,10 +295,10 @@ func (ipv4FormatValidator) unmarshalValue(json []byte) (string, error) {
 // IPv6 format validator types and methods.
 type ipv6FormatValidator struct{}
 type ipv6PtrStruct struct {
-	IP *string `json:"ip" pedantigo:"ipv6"`
+	IP *string `json:"ip" validate:"ipv6"`
 }
 type ipv6ValStruct struct {
-	IP string `json:"ip" pedantigo:"ipv6"`
+	IP string `json:"ip" validate:"ipv6"`
 }
 
 func (ipv6FormatValidator) unmarshalPointer(json []byte) (*string, error) {
@@ -339,7 +339,7 @@ func TestRegex_UppercasePattern(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.usePointer {
 				type Code struct {
-					Value *string `json:"value" pedantigo:"regexp=^[A-Z]{3}$"`
+					Value *string `json:"value" validate:"regexp=^[A-Z]{3}$"`
 				}
 				validator := New[Code]()
 				code, err := validator.Unmarshal([]byte(tt.json))
@@ -357,7 +357,7 @@ func TestRegex_UppercasePattern(t *testing.T) {
 				}
 			} else {
 				type Code struct {
-					Value string `json:"value" pedantigo:"regexp=^[A-Z]{3}$"`
+					Value string `json:"value" validate:"regexp=^[A-Z]{3}$"`
 				}
 				validator := New[Code]()
 				code, err := validator.Unmarshal([]byte(tt.json))
@@ -387,7 +387,7 @@ func TestRegex_DigitsPattern(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			type Code struct {
-				Value string `json:"value" pedantigo:"regexp=^\\d{4}$"`
+				Value string `json:"value" validate:"regexp=^\\d{4}$"`
 			}
 			validator := New[Code]()
 			code, err := validator.Unmarshal([]byte(tt.json))
@@ -498,13 +498,13 @@ func TestMinLength(t *testing.T) {
 				// Non-pointer test case
 				// User represents the data structure
 				type User struct {
-					Username string `json:"username" pedantigo:"min=3"`
+					Username string `json:"username" validate:"min=3"`
 				}
 
 				// For empty string test, use min=1
 				if tt.minVal == 1 {
 					type UserMin1 struct {
-						Username string `json:"username" pedantigo:"min=1"`
+						Username string `json:"username" validate:"min=1"`
 					}
 					validator := New[UserMin1]()
 					_, err := validator.Unmarshal([]byte(tt.json))
@@ -551,7 +551,7 @@ func TestMinLength(t *testing.T) {
 				// Pointer test case
 				// User represents the data structure
 				type User struct {
-					Bio *string `json:"bio" pedantigo:"min=10"`
+					Bio *string `json:"bio" validate:"min=10"`
 				}
 
 				validator := New[User]()
@@ -590,16 +590,16 @@ func TestMinLength(t *testing.T) {
 
 // max length test struct types (moved outside to reduce cognitive complexity).
 type userMax10 struct {
-	Username string `json:"username" pedantigo:"max=10"`
+	Username string `json:"username" validate:"max=10"`
 }
 type userMax5 struct {
-	Username string `json:"username" pedantigo:"max=5"`
+	Username string `json:"username" validate:"max=5"`
 }
 type userMinMax struct {
-	Password string `json:"password" pedantigo:"min=8,max=20"`
+	Password string `json:"password" validate:"min=8,max=20"`
 }
 type userBioPtr struct {
-	Bio *string `json:"bio" pedantigo:"max=20"`
+	Bio *string `json:"bio" validate:"max=20"`
 }
 
 // runMaxLengthStringTest handles non-pointer max length tests.
@@ -800,7 +800,7 @@ func TestGt(t *testing.T) {
 			switch tt.valueType {
 			case "int":
 				type Product struct {
-					Stock int `json:"stock" pedantigo:"gt=0"`
+					Stock int `json:"stock" validate:"gt=0"`
 				}
 
 				validator := New[Product]()
@@ -829,7 +829,7 @@ func TestGt(t *testing.T) {
 
 			case "float64":
 				type Product struct {
-					Price float64 `json:"price" pedantigo:"gt=0"`
+					Price float64 `json:"price" validate:"gt=0"`
 				}
 
 				validator := New[Product]()
@@ -858,7 +858,7 @@ func TestGt(t *testing.T) {
 
 			case "uint":
 				type Config struct {
-					Port uint `json:"port" pedantigo:"gt=1024"`
+					Port uint `json:"port" validate:"gt=1024"`
 				}
 
 				validator := New[Config]()
@@ -887,7 +887,7 @@ func TestGt(t *testing.T) {
 
 			case "intPtr":
 				type Product struct {
-					Stock *int `json:"stock" pedantigo:"gt=0"`
+					Stock *int `json:"stock" validate:"gt=0"`
 				}
 
 				validator := New[Product]()
@@ -931,7 +931,7 @@ func TestGt(t *testing.T) {
 // TestGe tests Ge validation.
 func TestGe(t *testing.T) {
 	type Product struct {
-		Stock int `json:"stock" pedantigo:"gte=0"`
+		Stock int `json:"stock" validate:"gte=0"`
 	}
 
 	tests := []struct {
@@ -995,10 +995,10 @@ func TestGe(t *testing.T) {
 
 // ltLteProduct types for lt/lte testing.
 type ltProduct struct {
-	Discount int `json:"discount" pedantigo:"lt=100"`
+	Discount int `json:"discount" validate:"lt=100"`
 }
 type lteProduct struct {
-	Discount int `json:"discount" pedantigo:"lte=100"`
+	Discount int `json:"discount" validate:"lte=100"`
 }
 
 // TestLtLte tests lt and lte constraints in a unified table-driven test.
@@ -1123,7 +1123,7 @@ func TestEnum(t *testing.T) {
 			switch tt.testType {
 			case "string_valid":
 				type User struct {
-					Role string `json:"role" pedantigo:"oneof=admin user guest"`
+					Role string `json:"role" validate:"oneof=admin user guest"`
 				}
 				validator := New[User]()
 				user, err := validator.Unmarshal([]byte(tt.json))
@@ -1132,7 +1132,7 @@ func TestEnum(t *testing.T) {
 
 			case "string_invalid":
 				type User struct {
-					Role string `json:"role" pedantigo:"oneof=admin user guest"`
+					Role string `json:"role" validate:"oneof=admin user guest"`
 				}
 				validator := New[User]()
 				_, err := validator.Unmarshal([]byte(tt.json))
@@ -1149,7 +1149,7 @@ func TestEnum(t *testing.T) {
 
 			case "int_valid":
 				type Status struct {
-					Code int `json:"code" pedantigo:"oneof=200 201 204"`
+					Code int `json:"code" validate:"oneof=200 201 204"`
 				}
 				validator := New[Status]()
 				status, err := validator.Unmarshal([]byte(tt.json))
@@ -1158,7 +1158,7 @@ func TestEnum(t *testing.T) {
 
 			case "int_invalid":
 				type Status struct {
-					Code int `json:"code" pedantigo:"oneof=200 201 204"`
+					Code int `json:"code" validate:"oneof=200 201 204"`
 				}
 				validator := New[Status]()
 				_, err := validator.Unmarshal([]byte(tt.json))
@@ -1175,7 +1175,7 @@ func TestEnum(t *testing.T) {
 
 			case "slice":
 				type Config struct {
-					Roles []string `json:"roles" pedantigo:"dive,oneof=admin user guest"`
+					Roles []string `json:"roles" validate:"dive,oneof=admin user guest"`
 				}
 				validator := New[Config]()
 				_, err := validator.Unmarshal([]byte(tt.json))
@@ -1193,7 +1193,7 @@ func TestEnum(t *testing.T) {
 
 			case "map":
 				type Config struct {
-					Permissions map[string]string `json:"permissions" pedantigo:"dive,oneof=read write execute"`
+					Permissions map[string]string `json:"permissions" validate:"dive,oneof=read write execute"`
 				}
 				validator := New[Config]()
 				_, err := validator.Unmarshal([]byte(tt.json))
@@ -1211,7 +1211,7 @@ func TestEnum(t *testing.T) {
 
 			case "schema":
 				type User struct {
-					Role string `json:"role" pedantigo:"oneof=admin user guest"`
+					Role string `json:"role" validate:"oneof=admin user guest"`
 				}
 				validator := New[User]()
 				schema := validator.Schema()
@@ -1325,7 +1325,7 @@ func TestEq(t *testing.T) {
 			switch tt.testType {
 			case "string_valid":
 				type Message struct {
-					Type string `json:"type" pedantigo:"eq=user"`
+					Type string `json:"type" validate:"eq=user"`
 				}
 				validator := New[Message]()
 				msg, err := validator.Unmarshal([]byte(tt.json))
@@ -1334,7 +1334,7 @@ func TestEq(t *testing.T) {
 
 			case "string_invalid":
 				type Message struct {
-					Type string `json:"type" pedantigo:"eq=user"`
+					Type string `json:"type" validate:"eq=user"`
 				}
 				validator := New[Message]()
 				_, err := validator.Unmarshal([]byte(tt.json))
@@ -1352,7 +1352,7 @@ func TestEq(t *testing.T) {
 
 			case "int_valid":
 				type Config struct {
-					Version int `json:"version" pedantigo:"eq=1"`
+					Version int `json:"version" validate:"eq=1"`
 				}
 				validator := New[Config]()
 				cfg, err := validator.Unmarshal([]byte(tt.json))
@@ -1361,7 +1361,7 @@ func TestEq(t *testing.T) {
 
 			case "int_invalid":
 				type Config struct {
-					Version int `json:"version" pedantigo:"eq=1"`
+					Version int `json:"version" validate:"eq=1"`
 				}
 				validator := New[Config]()
 				_, err := validator.Unmarshal([]byte(tt.json))
@@ -1379,7 +1379,7 @@ func TestEq(t *testing.T) {
 
 			case "float_valid":
 				type Rate struct {
-					Rate float64 `json:"rate" pedantigo:"eq=0.5"`
+					Rate float64 `json:"rate" validate:"eq=0.5"`
 				}
 				validator := New[Rate]()
 				r, err := validator.Unmarshal([]byte(tt.json))
@@ -1388,7 +1388,7 @@ func TestEq(t *testing.T) {
 
 			case "pointer_valid":
 				type Event struct {
-					Kind *string `json:"kind" pedantigo:"eq=event"`
+					Kind *string `json:"kind" validate:"eq=event"`
 				}
 				validator := New[Event]()
 				ev, err := validator.Unmarshal([]byte(tt.json))
@@ -1398,7 +1398,7 @@ func TestEq(t *testing.T) {
 
 			case "pointer_nil":
 				type Event struct {
-					Kind *string `json:"kind" pedantigo:"eq=event"`
+					Kind *string `json:"kind" validate:"eq=event"`
 				}
 				validator := New[Event]()
 				ev, err := validator.Unmarshal([]byte(tt.json))
@@ -1414,7 +1414,7 @@ func TestEqWithCombinedConstraints(t *testing.T) {
 	// eq combined with required
 	t.Run("eq with required", func(t *testing.T) {
 		type APIVersion struct {
-			Version string `json:"version" pedantigo:"required,eq=v1"`
+			Version string `json:"version" validate:"required,eq=v1"`
 		}
 		validator := New[APIVersion]()
 
@@ -1432,7 +1432,7 @@ func TestEqWithCombinedConstraints(t *testing.T) {
 // TestEqBoolValue tests eq constraint with boolean values.
 func TestEqBoolValue(t *testing.T) {
 	type Feature struct {
-		Enabled bool `json:"enabled" pedantigo:"eq=true"`
+		Enabled bool `json:"enabled" validate:"eq=true"`
 	}
 	validator := New[Feature]()
 
@@ -1525,7 +1525,7 @@ func TestNe(t *testing.T) {
 			switch tt.testType {
 			case "string_valid":
 				type Status struct {
-					Status string `json:"status" pedantigo:"ne=banned"`
+					Status string `json:"status" validate:"ne=banned"`
 				}
 				validator := New[Status]()
 				s, err := validator.Unmarshal([]byte(tt.json))
@@ -1534,7 +1534,7 @@ func TestNe(t *testing.T) {
 
 			case "string_invalid":
 				type Status struct {
-					Status string `json:"status" pedantigo:"ne=banned"`
+					Status string `json:"status" validate:"ne=banned"`
 				}
 				validator := New[Status]()
 				_, err := validator.Unmarshal([]byte(tt.json))
@@ -1552,7 +1552,7 @@ func TestNe(t *testing.T) {
 
 			case "int_valid":
 				type Config struct {
-					Version int `json:"version" pedantigo:"ne=0"`
+					Version int `json:"version" validate:"ne=0"`
 				}
 				validator := New[Config]()
 				cfg, err := validator.Unmarshal([]byte(tt.json))
@@ -1561,7 +1561,7 @@ func TestNe(t *testing.T) {
 
 			case "int_invalid":
 				type Config struct {
-					Version int `json:"version" pedantigo:"ne=0"`
+					Version int `json:"version" validate:"ne=0"`
 				}
 				validator := New[Config]()
 				_, err := validator.Unmarshal([]byte(tt.json))
@@ -1579,7 +1579,7 @@ func TestNe(t *testing.T) {
 
 			case "pointer_valid":
 				type Event struct {
-					Kind *string `json:"kind" pedantigo:"ne=banned"`
+					Kind *string `json:"kind" validate:"ne=banned"`
 				}
 				validator := New[Event]()
 				ev, err := validator.Unmarshal([]byte(tt.json))
@@ -1589,7 +1589,7 @@ func TestNe(t *testing.T) {
 
 			case "pointer_nil":
 				type Event struct {
-					Kind *string `json:"kind" pedantigo:"ne=banned"`
+					Kind *string `json:"kind" validate:"ne=banned"`
 				}
 				validator := New[Event]()
 				ev, err := validator.Unmarshal([]byte(tt.json))
@@ -1605,7 +1605,7 @@ func TestNeWithCombinedConstraints(t *testing.T) {
 	// ne combined with required
 	t.Run("ne with required", func(t *testing.T) {
 		type UserStatus struct {
-			Status string `json:"status" pedantigo:"required,ne=deleted"`
+			Status string `json:"status" validate:"required,ne=deleted"`
 		}
 		validator := New[UserStatus]()
 
@@ -1674,7 +1674,7 @@ func TestOneofci(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			type User struct {
-				Role string `json:"role" pedantigo:"oneofci=admin user guest"`
+				Role string `json:"role" validate:"oneofci=admin user guest"`
 			}
 			validator := New[User]()
 			user, err := validator.Unmarshal([]byte(tt.json))
@@ -1703,7 +1703,7 @@ func TestOneofci(t *testing.T) {
 // TestIscolorAlias tests the built-in iscolor alias that expands to color format validators.
 func TestIscolorAlias(t *testing.T) {
 	type Config struct {
-		Color string `json:"color" pedantigo:"iscolor"`
+		Color string `json:"color" validate:"iscolor"`
 	}
 	validator := New[Config]()
 
@@ -1751,7 +1751,7 @@ func TestIscolorAlias(t *testing.T) {
 // TestUriConstraint tests the uri constraint for database and other URI formats.
 func TestUriConstraintIntegration(t *testing.T) {
 	type Config struct {
-		DatabaseURL string `json:"database_url" pedantigo:"uri"`
+		DatabaseURL string `json:"database_url" validate:"uri"`
 	}
 	validator := New[Config]()
 

--- a/custom_tagname_test.go
+++ b/custom_tagname_test.go
@@ -12,18 +12,18 @@ import (
 // Integration Tests for Custom Tag Name Support
 // ============================================================================
 
-// TestCustomTagName_PlaygroundCompatibility tests using "validate" tags
+// TestCustomTagName_PlaygroundCompatibility tests using "custom_validate" tags
 // like go-playground/validator for seamless migration.
 func TestCustomTagName_PlaygroundCompatibility(t *testing.T) {
 	resetTagNameForTesting()
 	resetValidatorCreatedForTesting()
 
-	// Set global tag name to "validate" (playground compatible)
-	SetTagName("validate")
+	// Set global tag name to "custom_validate" (playground compatible)
+	SetTagName("custom_validate")
 
 	type User struct {
-		Email string `json:"email" validate:"required,email"`
-		Age   int    `json:"age" validate:"min=18,max=120"`
+		Email string `json:"email" custom_validate:"required,email"`
+		Age   int    `json:"age" custom_validate:"min=18,max=120"`
 	}
 
 	v := New[User]()
@@ -54,12 +54,12 @@ func TestCustomTagName_InstanceOverridesGlobal(t *testing.T) {
 	resetTagNameForTesting()
 	resetValidatorCreatedForTesting()
 
-	// Set global to "validate"
-	SetTagName("validate")
+	// Set global to "custom_validate"
+	SetTagName("custom_validate")
 
 	type Data struct {
-		// Has both validate and custom tags with different constraints
-		Value string `json:"value" validate:"required" custom:"min=5"`
+		// Has both custom_validate and custom tags with different constraints
+		Value string `json:"value" custom_validate:"required" custom:"min=5"`
 	}
 
 	// Create validator with custom tag name override
@@ -80,13 +80,13 @@ func TestCustomTagName_InstanceOverridesGlobal(t *testing.T) {
 	resetValidatorCreatedForTesting()
 }
 
-// TestCustomTagName_DefaultIsPedantigo verifies default tag is "pedantigo".
-func TestCustomTagName_DefaultIsPedantigo(t *testing.T) {
+// TestCustomTagName_DefaultIsValidate verifies default tag is "validate".
+func TestCustomTagName_DefaultIsValidate(t *testing.T) {
 	resetTagNameForTesting()
 	resetValidatorCreatedForTesting()
 
 	type User struct {
-		Name string `json:"name" pedantigo:"required,min=2"`
+		Name string `json:"name" validate:"required,min=2"`
 	}
 
 	v := New[User]()
@@ -142,10 +142,10 @@ func TestCustomTagName_DiveWithCustomTag(t *testing.T) {
 	resetTagNameForTesting()
 	resetValidatorCreatedForTesting()
 
-	SetTagName("validate")
+	SetTagName("custom_validate")
 
 	type EmailList struct {
-		Emails []string `json:"emails" validate:"min=1,dive,email"`
+		Emails []string `json:"emails" custom_validate:"min=1,dive,email"`
 	}
 
 	v := New[EmailList]()
@@ -169,15 +169,15 @@ func TestCustomTagName_NestedStructs(t *testing.T) {
 	resetTagNameForTesting()
 	resetValidatorCreatedForTesting()
 
-	SetTagName("validate")
+	SetTagName("custom_validate")
 
 	type Address struct {
-		City    string `json:"city" validate:"required"`
-		ZipCode string `json:"zip_code" validate:"len=5"`
+		City    string `json:"city" custom_validate:"required"`
+		ZipCode string `json:"zip_code" custom_validate:"len=5"`
 	}
 
 	type Person struct {
-		Name    string  `json:"name" validate:"required"`
+		Name    string  `json:"name" custom_validate:"required"`
 		Address Address `json:"address"`
 	}
 
@@ -203,10 +203,10 @@ func TestCustomTagName_Validate(t *testing.T) {
 	resetTagNameForTesting()
 	resetValidatorCreatedForTesting()
 
-	SetTagName("validate")
+	SetTagName("custom_validate")
 
 	type User struct {
-		Email string `json:"email" validate:"required,email"`
+		Email string `json:"email" custom_validate:"required,email"`
 	}
 
 	v := New[User]()
@@ -231,17 +231,17 @@ func TestCustomTagName_Schema(t *testing.T) {
 	resetTagNameForTesting()
 	resetValidatorCreatedForTesting()
 
-	SetTagName("validate")
+	SetTagName("custom_validate")
 
 	type Product struct {
-		Name  string `json:"name" validate:"required,min=1,max=100"`
-		Price int    `json:"price" validate:"min=0"`
+		Name  string `json:"name" custom_validate:"required,min=1,max=100"`
+		Price int    `json:"price" custom_validate:"min=0"`
 	}
 
 	v := New[Product]()
 	schema := v.Schema()
 
-	// Schema should include constraints from the "validate" tag
+	// Schema should include constraints from the "custom_validate" tag
 	require.NotNil(t, schema)
 	require.NotNil(t, schema.Properties)
 
@@ -265,14 +265,14 @@ func TestCustomTagName_UnionValidator(t *testing.T) {
 	resetTagNameForTesting()
 	resetValidatorCreatedForTesting()
 
-	SetTagName("validate")
+	SetTagName("custom_validate")
 
 	type Cat struct {
-		Name  string `json:"name" validate:"required"`
-		Lives int    `json:"lives" validate:"min=1,max=9"`
+		Name  string `json:"name" custom_validate:"required"`
+		Lives int    `json:"lives" custom_validate:"min=1,max=9"`
 	}
 	type Dog struct {
-		Name  string `json:"name" validate:"required"`
+		Name  string `json:"name" custom_validate:"required"`
 		Breed string `json:"breed"`
 	}
 
@@ -303,11 +303,11 @@ func TestCustomTagName_UnionSchema(t *testing.T) {
 	resetTagNameForTesting()
 	resetValidatorCreatedForTesting()
 
-	SetTagName("validate")
+	SetTagName("custom_validate")
 
 	type Cat struct {
-		Name  string `json:"name" validate:"required,min=2"`
-		Lives int    `json:"lives" validate:"min=1,max=9"`
+		Name  string `json:"name" custom_validate:"required,min=2"`
+		Lives int    `json:"lives" custom_validate:"min=1,max=9"`
 	}
 
 	v, err := NewUnion[any](UnionOptions{
@@ -335,11 +335,11 @@ func TestCustomTagName_SchemaOpenAPI(t *testing.T) {
 	resetTagNameForTesting()
 	resetValidatorCreatedForTesting()
 
-	SetTagName("validate")
+	SetTagName("custom_validate")
 
 	type Product struct {
-		Name  string `json:"name" validate:"required,min=1,max=100"`
-		Price int    `json:"price" validate:"min=0"`
+		Name  string `json:"name" custom_validate:"required,min=1,max=100"`
+		Price int    `json:"price" custom_validate:"min=0"`
 	}
 
 	v := New[Product]()
@@ -360,10 +360,10 @@ func TestCustomTagName_SchemaJSON(t *testing.T) {
 	resetTagNameForTesting()
 	resetValidatorCreatedForTesting()
 
-	SetTagName("validate")
+	SetTagName("custom_validate")
 
 	type User struct {
-		Email string `json:"email" validate:"required,email"`
+		Email string `json:"email" custom_validate:"required,email"`
 	}
 
 	v := New[User]()
@@ -383,12 +383,12 @@ func TestCustomTagName_MarshalWithOptions(t *testing.T) {
 	resetTagNameForTesting()
 	resetValidatorCreatedForTesting()
 
-	SetTagName("validate")
+	SetTagName("custom_validate")
 
 	type User struct {
 		ID       int    `json:"id"`
 		Name     string `json:"name"`
-		Password string `json:"password" validate:"exclude:api"`
+		Password string `json:"password" custom_validate:"exclude:api"`
 	}
 
 	v := New[User]()
@@ -409,11 +409,11 @@ func TestCustomTagName_InstanceOverride_Schema(t *testing.T) {
 	resetTagNameForTesting()
 	resetValidatorCreatedForTesting()
 
-	SetTagName("validate") // Global is "validate"
+	SetTagName("custom_validate") // Global is "custom_validate"
 
 	type Data struct {
 		// Has different constraints in different tags
-		Value string `json:"value" validate:"min=10" custom:"min=5"`
+		Value string `json:"value" custom_validate:"min=10" custom:"min=5"`
 	}
 
 	// Use instance override to "custom"
@@ -422,7 +422,7 @@ func TestCustomTagName_InstanceOverride_Schema(t *testing.T) {
 
 	valueSchema, ok := schema.Properties.Get("value")
 	require.True(t, ok)
-	// Should be min=5 from "custom" tag, not min=10 from "validate" tag
+	// Should be min=5 from "custom" tag, not min=10 from "custom_validate" tag
 	assert.Equal(t, uint64(5), *valueSchema.MinLength)
 
 	resetTagNameForTesting()

--- a/docs/advanced/custom-validators.md
+++ b/docs/advanced/custom-validators.md
@@ -157,12 +157,12 @@ package main
 import "github.com/smrutai/pedantigo"
 
 type User struct {
-    Email      string `json:"email" pedantigo:"required,email"`
-    Phone      string `json:"phone" pedantigo:"us_phone"`
+    Email      string `json:"email" validate:"required,email"`
+    Phone      string `json:"phone" validate:"us_phone"`
 }
 
 type Payment struct {
-    CardNumber string `json:"card_number" pedantigo:"required,credit_card"`
+    CardNumber string `json:"card_number" validate:"required,credit_card"`
 }
 
 func main() {
@@ -207,8 +207,8 @@ func ValidateLength(value any, param string) error {
 pedantigo.RegisterValidation("length", ValidateLength)
 
 type Product struct {
-    SKU string `json:"sku" pedantigo:"length=12"` // Exactly 12 chars
-    UPC string `json:"upc" pedantigo:"length=13"` // Exactly 13 chars
+    SKU string `json:"sku" validate:"length=12"` // Exactly 12 chars
+    UPC string `json:"upc" validate:"length=13"` // Exactly 13 chars
 }
 ```
 
@@ -263,7 +263,7 @@ Use `ValidateCtx` instead of `Validate` to pass the context:
 
 ```go
 type User struct {
-    Email string `json:"email" pedantigo:"required,email,db_unique"`
+    Email string `json:"email" validate:"required,email,db_unique"`
 }
 
 func CreateUser(ctx context.Context, data []byte) (*User, error) {
@@ -315,8 +315,8 @@ if err != nil {
 }
 
 type User struct {
-    // Instead of: `pedantigo:"required,alphanum,min=3,max=20"`
-    Username string `json:"username" pedantigo:"username"`
+    // Instead of: `validate:"required,alphanum,min=3,max=20"`
+    Username string `json:"username" validate:"username"`
 }
 ```
 
@@ -330,7 +330,7 @@ if err != nil {
 }
 
 type Theme struct {
-    Primary string `json:"primary" pedantigo:"required,color"`
+    Primary string `json:"primary" validate:"required,color"`
 }
 ```
 
@@ -347,7 +347,7 @@ Pedantigo includes built-in aliases for common patterns:
 ```go
 type Design struct {
     // Accepts any valid CSS color format
-    BackgroundColor string `json:"background" pedantigo:"iscolor"`
+    BackgroundColor string `json:"background" validate:"iscolor"`
 }
 ```
 
@@ -376,9 +376,9 @@ type Validatable interface {
 
 ```go
 type PasswordChange struct {
-    CurrentPassword string `json:"current_password" pedantigo:"required,minLength=8"`
-    NewPassword     string `json:"new_password" pedantigo:"required,minLength=8"`
-    Confirm         string `json:"confirm" pedantigo:"required,eqfield=NewPassword"`
+    CurrentPassword string `json:"current_password" validate:"required,minLength=8"`
+    NewPassword     string `json:"new_password" validate:"required,minLength=8"`
+    Confirm         string `json:"confirm" validate:"required,eqfield=NewPassword"`
 }
 
 // Implement Validatable for custom business logic
@@ -423,15 +423,15 @@ type StructLevelFunc[T any] func(obj *T) error
 
 ```go
 type Order struct {
-    Items      []OrderItem `json:"items" pedantigo:"required"`
-    TotalPrice float64     `json:"total_price" pedantigo:"required,gt=0"`
-    DiscountPercent int    `json:"discount_percent" pedantigo:"min=0,max=100"`
+    Items      []OrderItem `json:"items" validate:"required"`
+    TotalPrice float64     `json:"total_price" validate:"required,gt=0"`
+    DiscountPercent int    `json:"discount_percent" validate:"min=0,max=100"`
 }
 
 type OrderItem struct {
-    Product string  `json:"product" pedantigo:"required"`
-    Qty     int     `json:"qty" pedantigo:"required,min=1"`
-    Price   float64 `json:"price" pedantigo:"required,gt=0"`
+    Product string  `json:"product" validate:"required"`
+    Qty     int     `json:"qty" validate:"required,min=1"`
+    Price   float64 `json:"price" validate:"required,gt=0"`
 }
 
 // Register struct-level validation
@@ -542,7 +542,7 @@ Design validators to be independent and composable with other constraints:
 ```go
 // These work together
 type Username struct {
-    Name string `json:"name" pedantigo:"required,alphanumeric,minLength=3,maxLength=20,username_available"`
+    Name string `json:"name" validate:"required,alphanumeric,minLength=3,maxLength=20,username_available"`
 }
 
 // username_available checks if the username is not in the reserved list
@@ -692,11 +692,11 @@ func ValidateSlug(value any, param string) error {
 }
 
 type ThemeConfig struct {
-    Name          string `json:"name" pedantigo:"required,minLength=3,maxLength=50"`
-    Slug          string `json:"slug" pedantigo:"required,slug"`
-    PrimaryColor  string `json:"primary_color" pedantigo:"required,hex_color"`
-    SecondaryColor string `json:"secondary_color" pedantigo:"hex_color"`
-    AccentColor   string `json:"accent_color" pedantigo:"hex_color"`
+    Name          string `json:"name" validate:"required,minLength=3,maxLength=50"`
+    Slug          string `json:"slug" validate:"required,slug"`
+    PrimaryColor  string `json:"primary_color" validate:"required,hex_color"`
+    SecondaryColor string `json:"secondary_color" validate:"hex_color"`
+    AccentColor   string `json:"accent_color" validate:"hex_color"`
 }
 
 // Validate custom cross-field rules
@@ -708,10 +708,10 @@ func (t ThemeConfig) Validate() error {
 }
 
 type UserProfile struct {
-    Email      string `json:"email" pedantigo:"required,email"`
-    Phone      string `json:"phone" pedantigo:"us_phone"`
-    Theme      ThemeConfig `json:"theme" pedantigo:"required"`
-    Bio        string `json:"bio" pedantigo:"maxLength=500"`
+    Email      string `json:"email" validate:"required,email"`
+    Phone      string `json:"phone" validate:"us_phone"`
+    Theme      ThemeConfig `json:"theme" validate:"required"`
+    Bio        string `json:"bio" validate:"maxLength=500"`
 }
 
 func init() {

--- a/docs/advanced/performance.md
+++ b/docs/advanced/performance.md
@@ -33,8 +33,8 @@ The cache uses `sync.RWMutex` for thread-safe concurrent access. Type hash detec
 **Example**:
 ```go
 type User struct {
-    Email string `json:"email" pedantigo:"required,email"`
-    Age   int    `json:"age" pedantigo:"min=18"`
+    Email string `json:"email" validate:"required,email"`
+    Age   int    `json:"age" validate:"min=18"`
 }
 
 // First call: ~10ms (generates schema)
@@ -64,8 +64,8 @@ The Simple API uses `sync.Map` to cache validators per type:
 **Example**:
 ```go
 type Product struct {
-    Name  string `json:"name" pedantigo:"required,min=1"`
-    Price float64 `json:"price" pedantigo:"gt=0"`
+    Name  string `json:"name" validate:"required,min=1"`
+    Price float64 `json:"price" validate:"gt=0"`
 }
 
 // First call: ~1-2ms (creates and caches validator)
@@ -191,9 +191,9 @@ import (
 )
 
 type User struct {
-    Email string `json:"email" pedantigo:"required,email"`
-    Age   int    `json:"age" pedantigo:"min=18,max=120"`
-    Name  string `json:"name" pedantigo:"required,min=1"`
+    Email string `json:"email" validate:"required,email"`
+    Age   int    `json:"age" validate:"min=18,max=120"`
+    Name  string `json:"name" validate:"required,min=1"`
 }
 
 // Benchmark Simple API Unmarshal
@@ -409,8 +409,8 @@ import (
 )
 
 type User struct {
-    Email string `json:"email" pedantigo:"required,email"`
-    Name  string `json:"name" pedantigo:"required,min=1"`
+    Email string `json:"email" validate:"required,email"`
+    Name  string `json:"name" validate:"required,min=1"`
 }
 
 // Pre-create validator at startup (done once)
@@ -450,8 +450,8 @@ import (
 )
 
 type Item struct {
-    ID   string `json:"id" pedantigo:"required"`
-    Data string `json:"data" pedantigo:"required"`
+    ID   string `json:"id" validate:"required"`
+    Data string `json:"data" validate:"required"`
 }
 
 // Create validator once

--- a/docs/advanced/secrets.md
+++ b/docs/advanced/secrets.md
@@ -60,13 +60,13 @@ func (s *SecretStr) UnmarshalJSON(data []byte) error
 ```go
 type Config struct {
     // Database connection string (sensitive)
-    DatabaseURL SecretStr `json:"database_url" pedantigo:"required"`
+    DatabaseURL SecretStr `json:"database_url" validate:"required"`
 
     // API authentication token
-    APIToken SecretStr `json:"api_token" pedantigo:"required,min=20"`
+    APIToken SecretStr `json:"api_token" validate:"required,min=20"`
 
     // Webhook secret for signature verification
-    WebhookSecret SecretStr `json:"webhook_secret" pedantigo:"required"`
+    WebhookSecret SecretStr `json:"webhook_secret" validate:"required"`
 }
 ```
 
@@ -143,13 +143,13 @@ import (
 
 type AppConfig struct {
     // Database credentials
-    DatabaseURL SecretStr `json:"database_url" pedantigo:"required"`
+    DatabaseURL SecretStr `json:"database_url" validate:"required"`
 
     // External service API key
-    ExternalAPIKey SecretStr `json:"external_api_key" pedantigo:"required,min=20"`
+    ExternalAPIKey SecretStr `json:"external_api_key" validate:"required,min=20"`
 
     // Application name (not sensitive)
-    AppName string `json:"app_name" pedantigo:"required,min=1"`
+    AppName string `json:"app_name" validate:"required,min=1"`
 }
 
 func main() {
@@ -232,7 +232,7 @@ Since JSON cannot represent raw binary data, `SecretBytes` expects **base64-enco
 ```go
 type EncryptionConfig struct {
     // Encryption key as base64-encoded bytes
-    EncryptionKey SecretBytes `json:"encryption_key" pedantigo:"required"`
+    EncryptionKey SecretBytes `json:"encryption_key" validate:"required"`
 }
 
 // JSON must contain base64-encoded value
@@ -265,13 +265,13 @@ import (
 
 type SecurityConfig struct {
     // 32-byte AES-256 encryption key (base64-encoded in JSON)
-    EncryptionKey SecretBytes `json:"encryption_key" pedantigo:"required"`
+    EncryptionKey SecretBytes `json:"encryption_key" validate:"required"`
 
     // HMAC key for signature verification
-    HMACKey SecretBytes `json:"hmac_key" pedantigo:"required"`
+    HMACKey SecretBytes `json:"hmac_key" validate:"required"`
 
     // Security level
-    Level string `json:"level" pedantigo:"required,oneof=low medium high"`
+    Level string `json:"level" validate:"required,oneof=low medium high"`
 }
 
 func main() {
@@ -338,20 +338,20 @@ import (
 
 type ServerConfig struct {
     // Server basics
-    Host string `json:"host" pedantigo:"required"`
-    Port int    `json:"port" pedantigo:"required,min=1,max=65535"`
+    Host string `json:"host" validate:"required"`
+    Port int    `json:"port" validate:"required,min=1,max=65535"`
 
     // Secrets - string-based
-    JWTSecret  SecretStr `json:"jwt_secret" pedantigo:"required,min=32"`
-    APIKey     SecretStr `json:"api_key" pedantigo:"required"`
+    JWTSecret  SecretStr `json:"jwt_secret" validate:"required,min=32"`
+    APIKey     SecretStr `json:"api_key" validate:"required"`
 
     // Secrets - binary (base64-encoded)
-    TLSCert SecretBytes `json:"tls_cert" pedantigo:"required"`
-    TLSKey  SecretBytes `json:"tls_key" pedantigo:"required"`
+    TLSCert SecretBytes `json:"tls_cert" validate:"required"`
+    TLSKey  SecretBytes `json:"tls_key" validate:"required"`
 
     // Non-sensitive fields
-    Environment string `json:"environment" pedantigo:"required,oneof=dev staging prod"`
-    Timeout     int    `json:"timeout" pedantigo:"min=1,max=300"`
+    Environment string `json:"environment" validate:"required,oneof=dev staging prod"`
+    Timeout     int    `json:"timeout" validate:"min=1,max=300"`
 }
 
 func main() {
@@ -479,8 +479,8 @@ type Config struct {
 ```go
 // Good: Add validation constraints
 type Config struct {
-    APIKey SecretStr `json:"api_key" pedantigo:"required,min=20,max=100"`
-    Secret SecretStr `json:"secret" pedantigo:"required"`
+    APIKey SecretStr `json:"api_key" validate:"required,min=20,max=100"`
+    Secret SecretStr `json:"secret" validate:"required"`
 }
 
 // This ensures:
@@ -508,7 +508,7 @@ Both `SecretStr` and `SecretBytes` report validation errors without exposing sec
 
 ```go
 type Config struct {
-    APIKey SecretStr `json:"api_key" pedantigo:"required,min=32"`
+    APIKey SecretStr `json:"api_key" validate:"required,min=32"`
 }
 
 // If validation fails, error message won't contain the actual secret

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -70,7 +70,7 @@ Here's exactly what you'll see when validation fails:
 
 ```go
 type User struct {
-    Email string `json:"email" pedantigo:"required,email"`
+    Email string `json:"email" validate:"required,email"`
 }
 
 _, err := pedantigo.Unmarshal[User]([]byte(`{"email": "not-valid"}`))
@@ -82,8 +82,8 @@ fmt.Println(err)
 
 ```go
 type User struct {
-    Email string `json:"email" pedantigo:"required,email"`
-    Age   int    `json:"age" pedantigo:"min=18"`
+    Email string `json:"email" validate:"required,email"`
+    Age   int    `json:"age" validate:"min=18"`
 }
 
 _, err := pedantigo.Unmarshal[User]([]byte(`{"email": "bad", "age": 5}`))
@@ -200,9 +200,9 @@ if err != nil {
 
 ```go
 type User struct {
-    Email    string `json:"email" pedantigo:"required,email"`
-    Age      int    `json:"age" pedantigo:"required,min=18,max=120"`
-    Username string `json:"username" pedantigo:"required,min=3,max=20"`
+    Email    string `json:"email" validate:"required,email"`
+    Age      int    `json:"age" validate:"required,min=18,max=120"`
+    Username string `json:"username" validate:"required,min=3,max=20"`
 }
 
 user, err := pedantigo.Unmarshal[User](jsonData)
@@ -293,15 +293,15 @@ import (
 )
 
 type Address struct {
-    Street string `json:"street" pedantigo:"required,min=5"`
-    City   string `json:"city" pedantigo:"required,min=2"`
-    Zip    string `json:"zip" pedantigo:"required,regexp=^\\d{5}$"`
+    Street string `json:"street" validate:"required,min=5"`
+    City   string `json:"city" validate:"required,min=2"`
+    Zip    string `json:"zip" validate:"required,regexp=^\\d{5}$"`
 }
 
 type User struct {
-    Email   string  `json:"email" pedantigo:"required,email"`
-    Age     int     `json:"age" pedantigo:"required,min=18,max=120"`
-    Address Address `json:"address" pedantigo:"required"`
+    Email   string  `json:"email" validate:"required,email"`
+    Age     int     `json:"age" validate:"required,min=18,max=120"`
+    Address Address `json:"address" validate:"required"`
 }
 
 func handleValidationError(err error) {

--- a/docs/api/initialization.md
+++ b/docs/api/initialization.md
@@ -156,7 +156,7 @@ StrictMissingFields bool
 ExtraFields ExtraFieldsMode
 
 // TagName overrides the global struct tag name for this validator instance
-// Default: "" (uses global default "pedantigo")
+// Default: "" (uses global default "validate")
 TagName string
 }
 ```
@@ -176,7 +176,7 @@ pedantigo.DefaultValidatorOptions()
 // Returns: ValidatorOptions{
 //     StrictMissingFields: true,
 //     ExtraFields:         ExtraIgnore,
-//     TagName:             "",  // Uses global default "pedantigo"
+//     TagName:             "",  // Uses global default "validate"
 // }
 ```
 
@@ -192,7 +192,7 @@ Missing fields without defaults are validation errors:
 
 ```go
 type Config struct {
-Host string `json:"host" pedantigo:"required"`
+Host string `json:"host" validate:"required"`
 Port int    `json:"port"` // No default
 }
 
@@ -217,7 +217,7 @@ Missing fields without defaults are left as zero values:
 
 ```go
 type Config struct {
-Host string `json:"host" pedantigo:"required"`
+Host string `json:"host" validate:"required"`
 Port int    `json:"port"` // Zero value: 0
 }
 
@@ -243,7 +243,7 @@ Understanding how Go's `json:",omitempty"` marshaling tag interacts with Pedanti
 
 | Struct Tags                     | In JSON Schema `required` | Unmarshal Behavior               |
 |---------------------------------|---------------------------|----------------------------------|
-| `pedantigo:"required"`          | Yes                       | Error if field missing from JSON |
+| `validate:"required"`          | Yes                       | Error if field missing from JSON |
 | `json:",omitempty"` only        | No                        | Zero value if missing (valid)    |
 | Both `required` + `omitempty`   | Yes                       | Error if missing (required wins) |
 | Pointer `*T` + `required`       | Yes                       | Error if missing or null         |
@@ -261,7 +261,7 @@ Understanding how Go's `json:",omitempty"` marshaling tag interacts with Pedanti
 ```go
 type Config struct {
 // Required: must be in JSON, appears in schema required array
-Host string `json:"host" pedantigo:"required"`
+Host string `json:"host" validate:"required"`
 
 // Optional with omitempty: omitted from output if zero, NOT in required array
 Port int `json:"port,omitempty"`
@@ -270,7 +270,7 @@ Port int `json:"port,omitempty"`
 Timeout *int `json:"timeout,omitempty"`
 
 // Required + omitempty: must be in JSON input, omitted from output if zero
-Name string `json:"name,omitempty" pedantigo:"required"`
+Name string `json:"name,omitempty" validate:"required"`
 }
 ```
 
@@ -287,14 +287,14 @@ the pedantigo struct tag itself.
 
 ```go
 type SearchRequest struct {
-ActorID   string `pedantigo:"omitempty,max=64,required_with=ActorType"`
-ActorType string `pedantigo:"omitempty,oneof=user agent system,required_with=ActorID"`
+ActorID   string `validate:"omitempty,max=64,required_with=ActorType"`
+ActorType string `validate:"omitempty,oneof=user agent system,required_with=ActorID"`
 }
 ```
 
 **Semantics:**
 
-When a field is tagged with `pedantigo:"omitempty,..."` and its value is the **zero value** for its type (empty string,
+When a field is tagged with `validate:"omitempty,..."` and its value is the **zero value** for its type (empty string,
 `0`, `false`, nil pointer, etc.):
 
 - Regular constraints (`min`, `max`, `oneof`, `email`, `url`, etc.) are **skipped** — the field is treated as
@@ -309,8 +309,8 @@ When the field has a non-zero value, all constraints run normally.
 ```go
 type Actor struct {
 // Both are optional. If one is provided, the other must be too.
-ActorID   string `pedantigo:"omitempty,max=64,required_with=ActorType"`
-ActorType string `pedantigo:"omitempty,oneof=user agent system,required_with=ActorID"`
+ActorID   string `validate:"omitempty,max=64,required_with=ActorType"`
+ActorType string `validate:"omitempty,oneof=user agent system,required_with=ActorID"`
 }
 ```
 
@@ -327,13 +327,13 @@ ActorType string `pedantigo:"omitempty,oneof=user agent system,required_with=Act
 | Tag                     | Where it appears     | Effect                                                                      |
 |-------------------------|----------------------|-----------------------------------------------------------------------------|
 | `json:",omitempty"`     | JSON struct tag      | Controls marshaling output: omits the field from JSON if its value is zero  |
-| `pedantigo:"omitempty"` | Pedantigo constraint | Controls validation: skips regular constraints when the field value is zero |
+| `validate:"omitempty"` | Pedantigo constraint | Controls validation: skips regular constraints when the field value is zero |
 
 Both can be combined:
 
 ```go
 // Omitted from JSON output when zero AND skips validation when zero
-Region string `json:"region,omitempty" pedantigo:"omitempty,oneof=us-east-1 us-west-2 eu-west-1"`
+Region string `json:"region,omitempty" validate:"omitempty,oneof=us-east-1 us-west-2 eu-west-1"`
 ```
 
 ---
@@ -416,7 +416,7 @@ Unknown JSON fields are captured and stored in a designated `map[string]any` fie
 type User struct {
 Name   string         `json:"name"`
 Email  string         `json:"email"`
-Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+Extras map[string]any `json:"-" validate:"extra_fields"`
 }
 
 jsonData := []byte(`{
@@ -440,7 +440,7 @@ fmt.Println(user.Extras["phone"]) // Output: 555-1234
 
 1. **Struct must have an extra_fields tagged field:**
    ```go
-   Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+   Extras map[string]any `json:"-" validate:"extra_fields"`
    ```
 
 2. **The field type must be `map[string]any`** (or `map[string]interface{}`)
@@ -455,13 +455,13 @@ extras at that level:
 ```go
 type Address struct {
 City   string         `json:"city"`
-Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+Extras map[string]any `json:"-" validate:"extra_fields"`
 }
 
 type User struct {
 Name    string         `json:"name"`
 Address Address        `json:"address"`
-Extras  map[string]any `json:"-" pedantigo:"extra_fields"`
+Extras  map[string]any `json:"-" validate:"extra_fields"`
 }
 
 jsonData := []byte(`{
@@ -507,9 +507,9 @@ fields for:
 
 ```go
 type UserV1 struct {
-Name   string         `json:"name" pedantigo:"required"`
-Email  string         `json:"email" pedantigo:"required,email"`
-Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+Name   string         `json:"name" validate:"required"`
+Email  string         `json:"email" validate:"required,email"`
+Extras map[string]any `json:"-" validate:"extra_fields"`
 }
 
 // Accept requests from V2 clients that include "profile_picture", "preferences", etc.
@@ -540,9 +540,9 @@ When using LLMs with structured output (JSON mode), models may include unexpecte
 
 ```go
 type LLMResponse struct {
-Answer     string         `json:"answer" pedantigo:"required"`
+Answer     string         `json:"answer" validate:"required"`
 Confidence float64        `json:"confidence"`
-Extras     map[string]any `json:"-" pedantigo:"extra_fields"`
+Extras     map[string]any `json:"-" validate:"extra_fields"`
 }
 
 validator := pedantigo.New[LLMResponse](pedantigo.ValidatorOptions{
@@ -576,7 +576,7 @@ metrics.RecordExtraFields(modelName, promptID, response.Extras)
 
 Override the struct tag name for a specific validator instance.
 
-**Default**: Uses global tag name (`"pedantigo"` or set via `SetTagName()`)
+**Default**: Uses global tag name (`"validate"` by default, or whatever was set via `SetTagName()`)
 
 | Value        | Behavior                          |
 |--------------|-----------------------------------|
@@ -678,9 +678,9 @@ import (
 )
 
 type CreateUserRequest struct {
-	Username string `json:"username" pedantigo:"required,min=3,max=20"`
-	Email    string `json:"email" pedantigo:"required,email"`
-	Password string `json:"password" pedantigo:"required,min=8"`
+	Username string `json:"username" validate:"required,min=3,max=20"`
+	Email    string `json:"email" validate:"required,email"`
+	Password string `json:"password" validate:"required,min=8"`
 }
 
 // API validator: strict about extra fields, requires all fields
@@ -709,13 +709,13 @@ func handleCreateUser(jsonData []byte) (*CreateUserRequest, error) {
 ```go
 type AppConfig struct {
 Database struct {
-Host     string `json:"host" pedantigo:"required"`
-Port     int    `json:"port" pedantigo:"default=5432"`
-Username string `json:"username" pedantigo:"required"`
-Password string `json:"password" pedantigo:"required"`
+Host     string `json:"host" validate:"required"`
+Port     int    `json:"port" validate:"default=5432"`
+Username string `json:"username" validate:"required"`
+Password string `json:"password" validate:"required"`
 } `json:"database"`
 Server struct {
-Addr string `json:"addr" pedantigo:"default=0.0.0.0:8080"`
+Addr string `json:"addr" validate:"default=0.0.0.0:8080"`
 } `json:"server"`
 }
 
@@ -732,10 +732,10 @@ ExtraFields:         pedantigo.ExtraIgnore,
 
 ```go
 type UserV2 struct {
-ID       string `json:"id" pedantigo:"required,uuid"`
-Username string `json:"username" pedantigo:"required"`
-Email    string `json:"email" pedantigo:"required,email"`
-Status   string `json:"status" pedantigo:"default=active"`
+ID       string `json:"id" validate:"required,uuid"`
+Username string `json:"username" validate:"required"`
+Email    string `json:"email" validate:"required,email"`
+Status   string `json:"status" validate:"default=active"`
 }
 
 // Migration validator: accept both old and new client requests

--- a/docs/api/initialization.md
+++ b/docs/api/initialization.md
@@ -6,6 +6,10 @@ sidebar_position: 0
 
 Complete reference for all Pedantigo initialization methods and configuration options.
 
+:::note v2: default `TagName` changed
+The default struct tag (and `TagName`/`SetTagName` default, described below) changed from `pedantigo` to `validate` in v2. See the [v1 to v2 migration guide](../migration/v1-to-v2) if you're upgrading.
+:::
+
 ## Quick Comparison {#quick-comparison}
 
 | API             | Use Case             | Customizable       | Link                  |

--- a/docs/api/simple-api.md
+++ b/docs/api/simple-api.md
@@ -41,9 +41,9 @@ Unmarshals JSON bytes into a struct of type T with automatic validation.
 **Example**:
 ```go
 type User struct {
-    Name  string `json:"name" pedantigo:"required"`
-    Email string `json:"email" pedantigo:"email"`
-    Age   int    `json:"age" pedantigo:"min=18"`
+    Name  string `json:"name" validate:"required"`
+    Email string `json:"email" validate:"email"`
+    Age   int    `json:"age" validate:"min=18"`
 }
 
 data := []byte(`{"name":"Alice","email":"alice@example.com","age":25}`)
@@ -82,8 +82,8 @@ Validates a struct that already exists in memory (not from JSON).
 **Example**:
 ```go
 type Config struct {
-    Host string `pedantigo:"required"`
-    Port int    `pedantigo:"min=1,max=65535"`
+    Host string `validate:"required"`
+    Port int    `validate:"min=1,max=65535"`
 }
 
 config := &Config{
@@ -119,8 +119,8 @@ Accepts multiple input formats and creates a validated struct:
 **Example - From JSON**:
 ```go
 type User struct {
-    Email string `json:"email" pedantigo:"email"`
-    Age   int    `json:"age" pedantigo:"min=18"`
+    Email string `json:"email" validate:"email"`
+    Age   int    `json:"age" validate:"min=18"`
 }
 
 user, err := pedantigo.NewModel[User]([]byte(`{"email":"bob@example.com","age":30}`))
@@ -157,8 +157,8 @@ Returns the JSON Schema as a `*jsonschema.Schema` object (from `invopop/jsonsche
 **Example**:
 ```go
 type Product struct {
-    Name  string `json:"name" pedantigo:"required,min=1"`
-    Price float64 `json:"price" pedantigo:"min=0"`
+    Name  string `json:"name" validate:"required,min=1"`
+    Price float64 `json:"price" validate:"min=0"`
 }
 
 schema := pedantigo.Schema[Product]()
@@ -216,7 +216,7 @@ Returns a JSON Schema compatible with OpenAPI 3.1 specifications:
 **Example**:
 ```go
 type APIResponse struct {
-    Success bool      `json:"success" pedantigo:"required"`
+    Success bool      `json:"success" validate:"required"`
     Data    *User     `json:"data"` // nullable
     Message string    `json:"message"`
 }
@@ -359,9 +359,9 @@ opts := pedantigo.DefaultMarshalOptions() // Create default options
 **Example - Context-based Exclusion**:
 ```go
 type User struct {
-    Name     string `json:"name" pedantigo:"required"`
-    Email    string `json:"email" pedantigo:"email"`
-    Password string `json:"password" pedantigo:"exclude:api"`
+    Name     string `json:"name" validate:"required"`
+    Email    string `json:"email" validate:"email"`
+    Password string `json:"password" validate:"exclude:api"`
 }
 
 user := &User{
@@ -380,9 +380,9 @@ jsonData, err := pedantigo.MarshalWithOptions(user, opts)
 **Example - With OmitZero**:
 ```go
 type Config struct {
-    Host     string `json:"host" pedantigo:"required"`
-    Port     int    `json:"port" pedantigo:"omitzero"`
-    Timeout  int    `json:"timeout" pedantigo:"omitzero"`
+    Host     string `json:"host" validate:"required"`
+    Port     int    `json:"port" validate:"omitzero"`
+    Timeout  int    `json:"timeout" validate:"omitzero"`
 }
 
 config := &Config{
@@ -465,25 +465,25 @@ Use the `pedantigo` struct tag (not `validate`) for Simple API:
 ```go
 type User struct {
     // Field name for JSON serialization
-    Name string `json:"name" pedantigo:"required,min=1,max=100"`
+    Name string `json:"name" validate:"required,min=1,max=100"`
 
     // Email validation
-    Email string `json:"email" pedantigo:"required,email"`
+    Email string `json:"email" validate:"required,email"`
 
     // Numeric constraints
-    Age int `json:"age" pedantigo:"min=0,max=150"`
+    Age int `json:"age" validate:"min=0,max=150"`
 
     // Pattern matching
-    Phone string `json:"phone" pedantigo:"pattern=^\\d{10}$"`
+    Phone string `json:"phone" validate:"pattern=^\\d{10}$"`
 
     // Field exclusion by context
-    Password string `json:"password" pedantigo:"exclude:api,exclude:logs"`
+    Password string `json:"password" validate:"exclude:api,exclude:logs"`
 
     // Zero value omission
-    Score int `json:"score" pedantigo:"omitzero"`
+    Score int `json:"score" validate:"omitzero"`
 
     // Default values
-    Status string `json:"status" pedantigo:"default=pending"`
+    Status string `json:"status" validate:"default=pending"`
 }
 ```
 

--- a/docs/api/validator.md
+++ b/docs/api/validator.md
@@ -30,8 +30,8 @@ The Validator API creates reusable validator instances with custom configuration
 import "github.com/SmrutAI/pedantigo"
 
 type User struct {
-    Email string `pedantigo:"required,email"`
-    Age   int    `pedantigo:"required,min=18"`
+    Email string `validate:"required,email"`
+    Age   int    `validate:"required,min=18"`
 }
 
 // Create validator with default options
@@ -453,9 +453,9 @@ import (
 )
 
 type User struct {
-    Email    string `pedantigo:"required,email"`
-    Age      int    `pedantigo:"required,min=18,max=120"`
-    Username string `pedantigo:"required,min=3,max=50"`
+    Email    string `validate:"required,email"`
+    Age      int    `validate:"required,min=18,max=120"`
+    Username string `validate:"required,min=3,max=50"`
 }
 
 func main() {

--- a/docs/concepts/constraints.md
+++ b/docs/concepts/constraints.md
@@ -13,14 +13,14 @@ Constraints are specified using the `pedantigo` struct tag. Multiple constraints
 ```go
 type User struct {
     // Basic constraint
-    Name     string `json:"name" pedantigo:"required"`
+    Name     string `json:"name" validate:"required"`
 
     // Multiple constraints
-    Email    string `json:"email" pedantigo:"required,email"`
+    Email    string `json:"email" validate:"required,email"`
 
     // Constraints with parameters
-    Age      int    `json:"age" pedantigo:"required,min=18,max=120"`
-    Username string `json:"username" pedantigo:"minLength=3,maxLength=20,pattern=^[a-z0-9_]+$"`
+    Age      int    `json:"age" validate:"required,min=18,max=120"`
+    Username string `json:"username" validate:"minLength=3,maxLength=20,pattern=^[a-z0-9_]+$"`
 }
 ```
 
@@ -32,19 +32,19 @@ The fundamental constraints applicable across multiple types:
 
 | Constraint | Parameter | Description | Example |
 |-----------|-----------|-------------|---------|
-| `required` | None | Field must be present in the input | `pedantigo:"required"` |
-| `omitempty` | None | Skip regular constraints when the field is at its zero value; cross-field constraints still run | `pedantigo:"omitempty,email"` |
-| `min` | Numeric | Minimum value (numeric) or length (string) | `pedantigo:"min=18"` |
-| `max` | Numeric | Maximum value (numeric) or length (string) | `pedantigo:"max=100"` |
-| `gt` | Numeric | Greater than | `pedantigo:"gt=0"` |
-| `gte` | Numeric | Greater than or equal | `pedantigo:"gte=1"` |
-| `lt` | Numeric | Less than | `pedantigo:"lt=100"` |
-| `lte` | Numeric | Less than or equal | `pedantigo:"lte=99"` |
-| `eq` | Value | Must equal exact value | `pedantigo:"eq=active"` |
-| `ne` | Value | Must NOT equal value | `pedantigo:"ne=banned"` |
-| `oneof` | Space-separated values | Must be one of specified values | `pedantigo:"oneof=red green blue"` |
-| `oneofci` | Space-separated values | Case-insensitive oneof | `pedantigo:"oneofci=admin user guest"` |
-| `len` | Numeric | Exact length (strings/arrays) | `pedantigo:"len=32"` |
+| `required` | None | Field must be present in the input | `validate:"required"` |
+| `omitempty` | None | Skip regular constraints when the field is at its zero value; cross-field constraints still run | `validate:"omitempty,email"` |
+| `min` | Numeric | Minimum value (numeric) or length (string) | `validate:"min=18"` |
+| `max` | Numeric | Maximum value (numeric) or length (string) | `validate:"max=100"` |
+| `gt` | Numeric | Greater than | `validate:"gt=0"` |
+| `gte` | Numeric | Greater than or equal | `validate:"gte=1"` |
+| `lt` | Numeric | Less than | `validate:"lt=100"` |
+| `lte` | Numeric | Less than or equal | `validate:"lte=99"` |
+| `eq` | Value | Must equal exact value | `validate:"eq=active"` |
+| `ne` | Value | Must NOT equal value | `validate:"ne=banned"` |
+| `oneof` | Space-separated values | Must be one of specified values | `validate:"oneof=red green blue"` |
+| `oneofci` | Space-separated values | Case-insensitive oneof | `validate:"oneofci=admin user guest"` |
+| `len` | Numeric | Exact length (strings/arrays) | `validate:"len=32"` |
 
 See the [Numeric Constraints](/docs/constraints/numeric) page for detailed numeric range examples.
 See [omitempty as a Validation Constraint](/docs/api/initialization#pedantigo-omitempty) for the full `omitempty` reference including cross-field interaction.
@@ -55,20 +55,20 @@ Specialized constraints for string validation:
 
 | Constraint | Parameter | Description | Example |
 |-----------|-----------|-------------|---------|
-| `minLength` | Numeric | Minimum string length | `pedantigo:"minLength=3"` |
-| `maxLength` | Numeric | Maximum string length | `pedantigo:"maxLength=100"` |
-| `alpha` | None | Only alphabetic characters | `pedantigo:"alpha"` |
-| `alphanum` | None | Only letters and numbers | `pedantigo:"alphanum"` |
-| `ascii` | None | Only ASCII characters | `pedantigo:"ascii"` |
-| `lowercase` | None | Must be lowercase | `pedantigo:"lowercase"` |
-| `uppercase` | None | Must be uppercase | `pedantigo:"uppercase"` |
-| `contains` | String | Must contain substring | `pedantigo:"contains=test"` |
-| `excludes` | String | Must not contain substring | `pedantigo:"excludes=forbidden"` |
-| `startswith` | String | Must start with prefix | `pedantigo:"startswith=https://"` |
-| `endswith` | String | Must end with suffix | `pedantigo:"endswith=.com"` |
-| `strip_whitespace` | None | No leading/trailing whitespace | `pedantigo:"strip_whitespace"` |
-| `pattern` | Regex | Match regex pattern | `pedantigo:"pattern=^[a-z]+$"` |
-| `regexp` | Regex | Match regex pattern (alias) | `pedantigo:"regexp=^[a-z]+$"` |
+| `minLength` | Numeric | Minimum string length | `validate:"minLength=3"` |
+| `maxLength` | Numeric | Maximum string length | `validate:"maxLength=100"` |
+| `alpha` | None | Only alphabetic characters | `validate:"alpha"` |
+| `alphanum` | None | Only letters and numbers | `validate:"alphanum"` |
+| `ascii` | None | Only ASCII characters | `validate:"ascii"` |
+| `lowercase` | None | Must be lowercase | `validate:"lowercase"` |
+| `uppercase` | None | Must be uppercase | `validate:"uppercase"` |
+| `contains` | String | Must contain substring | `validate:"contains=test"` |
+| `excludes` | String | Must not contain substring | `validate:"excludes=forbidden"` |
+| `startswith` | String | Must start with prefix | `validate:"startswith=https://"` |
+| `endswith` | String | Must end with suffix | `validate:"endswith=.com"` |
+| `strip_whitespace` | None | No leading/trailing whitespace | `validate:"strip_whitespace"` |
+| `pattern` | Regex | Match regex pattern | `validate:"pattern=^[a-z]+$"` |
+| `regexp` | Regex | Match regex pattern (alias) | `validate:"regexp=^[a-z]+$"` |
 
 See the [String Constraints](/docs/constraints/string) page for detailed string validation examples.
 
@@ -78,12 +78,12 @@ Additional constraints specific to numeric types:
 
 | Constraint | Parameter | Description | Example |
 |-----------|-----------|-------------|---------|
-| `positive` | None | Must be greater than zero | `pedantigo:"positive"` |
-| `negative` | None | Must be less than zero | `pedantigo:"negative"` |
-| `multiple_of` | Numeric | Must be divisible by value | `pedantigo:"multiple_of=5"` |
-| `max_digits` | Numeric | Maximum total digits | `pedantigo:"max_digits=8"` |
-| `decimal_places` | Numeric | Maximum decimal places | `pedantigo:"decimal_places=2"` |
-| `disallow_inf_nan` | None | Reject infinity and NaN values | `pedantigo:"disallow_inf_nan"` |
+| `positive` | None | Must be greater than zero | `validate:"positive"` |
+| `negative` | None | Must be less than zero | `validate:"negative"` |
+| `multiple_of` | Numeric | Must be divisible by value | `validate:"multiple_of=5"` |
+| `max_digits` | Numeric | Maximum total digits | `validate:"max_digits=8"` |
+| `decimal_places` | Numeric | Maximum decimal places | `validate:"decimal_places=2"` |
+| `disallow_inf_nan` | None | Reject infinity and NaN values | `validate:"disallow_inf_nan"` |
 
 See the [Numeric Constraints](/docs/constraints/numeric) page for detailed numeric validation examples.
 
@@ -93,30 +93,30 @@ Constraints for common data formats:
 
 | Constraint | Description | Example |
 |-----------|-------------|---------|
-| `email` | Valid email address format | `pedantigo:"email"` |
-| `url` | Valid URL format | `pedantigo:"url"` |
-| `uri` | Valid URI format | `pedantigo:"uri"` |
-| `uuid` | Valid UUID (any version) | `pedantigo:"uuid"` |
-| `ipv4` | Valid IPv4 address | `pedantigo:"ipv4"` |
-| `ipv6` | Valid IPv6 address | `pedantigo:"ipv6"` |
-| `ip` | Valid IPv4 or IPv6 address | `pedantigo:"ip"` |
-| `cidr` | Valid CIDR notation (IPv4 or IPv6) | `pedantigo:"cidr"` |
-| `cidrv4` | Valid IPv4 CIDR notation | `pedantigo:"cidrv4"` |
-| `cidrv6` | Valid IPv6 CIDR notation | `pedantigo:"cidrv6"` |
-| `mac` | Valid MAC address | `pedantigo:"mac"` |
-| `hostname` | Valid hostname | `pedantigo:"hostname"` |
-| `hostname_rfc1123` | Valid RFC 1123 hostname | `pedantigo:"hostname_rfc1123"` |
-| `fqdn` | Valid fully qualified domain name | `pedantigo:"fqdn"` |
-| `port` | Valid port number (0-65535) | `pedantigo:"port"` |
-| `tcp_addr` | Valid TCP address | `pedantigo:"tcp_addr"` |
-| `udp_addr` | Valid UDP address | `pedantigo:"udp_addr"` |
-| `tcp4_addr` | Valid TCP4 address | `pedantigo:"tcp4_addr"` |
-| `json` | Valid JSON string | `pedantigo:"json"` |
-| `jwt` | Valid JSON Web Token | `pedantigo:"jwt"` |
-| `semver` | Valid semantic version | `pedantigo:"semver"` |
-| `cron` | Valid cron expression | `pedantigo:"cron"` |
-| `datetime` | Matches Go time layout | `pedantigo:"datetime=2006-01-02"` |
-| `ulid` | Valid ULID format | `pedantigo:"ulid"` |
+| `email` | Valid email address format | `validate:"email"` |
+| `url` | Valid URL format | `validate:"url"` |
+| `uri` | Valid URI format | `validate:"uri"` |
+| `uuid` | Valid UUID (any version) | `validate:"uuid"` |
+| `ipv4` | Valid IPv4 address | `validate:"ipv4"` |
+| `ipv6` | Valid IPv6 address | `validate:"ipv6"` |
+| `ip` | Valid IPv4 or IPv6 address | `validate:"ip"` |
+| `cidr` | Valid CIDR notation (IPv4 or IPv6) | `validate:"cidr"` |
+| `cidrv4` | Valid IPv4 CIDR notation | `validate:"cidrv4"` |
+| `cidrv6` | Valid IPv6 CIDR notation | `validate:"cidrv6"` |
+| `mac` | Valid MAC address | `validate:"mac"` |
+| `hostname` | Valid hostname | `validate:"hostname"` |
+| `hostname_rfc1123` | Valid RFC 1123 hostname | `validate:"hostname_rfc1123"` |
+| `fqdn` | Valid fully qualified domain name | `validate:"fqdn"` |
+| `port` | Valid port number (0-65535) | `validate:"port"` |
+| `tcp_addr` | Valid TCP address | `validate:"tcp_addr"` |
+| `udp_addr` | Valid UDP address | `validate:"udp_addr"` |
+| `tcp4_addr` | Valid TCP4 address | `validate:"tcp4_addr"` |
+| `json` | Valid JSON string | `validate:"json"` |
+| `jwt` | Valid JSON Web Token | `validate:"jwt"` |
+| `semver` | Valid semantic version | `validate:"semver"` |
+| `cron` | Valid cron expression | `validate:"cron"` |
+| `datetime` | Matches Go time layout | `validate:"datetime=2006-01-02"` |
+| `ulid` | Valid ULID format | `validate:"ulid"` |
 
 See the [Format Constraints](/docs/constraints/format) page for detailed format validation examples.
 
@@ -126,9 +126,9 @@ Constraints for encoded data formats:
 
 | Constraint | Description | Example |
 |-----------|-------------|---------|
-| `base64` | Valid base64 encoding | `pedantigo:"base64"` |
-| `base64url` | Valid URL-safe base64 encoding | `pedantigo:"base64url"` |
-| `base64rawurl` | Valid raw URL-safe base64 encoding | `pedantigo:"base64rawurl"` |
+| `base64` | Valid base64 encoding | `validate:"base64"` |
+| `base64url` | Valid URL-safe base64 encoding | `validate:"base64url"` |
+| `base64rawurl` | Valid raw URL-safe base64 encoding | `validate:"base64rawurl"` |
 
 ### Hash Constraints
 
@@ -136,11 +136,11 @@ Constraints for validating hash format strings:
 
 | Constraint | Description | Example |
 |-----------|-------------|---------|
-| `md5` | Valid MD5 hash format | `pedantigo:"md5"` |
-| `sha256` | Valid SHA256 hash format | `pedantigo:"sha256"` |
-| `sha384` | Valid SHA384 hash format | `pedantigo:"sha384"` |
-| `sha512` | Valid SHA512 hash format | `pedantigo:"sha512"` |
-| `mongodb` | Valid MongoDB ObjectID format | `pedantigo:"mongodb"` |
+| `md5` | Valid MD5 hash format | `validate:"md5"` |
+| `sha256` | Valid SHA256 hash format | `validate:"sha256"` |
+| `sha384` | Valid SHA384 hash format | `validate:"sha384"` |
+| `sha512` | Valid SHA512 hash format | `validate:"sha512"` |
+| `mongodb` | Valid MongoDB ObjectID format | `validate:"mongodb"` |
 
 ### Finance Constraints
 
@@ -148,11 +148,11 @@ Constraints for financial and cryptocurrency identifiers:
 
 | Constraint | Description | Example |
 |-----------|-------------|---------|
-| `credit_card` | Valid credit card number (Luhn check) | `pedantigo:"credit_card"` |
-| `luhn_checksum` | Valid Luhn checksum | `pedantigo:"luhn_checksum"` |
-| `btc_addr` | Valid Bitcoin address (P2PKH/P2SH) | `pedantigo:"btc_addr"` |
-| `btc_addr_bech32` | Valid Bitcoin bech32 address | `pedantigo:"btc_addr_bech32"` |
-| `eth_addr` | Valid Ethereum address | `pedantigo:"eth_addr"` |
+| `credit_card` | Valid credit card number (Luhn check) | `validate:"credit_card"` |
+| `luhn_checksum` | Valid Luhn checksum | `validate:"luhn_checksum"` |
+| `btc_addr` | Valid Bitcoin address (P2PKH/P2SH) | `validate:"btc_addr"` |
+| `btc_addr_bech32` | Valid Bitcoin bech32 address | `validate:"btc_addr_bech32"` |
+| `eth_addr` | Valid Ethereum address | `validate:"eth_addr"` |
 
 ### Identity Constraints
 
@@ -160,13 +160,13 @@ Constraints for identification numbers and codes:
 
 | Constraint | Description | Example |
 |-----------|-------------|---------|
-| `isbn` | Valid ISBN (10 or 13) | `pedantigo:"isbn"` |
-| `isbn10` | Valid ISBN-10 | `pedantigo:"isbn10"` |
-| `isbn13` | Valid ISBN-13 | `pedantigo:"isbn13"` |
-| `issn` | Valid ISSN format | `pedantigo:"issn"` |
-| `ssn` | Valid US Social Security Number | `pedantigo:"ssn"` |
-| `ein` | Valid US Employer Identification Number | `pedantigo:"ein"` |
-| `e164` | Valid E.164 phone number format | `pedantigo:"e164"` |
+| `isbn` | Valid ISBN (10 or 13) | `validate:"isbn"` |
+| `isbn10` | Valid ISBN-10 | `validate:"isbn10"` |
+| `isbn13` | Valid ISBN-13 | `validate:"isbn13"` |
+| `issn` | Valid ISSN format | `validate:"issn"` |
+| `ssn` | Valid US Social Security Number | `validate:"ssn"` |
+| `ein` | Valid US Employer Identification Number | `validate:"ein"` |
+| `e164` | Valid E.164 phone number format | `validate:"e164"` |
 
 ### Geographic Constraints
 
@@ -174,8 +174,8 @@ Constraints for geographic coordinates:
 
 | Constraint | Description | Example |
 |-----------|-------------|---------|
-| `latitude` | Valid latitude (-90 to 90) | `pedantigo:"latitude"` |
-| `longitude` | Valid longitude (-180 to 180) | `pedantigo:"longitude"` |
+| `latitude` | Valid latitude (-90 to 90) | `validate:"latitude"` |
+| `longitude` | Valid longitude (-180 to 180) | `validate:"longitude"` |
 
 ### Color Constraints
 
@@ -183,11 +183,11 @@ Constraints for color format validation:
 
 | Constraint | Description | Example |
 |-----------|-------------|---------|
-| `hexcolor` | Valid hex color (#RGB or #RRGGBB) | `pedantigo:"hexcolor"` |
-| `rgb` | Valid RGB color | `pedantigo:"rgb"` |
-| `rgba` | Valid RGBA color | `pedantigo:"rgba"` |
-| `hsl` | Valid HSL color | `pedantigo:"hsl"` |
-| `hsla` | Valid HSLA color | `pedantigo:"hsla"` |
+| `hexcolor` | Valid hex color (#RGB or #RRGGBB) | `validate:"hexcolor"` |
+| `rgb` | Valid RGB color | `validate:"rgb"` |
+| `rgba` | Valid RGBA color | `validate:"rgba"` |
+| `hsl` | Valid HSL color | `validate:"hsl"` |
+| `hsla` | Valid HSLA color | `validate:"hsla"` |
 
 ### ISO Constraints
 
@@ -195,17 +195,17 @@ Constraints for ISO standard codes and formats:
 
 | Constraint | Parameter | Description | Example |
 |-----------|-----------|-------------|---------|
-| `iso3166_alpha2` | None | ISO 3166-1 alpha-2 country code | `pedantigo:"iso3166_alpha2"` |
-| `iso3166_alpha2_eu` | None | ISO 3166-1 alpha-2 EU country code | `pedantigo:"iso3166_alpha2_eu"` |
-| `iso3166_alpha3` | None | ISO 3166-1 alpha-3 country code | `pedantigo:"iso3166_alpha3"` |
-| `iso3166_alpha3_eu` | None | ISO 3166-1 alpha-3 EU country code | `pedantigo:"iso3166_alpha3_eu"` |
-| `iso3166_numeric` | None | ISO 3166-1 numeric country code | `pedantigo:"iso3166_numeric"` |
-| `iso3166_2` | None | ISO 3166-2 subdivision code | `pedantigo:"iso3166_2"` |
-| `iso4217` | None | ISO 4217 currency code | `pedantigo:"iso4217"` |
-| `iso4217_numeric` | None | ISO 4217 numeric currency code | `pedantigo:"iso4217_numeric"` |
-| `postcode` | Country code | Postal code for specific country | `pedantigo:"postcode=US"` |
-| `postcode_iso3166_alpha2` | Country code | Postal code (alias for `postcode`) | `pedantigo:"postcode_iso3166_alpha2=GB"` |
-| `bcp47` | None | BCP 47 language tag | `pedantigo:"bcp47"` |
+| `iso3166_alpha2` | None | ISO 3166-1 alpha-2 country code | `validate:"iso3166_alpha2"` |
+| `iso3166_alpha2_eu` | None | ISO 3166-1 alpha-2 EU country code | `validate:"iso3166_alpha2_eu"` |
+| `iso3166_alpha3` | None | ISO 3166-1 alpha-3 country code | `validate:"iso3166_alpha3"` |
+| `iso3166_alpha3_eu` | None | ISO 3166-1 alpha-3 EU country code | `validate:"iso3166_alpha3_eu"` |
+| `iso3166_numeric` | None | ISO 3166-1 numeric country code | `validate:"iso3166_numeric"` |
+| `iso3166_2` | None | ISO 3166-2 subdivision code | `validate:"iso3166_2"` |
+| `iso4217` | None | ISO 4217 currency code | `validate:"iso4217"` |
+| `iso4217_numeric` | None | ISO 4217 numeric currency code | `validate:"iso4217_numeric"` |
+| `postcode` | Country code | Postal code for specific country | `validate:"postcode=US"` |
+| `postcode_iso3166_alpha2` | Country code | Postal code (alias for `postcode`) | `validate:"postcode_iso3166_alpha2=GB"` |
+| `bcp47` | None | BCP 47 language tag | `validate:"bcp47"` |
 
 ### Filesystem Constraints
 
@@ -213,10 +213,10 @@ Constraints for file and directory path validation:
 
 | Constraint | Description | Example |
 |-----------|-------------|---------|
-| `filepath` | Valid file path | `pedantigo:"filepath"` |
-| `dirpath` | Valid directory path | `pedantigo:"dirpath"` |
-| `file` | Path must point to existing file | `pedantigo:"file"` |
-| `dir` | Path must point to existing directory | `pedantigo:"dir"` |
+| `filepath` | Valid file path | `validate:"filepath"` |
+| `dirpath` | Valid directory path | `validate:"dirpath"` |
+| `file` | Path must point to existing file | `validate:"file"` |
+| `dir` | Path must point to existing directory | `validate:"dir"` |
 
 ### Collection Constraints
 
@@ -224,9 +224,9 @@ Constraints for arrays, slices, and maps:
 
 | Constraint | Parameter | Description | Example |
 |-----------|-----------|-------------|---------|
-| `minItems` | Numeric | Minimum number of items | `pedantigo:"minItems=1"` |
-| `maxItems` | Numeric | Maximum number of items | `pedantigo:"maxItems=100"` |
-| `unique` | None | All items must be unique | `pedantigo:"unique"` |
+| `minItems` | Numeric | Minimum number of items | `validate:"minItems=1"` |
+| `maxItems` | Numeric | Maximum number of items | `validate:"maxItems=100"` |
+| `unique` | None | All items must be unique | `validate:"unique"` |
 
 See the [Collection Constraints](/docs/constraints/collection) page for detailed collection validation examples.
 
@@ -234,13 +234,13 @@ See the [Collection Constraints](/docs/constraints/collection) page for detailed
 
 | Constraint | Parameter | Description | Example |
 |-----------|-----------|-------------|---------|
-| `default` | Value | Default value if field missing | `pedantigo:"default=active"` |
+| `default` | Value | Default value if field missing | `validate:"default=active"` |
 
 For slice fields, use **space-separated values** (consistent with `oneof` syntax):
 
 ```go
-Scopes []string `json:"scopes" pedantigo:"default=read write"`
-Tags   []string `json:"tags" pedantigo:"default=general"`
+Scopes []string `json:"scopes" validate:"default=read write"`
+Tags   []string `json:"tags" validate:"default=general"`
 ```
 
 ## Complete Example
@@ -257,32 +257,32 @@ import (
 
 type UserProfile struct {
     // Core constraints
-    ID       string `json:"id" pedantigo:"required,uuid"`
-    Email    string `json:"email" pedantigo:"required,email"`
-    Username string `json:"username" pedantigo:"required,minLength=3,maxLength=20,alphanum"`
+    ID       string `json:"id" validate:"required,uuid"`
+    Email    string `json:"email" validate:"required,email"`
+    Username string `json:"username" validate:"required,minLength=3,maxLength=20,alphanum"`
 
     // String constraints
-    Bio      string `json:"bio,omitempty" pedantigo:"maxLength=500"`
-    Website  string `json:"website,omitempty" pedantigo:"url"`
+    Bio      string `json:"bio,omitempty" validate:"maxLength=500"`
+    Website  string `json:"website,omitempty" validate:"url"`
 
     // Numeric constraints
-    Age      int    `json:"age" pedantigo:"min=13,max=120"`
-    Rating   float64 `json:"rating,omitempty" pedantigo:"min=0,max=5,decimal_places=1"`
+    Age      int    `json:"age" validate:"min=13,max=120"`
+    Rating   float64 `json:"rating,omitempty" validate:"min=0,max=5,decimal_places=1"`
 
     // Geographic constraints
-    Latitude  float64 `json:"latitude,omitempty" pedantigo:"latitude"`
-    Longitude float64 `json:"longitude,omitempty" pedantigo:"longitude"`
+    Latitude  float64 `json:"latitude,omitempty" validate:"latitude"`
+    Longitude float64 `json:"longitude,omitempty" validate:"longitude"`
 
     // ISO constraints
-    Country  string `json:"country,omitempty" pedantigo:"iso3166_alpha2"`
-    Currency string `json:"currency,omitempty" pedantigo:"iso4217"`
+    Country  string `json:"country,omitempty" validate:"iso3166_alpha2"`
+    Currency string `json:"currency,omitempty" validate:"iso4217"`
 
     // Collection constraints
-    Tags     []string `json:"tags,omitempty" pedantigo:"maxItems=10,unique"`
-    Roles    []string `json:"roles" pedantigo:"minItems=1,oneof=admin moderator user"`
+    Tags     []string `json:"tags,omitempty" validate:"maxItems=10,unique"`
+    Roles    []string `json:"roles" validate:"minItems=1,oneof=admin moderator user"`
 
     // Enum constraint
-    Status   string `json:"status" pedantigo:"required,oneof=active inactive suspended"`
+    Status   string `json:"status" validate:"required,oneof=active inactive suspended"`
 }
 
 func main() {

--- a/docs/concepts/cross-field.md
+++ b/docs/concepts/cross-field.md
@@ -18,9 +18,9 @@ Use `eqfield` to require a field to equal another field, and `nefield` to requir
 
 ```go
 type RegisterRequest struct {
-    Email            string `json:"email" pedantigo:"required,email"`
-    Password         string `json:"password" pedantigo:"required,minLength=8"`
-    PasswordConfirm  string `json:"password_confirm" pedantigo:"required,eqfield=Password"`
+    Email            string `json:"email" validate:"required,email"`
+    Password         string `json:"password" validate:"required,minLength=8"`
+    PasswordConfirm  string `json:"password_confirm" validate:"required,eqfield=Password"`
 }
 
 // Valid - passwords match
@@ -50,8 +50,8 @@ if err != nil {
 
 ```go
 type UpdateUsername struct {
-    CurrentUsername string `json:"current_username" pedantigo:"required"`
-    NewUsername     string `json:"new_username" pedantigo:"required,nefield=CurrentUsername"`
+    CurrentUsername string `json:"current_username" validate:"required"`
+    NewUsername     string `json:"new_username" validate:"required,nefield=CurrentUsername"`
 }
 
 // Valid - new username differs from current
@@ -78,9 +78,9 @@ Use `gtfield`, `gtefield`, `ltfield`, and `ltefield` to compare numeric or strin
 
 ```go
 type EventBooking struct {
-    EventName  string    `json:"event_name" pedantigo:"required"`
-    StartDate  time.Time `json:"start_date" pedantigo:"required"`
-    EndDate    time.Time `json:"end_date" pedantigo:"required,gtfield=StartDate"`
+    EventName  string    `json:"event_name" validate:"required"`
+    StartDate  time.Time `json:"start_date" validate:"required"`
+    EndDate    time.Time `json:"end_date" validate:"required,gtfield=StartDate"`
 }
 
 // Valid - end date is after start date
@@ -105,10 +105,10 @@ _, err := pedantigo.Unmarshal[EventBooking](badData)
 
 ```go
 type ProductListing struct {
-    Name       string  `json:"name" pedantigo:"required"`
-    MinPrice   float64 `json:"min_price" pedantigo:"required,gt=0"`
-    MaxPrice   float64 `json:"max_price" pedantigo:"required,gtfield=MinPrice"`
-    DiscountAt float64 `json:"discount_at" pedantigo:"gtefield=MinPrice,ltefield=MaxPrice"`
+    Name       string  `json:"name" validate:"required"`
+    MinPrice   float64 `json:"min_price" validate:"required,gt=0"`
+    MaxPrice   float64 `json:"max_price" validate:"required,gtfield=MinPrice"`
+    DiscountAt float64 `json:"discount_at" validate:"gtefield=MinPrice,ltefield=MaxPrice"`
 }
 
 // Valid - prices are properly ordered
@@ -143,10 +143,10 @@ Use `required_if` to require a field when another field has a specific value. Us
 
 ```go
 type ShippingForm struct {
-    Country      string `json:"country" pedantigo:"required,oneof=US CA MX"`
-    State        string `json:"state" pedantigo:"required_if=Country US"`
-    Province     string `json:"province" pedantigo:"required_if=Country CA"`
-    PostalCode   string `json:"postal_code" pedantigo:"required"`
+    Country      string `json:"country" validate:"required,oneof=US CA MX"`
+    State        string `json:"state" validate:"required_if=Country US"`
+    Province     string `json:"province" validate:"required_if=Country CA"`
+    PostalCode   string `json:"postal_code" validate:"required"`
 }
 
 // Valid - Country is US and State is provided
@@ -179,9 +179,9 @@ _, err := pedantigo.Unmarshal[ShippingForm](badData)
 ```go
 type SubscriptionForm struct {
     HasBusiness      bool   `json:"has_business"`
-    BusinessName     string `json:"business_name" pedantigo:"required_if=HasBusiness true"`
-    BusinessLicense  string `json:"business_license" pedantigo:"required_if=HasBusiness true"`
-    PersonalName     string `json:"personal_name" pedantigo:"required_unless=HasBusiness true"`
+    BusinessName     string `json:"business_name" validate:"required_if=HasBusiness true"`
+    BusinessLicense  string `json:"business_license" validate:"required_if=HasBusiness true"`
+    PersonalName     string `json:"personal_name" validate:"required_unless=HasBusiness true"`
 }
 
 // Valid - business fields provided
@@ -215,11 +215,11 @@ Use `required_with` to require a field only if another field is present (non-zer
 
 ```go
 type PaymentInfo struct {
-    PaymentMethod string `json:"payment_method" pedantigo:"required,oneof=credit_card bank_transfer"`
-    CardNumber    string `json:"card_number" pedantigo:"required_if=PaymentMethod credit_card"`
-    CVV           string `json:"cvv" pedantigo:"required_with=CardNumber"`
-    BankAccount   string `json:"bank_account" pedantigo:"required_if=PaymentMethod bank_transfer"`
-    RoutingNumber string `json:"routing_number" pedantigo:"required_with=BankAccount"`
+    PaymentMethod string `json:"payment_method" validate:"required,oneof=credit_card bank_transfer"`
+    CardNumber    string `json:"card_number" validate:"required_if=PaymentMethod credit_card"`
+    CVV           string `json:"cvv" validate:"required_with=CardNumber"`
+    BankAccount   string `json:"bank_account" validate:"required_if=PaymentMethod bank_transfer"`
+    RoutingNumber string `json:"routing_number" validate:"required_with=BankAccount"`
 }
 
 // Valid - credit card with CVV
@@ -252,7 +252,7 @@ _, err := pedantigo.Unmarshal[PaymentInfo](badData)
 ```go
 type TwoFactorSettings struct {
     TwoFactorEnabled bool   `json:"two_factor_enabled"`
-    BackupCode      string `json:"backup_code" pedantigo:"required_without=TwoFactorEnabled"`
+    BackupCode      string `json:"backup_code" validate:"required_without=TwoFactorEnabled"`
 }
 
 // Valid - backup code provided when 2FA is disabled
@@ -286,8 +286,8 @@ Use `skip_unless` to conditionally apply validation only when a condition is met
 
 ```go
 type Order struct {
-    Type     string `json:"type" pedantigo:"required,oneof=standard express"`
-    Priority int    `json:"priority" pedantigo:"skip_unless=Type express,required,min=1,max=10"`
+    Type     string `json:"type" validate:"required,oneof=standard express"`
+    Priority int    `json:"priority" validate:"skip_unless=Type express,required,min=1,max=10"`
 }
 
 // Priority is only validated when Type is "express"
@@ -342,8 +342,8 @@ Use `excluded_if` to forbid a field when another field has a specific value. The
 ```go
 type DiscountCode struct {
     AccountID   string `json:"account_id"`
-    DiscountPercent int    `json:"discount_percent" pedantigo:"excluded_if=AccountID premium"`
-    Notes       string `json:"notes" pedantigo:"excluded_unless=AccountID enterprise"`
+    DiscountPercent int    `json:"discount_percent" validate:"excluded_if=AccountID premium"`
+    Notes       string `json:"notes" validate:"excluded_unless=AccountID enterprise"`
 }
 
 // Valid - premium account (no discount percent allowed)
@@ -376,8 +376,8 @@ Use `excluded_with` to forbid a field when another field is present. Use `exclud
 
 ```go
 type AuthRequest struct {
-    APIKey string `json:"api_key" pedantigo:"minLength=20,maxLength=50"`
-    Token  string `json:"token" pedantigo:"excluded_with=APIKey,minLength=20,maxLength=100"`
+    APIKey string `json:"api_key" validate:"minLength=20,maxLength=50"`
+    Token  string `json:"token" validate:"excluded_with=APIKey,minLength=20,maxLength=100"`
 }
 
 // Valid - uses API key only
@@ -425,9 +425,9 @@ Since Pedantigo calls your `Validate()` method automatically, calling `pedantigo
 
 ```go
 type FlightBooking struct {
-    Origin      string    `json:"origin" pedantigo:"required"`
-    Destination string    `json:"destination" pedantigo:"required,nefield=Origin"`
-    DepartDate  time.Time `json:"depart_date" pedantigo:"required"`
+    Origin      string    `json:"origin" validate:"required"`
+    Destination string    `json:"destination" validate:"required,nefield=Origin"`
+    DepartDate  time.Time `json:"depart_date" validate:"required"`
     ReturnDate  time.Time `json:"return_date"`
     IsRoundTrip bool      `json:"is_round_trip"`
 }
@@ -470,9 +470,9 @@ If your `Validate()` method returns an error, it will be collected in the `Valid
 
 ```go
 type Account struct {
-    Username string `json:"username" pedantigo:"required,minLength=3,maxLength=20"`
-    Email    string `json:"email" pedantigo:"required,email"`
-    Age      int    `json:"age" pedantigo:"min=18"`
+    Username string `json:"username" validate:"required,minLength=3,maxLength=20"`
+    Email    string `json:"email" validate:"required,email"`
+    Age      int    `json:"age" validate:"min=18"`
 }
 
 func (a Account) Validate() error {
@@ -513,30 +513,30 @@ import (
 
 type EventRegistration struct {
     // Basic fields
-    Email           string    `json:"email" pedantigo:"required,email"`
-    FullName        string    `json:"full_name" pedantigo:"required,minLength=2"`
+    Email           string    `json:"email" validate:"required,email"`
+    FullName        string    `json:"full_name" validate:"required,minLength=2"`
 
     // Field comparisons
-    Password        string    `json:"password" pedantigo:"required,minLength=12"`
-    PasswordConfirm string    `json:"password_confirm" pedantigo:"required,eqfield=Password"`
+    Password        string    `json:"password" validate:"required,minLength=12"`
+    PasswordConfirm string    `json:"password_confirm" validate:"required,eqfield=Password"`
 
     // Conditional requirements
     IsStudent       bool      `json:"is_student"`
-    StudentID       string    `json:"student_id" pedantigo:"required_if=IsStudent true,len=10"`
-    Company         string    `json:"company" pedantigo:"required_unless=IsStudent true"`
+    StudentID       string    `json:"student_id" validate:"required_if=IsStudent true,len=10"`
+    Company         string    `json:"company" validate:"required_unless=IsStudent true"`
 
     // Date ranges
-    StartDate       time.Time `json:"start_date" pedantigo:"required"`
-    EndDate         time.Time `json:"end_date" pedantigo:"required,gtfield=StartDate"`
+    StartDate       time.Time `json:"start_date" validate:"required"`
+    EndDate         time.Time `json:"end_date" validate:"required,gtfield=StartDate"`
 
     // Mutually exclusive
-    PhoneNumber     string    `json:"phone_number" pedantigo:"excluded_with=TelegramHandle,len=10"`
-    TelegramHandle  string    `json:"telegram_handle" pedantigo:"excluded_with=PhoneNumber"`
+    PhoneNumber     string    `json:"phone_number" validate:"excluded_with=TelegramHandle,len=10"`
+    TelegramHandle  string    `json:"telegram_handle" validate:"excluded_with=PhoneNumber"`
 
     // Optional dependencies
     HasAccommodation bool      `json:"has_accommodation"`
-    HotelName        string    `json:"hotel_name" pedantigo:"required_with=HasAccommodation"`
-    CheckinDate      time.Time `json:"checkin_date" pedantigo:"required_with=HasAccommodation"`
+    HotelName        string    `json:"hotel_name" validate:"required_with=HasAccommodation"`
+    CheckinDate      time.Time `json:"checkin_date" validate:"required_with=HasAccommodation"`
 }
 
 // Validate implements custom cross-field validation logic

--- a/docs/concepts/schema.md
+++ b/docs/concepts/schema.md
@@ -20,9 +20,9 @@ import (
 )
 
 type User struct {
-    Name  string `json:"name" pedantigo:"required,min=2,max=50"`
-    Email string `json:"email" pedantigo:"required,email"`
-    Age   int    `json:"age" pedantigo:"min=18,max=120"`
+    Name  string `json:"name" validate:"required,min=2,max=50"`
+    Email string `json:"email" validate:"required,email"`
+    Age   int    `json:"age" validate:"min=18,max=120"`
 }
 
 func main() {
@@ -80,12 +80,12 @@ Use `SchemaLLM()` / `SchemaJSONLLM()` for LLM integrations. Both `$schema` and `
 
 ```go
 type Address struct {
-    Street string `json:"street" pedantigo:"required"`
-    City   string `json:"city" pedantigo:"required"`
+    Street string `json:"street" validate:"required"`
+    City   string `json:"city" validate:"required"`
 }
 
 type User struct {
-    Name    string  `json:"name" pedantigo:"required"`
+    Name    string  `json:"name" validate:"required"`
     Address Address `json:"address"`
 }
 
@@ -194,7 +194,7 @@ func SchemaOpenAPI[T any]() *jsonschema.Schema
 **Example**:
 ```go
 type APIResponse struct {
-    Success bool   `json:"success" pedantigo:"required"`
+    Success bool   `json:"success" validate:"required"`
     Data    *User  `json:"data"`        // nullable
     Message string `json:"message,omitempty"`
 }
@@ -249,8 +249,8 @@ func SchemaLLM[T any]() *jsonschema.Schema
 **Example**:
 ```go
 type ToolArgs struct {
-    Query  string `json:"query" pedantigo:"required,min=1,description=Search query"`
-    Limit  int    `json:"limit" pedantigo:"min=1,max=100,description=Max results"`
+    Query  string `json:"query" validate:"required,min=1,description=Search query"`
+    Limit  int    `json:"limit" validate:"min=1,max=100,description=Max results"`
 }
 
 // Get schema for LLM function calling
@@ -274,8 +274,8 @@ func SchemaJSONLLM[T any]() ([]byte, error)
 **Example**:
 ```go
 type FunctionResponse struct {
-    Thought string `json:"thought" pedantigo:"required,description=Chain of thought"`
-    Action  string `json:"action" pedantigo:"required,oneof=search respond,description=Action to take"`
+    Thought string `json:"thought" validate:"required,description=Chain of thought"`
+    Action  string `json:"action" validate:"required,oneof=search respond,description=Action to take"`
 }
 
 schemaBytes, err := pedantigo.SchemaJSONLLM[FunctionResponse]()
@@ -353,37 +353,37 @@ Pedantigo validation constraints are automatically mapped to JSON Schema keyword
 
 | Constraint | JSON Schema | Description | Example |
 |-----------|-----------|-------------|---------|
-| `required` | `required: [...]` | Field is required | `pedantigo:"required"` |
-| `min` | `minimum` / `minLength` | Numeric min or string length | `pedantigo:"min=18"` |
-| `max` | `maximum` / `maxLength` | Numeric max or string length | `pedantigo:"max=100"` |
-| `gt` | `exclusiveMinimum` | Greater than (numeric) | `pedantigo:"gt=0"` |
-| `gte` | `minimum` | Greater than or equal | `pedantigo:"gte=1"` |
-| `lt` | `exclusiveMaximum` | Less than (numeric) | `pedantigo:"lt=100"` |
-| `lte` | `maximum` | Less than or equal | `pedantigo:"lte=99"` |
-| `len` | `minLength=X, maxLength=X` | Exact string/array length | `pedantigo:"len=32"` |
-| `oneof` / `enum` | `enum: [...]` | Must be one of values | `pedantigo:"oneof=draft published archived"` |
+| `required` | `required: [...]` | Field is required | `validate:"required"` |
+| `min` | `minimum` / `minLength` | Numeric min or string length | `validate:"min=18"` |
+| `max` | `maximum` / `maxLength` | Numeric max or string length | `validate:"max=100"` |
+| `gt` | `exclusiveMinimum` | Greater than (numeric) | `validate:"gt=0"` |
+| `gte` | `minimum` | Greater than or equal | `validate:"gte=1"` |
+| `lt` | `exclusiveMaximum` | Less than (numeric) | `validate:"lt=100"` |
+| `lte` | `maximum` | Less than or equal | `validate:"lte=99"` |
+| `len` | `minLength=X, maxLength=X` | Exact string/array length | `validate:"len=32"` |
+| `oneof` / `enum` | `enum: [...]` | Must be one of values | `validate:"oneof=draft published archived"` |
 
 ### String Constraints
 
 | Constraint | JSON Schema | Example |
 |-----------|-----------|---------|
-| `minLength` | `minLength` | `pedantigo:"minLength=3"` |
-| `maxLength` | `maxLength` | `pedantigo:"maxLength=255"` |
-| `pattern` | `pattern` | `pedantigo:"pattern=^[a-z]+$"` |
-| `email` | `format: "email"` | `pedantigo:"email"` |
-| `url` | `format: "uri"` | `pedantigo:"url"` |
-| `uuid` | `format: "uuid"` | `pedantigo:"uuid"` |
-| `lowercase` | `pattern` (enforced) | `pedantigo:"lowercase"` |
-| `uppercase` | `pattern` (enforced) | `pedantigo:"uppercase"` |
+| `minLength` | `minLength` | `validate:"minLength=3"` |
+| `maxLength` | `maxLength` | `validate:"maxLength=255"` |
+| `pattern` | `pattern` | `validate:"pattern=^[a-z]+$"` |
+| `email` | `format: "email"` | `validate:"email"` |
+| `url` | `format: "uri"` | `validate:"url"` |
+| `uuid` | `format: "uuid"` | `validate:"uuid"` |
+| `lowercase` | `pattern` (enforced) | `validate:"lowercase"` |
+| `uppercase` | `pattern` (enforced) | `validate:"uppercase"` |
 
 ### Numeric Constraints
 
 | Constraint | JSON Schema | Example |
 |-----------|-----------|---------|
-| `positive` | `exclusiveMinimum: 0` | `pedantigo:"positive"` |
-| `negative` | `exclusiveMaximum: 0` | `pedantigo:"negative"` |
-| `multiple_of` | `multipleOf` | `pedantigo:"multiple_of=5"` |
-| `decimal_places` | Custom format | `pedantigo:"decimal_places=2"` |
+| `positive` | `exclusiveMinimum: 0` | `validate:"positive"` |
+| `negative` | `exclusiveMaximum: 0` | `validate:"negative"` |
+| `multiple_of` | `multipleOf` | `validate:"multiple_of=5"` |
+| `decimal_places` | Custom format | `validate:"decimal_places=2"` |
 
 ### Format Constraints
 
@@ -391,22 +391,22 @@ All standard formats map to `format` keyword:
 
 | Constraint | Format Value | Example |
 |-----------|-------------|---------|
-| `email` | `"email"` | `pedantigo:"email"` |
-| `ipv4` | `"ipv4"` | `pedantigo:"ipv4"` |
-| `ipv6` | `"ipv6"` | `pedantigo:"ipv6"` |
-| `hostname` | `"hostname"` | `pedantigo:"hostname"` |
-| `fqdn` | `"fqdn"` | `pedantigo:"fqdn"` |
-| `port` | `"port"` | `pedantigo:"port"` |
-| `jwt` | `"jwt"` | `pedantigo:"jwt"` |
-| `semver` | `"semver"` | `pedantigo:"semver"` |
+| `email` | `"email"` | `validate:"email"` |
+| `ipv4` | `"ipv4"` | `validate:"ipv4"` |
+| `ipv6` | `"ipv6"` | `validate:"ipv6"` |
+| `hostname` | `"hostname"` | `validate:"hostname"` |
+| `fqdn` | `"fqdn"` | `validate:"fqdn"` |
+| `port` | `"port"` | `validate:"port"` |
+| `jwt` | `"jwt"` | `validate:"jwt"` |
+| `semver` | `"semver"` | `validate:"semver"` |
 
 ### Collection Constraints
 
 | Constraint | JSON Schema | Example |
 |-----------|-----------|---------|
-| `minItems` | `minItems` | `pedantigo:"minItems=1"` |
-| `maxItems` | `maxItems` | `pedantigo:"maxItems=100"` |
-| `unique` | `uniqueItems: true` | `pedantigo:"unique"` |
+| `minItems` | `minItems` | `validate:"minItems=1"` |
+| `maxItems` | `maxItems` | `validate:"maxItems=100"` |
+| `unique` | `uniqueItems: true` | `validate:"unique"` |
 
 ## Schema Metadata Tags
 
@@ -418,7 +418,7 @@ Set the schema title for a field:
 
 ```go
 type User struct {
-    Name string `json:"name" pedantigo:"required,title=Full Name"`
+    Name string `json:"name" validate:"required,title=Full Name"`
 }
 ```
 
@@ -441,8 +441,8 @@ Add field description (appears in API docs, forms, etc.):
 
 ```go
 type User struct {
-    Email string `json:"email" pedantigo:"required,email,description=User's primary email address"`
-    Age   int    `json:"age" pedantigo:"min=0,max=150,description=Age in years (0-150)"`
+    Email string `json:"email" validate:"required,email,description=User's primary email address"`
+    Age   int    `json:"age" validate:"min=0,max=150,description=Age in years (0-150)"`
 }
 ```
 
@@ -471,9 +471,9 @@ Provide example values in the schema using a JSON array literal:
 
 ```go
 type Product struct {
-    Name     string  `json:"name" pedantigo:"required,examples=[\"Laptop\",\"Monitor\",\"Keyboard\"]"`
-    Price    float64 `json:"price" pedantigo:"gt=0,examples=[99.99,299.99,1999.99]"`
-    Discount float64 `json:"discount" pedantigo:"min=0,max=100,examples=[10,25,50]"`
+    Name     string  `json:"name" validate:"required,examples=[\"Laptop\",\"Monitor\",\"Keyboard\"]"`
+    Price    float64 `json:"price" validate:"gt=0,examples=[99.99,299.99,1999.99]"`
+    Discount float64 `json:"discount" validate:"min=0,max=100,examples=[10,25,50]"`
 }
 ```
 
@@ -481,16 +481,16 @@ type Product struct {
 
 ```go
 // String examples
-Name string `pedantigo:"examples=[\"Alice\",\"Bob\"]"`
+Name string `validate:"examples=[\"Alice\",\"Bob\"]"`
 
 // Integer examples
-Age int `pedantigo:"examples=[18,25,42]"`
+Age int `validate:"examples=[18,25,42]"`
 
 // Float examples
-Score float64 `pedantigo:"examples=[0.5,0.75,1.0]"`
+Score float64 `validate:"examples=[0.5,0.75,1.0]"`
 
 // Nested array examples (e.g. for [][]int fields)
-Pairs [][]int `pedantigo:"examples=[[0,1],[2,3],[4,5]]"`
+Pairs [][]int `validate:"examples=[[0,1],[2,3],[4,5]]"`
 ```
 
 :::note Breaking change
@@ -521,10 +521,10 @@ Mark fields as deprecated:
 
 ```go
 type User struct {
-    Name     string `json:"name" pedantigo:"required"`
-    OldEmail string `json:"old_email" pedantigo:"email,deprecated"`
+    Name     string `json:"name" validate:"required"`
+    OldEmail string `json:"old_email" validate:"email,deprecated"`
     // or with message:
-    LegacyID int `json:"legacy_id" pedantigo:"deprecated=Use 'id' field instead"`
+    LegacyID int `json:"legacy_id" validate:"deprecated=Use 'id' field instead"`
 }
 ```
 
@@ -560,28 +560,28 @@ import (
 
 type CreateUserRequest struct {
     // Basic fields with constraints
-    Name string `json:"name" pedantigo:"required,min=2,max=100,title=Full Name,description=User's full name"`
+    Name string `json:"name" validate:"required,min=2,max=100,title=Full Name,description=User's full name"`
 
     // Email with format constraint
-    Email string `json:"email" pedantigo:"required,email,description=Primary email address"`
+    Email string `json:"email" validate:"required,email,description=Primary email address"`
 
     // Numeric with range
-    Age int `json:"age" pedantigo:"min=18,max=120,description=Age in years"`
+    Age int `json:"age" validate:"min=18,max=120,description=Age in years"`
 
     // Enum field
-    Status string `json:"status" pedantigo:"required,oneof=active inactive suspended,description=Account status"`
+    Status string `json:"status" validate:"required,oneof=active inactive suspended,description=Account status"`
 
     // Optional field with description
-    Bio string `json:"bio,omitempty" pedantigo:"maxLength=500,description=User biography"`
+    Bio string `json:"bio,omitempty" validate:"maxLength=500,description=User biography"`
 
     // Tags/roles array
-    Tags []string `json:"tags,omitempty" pedantigo:"maxItems=10,unique,description=User interests and skills"`
+    Tags []string `json:"tags,omitempty" validate:"maxItems=10,unique,description=User interests and skills"`
 
     // URL field
-    Website string `json:"website,omitempty" pedantigo:"url,description=User's personal website"`
+    Website string `json:"website,omitempty" validate:"url,description=User's personal website"`
 
     // Deprecated field
-    OldUsername string `json:"old_username,omitempty" pedantigo:"deprecated=Use 'name' instead"`
+    OldUsername string `json:"old_username,omitempty" validate:"deprecated=Use 'name' instead"`
 }
 
 func main() {
@@ -659,14 +659,14 @@ Nested structs are automatically inlined in the default schema mode:
 
 ```go
 type Address struct {
-    Street string `json:"street" pedantigo:"required"`
-    City   string `json:"city" pedantigo:"required"`
-    Zip    string `json:"zip" pedantigo:"required,len=5"`
+    Street string `json:"street" validate:"required"`
+    City   string `json:"city" validate:"required"`
+    Zip    string `json:"zip" validate:"required,len=5"`
 }
 
 type User struct {
-    Name    string  `json:"name" pedantigo:"required"`
-    Address Address `json:"address" pedantigo:"required"`
+    Name    string  `json:"name" validate:"required"`
+    Address Address `json:"address" validate:"required"`
 }
 
 schema := pedantigo.Schema[User]()
@@ -706,9 +706,9 @@ Generate OpenAPI/Swagger specs automatically:
 
 ```go
 type CreatePostRequest struct {
-    Title   string `json:"title" pedantigo:"required,min=5,max=200,description=Post title"`
-    Content string `json:"content" pedantigo:"required,min=10,max=10000,description=Post content"`
-    Tags    []string `json:"tags" pedantigo:"maxItems=10,unique,description=Post tags"`
+    Title   string `json:"title" validate:"required,min=5,max=200,description=Post title"`
+    Content string `json:"content" validate:"required,min=10,max=10000,description=Post content"`
+    Tags    []string `json:"tags" validate:"maxItems=10,unique,description=Post tags"`
 }
 
 schema := pedantigo.SchemaJSONOpenAPI[CreatePostRequest]()
@@ -737,10 +737,10 @@ Provide schema to LLMs for structured generation:
 
 ```go
 type TranslationResult struct {
-    Original string `json:"original" pedantigo:"required,description=Original text"`
-    Translated string `json:"translated" pedantigo:"required,description=Translated text"`
-    Language string `json:"language" pedantigo:"required,oneof=en es fr de,description=Target language code"`
-    Confidence float64 `json:"confidence" pedantigo:"min=0,max=1,description=Translation confidence 0-1"`
+    Original string `json:"original" validate:"required,description=Original text"`
+    Translated string `json:"translated" validate:"required,description=Translated text"`
+    Language string `json:"language" validate:"required,oneof=en es fr de,description=Target language code"`
+    Confidence float64 `json:"confidence" validate:"min=0,max=1,description=Translation confidence 0-1"`
 }
 
 schema := pedantigo.SchemaJSON[TranslationResult]()

--- a/docs/concepts/streaming.md
+++ b/docs/concepts/streaming.md
@@ -29,8 +29,8 @@ The simplest way to create a stream parser:
 
 ```go
 type Message struct {
-    Role    string `json:"role" pedantigo:"required,enum=user|assistant|system"`
-    Content string `json:"content" pedantigo:"required,min=1"`
+    Role    string `json:"role" validate:"required,enum=user|assistant|system"`
+    Content string `json:"content" validate:"required,min=1"`
 }
 
 // Create a parser for streaming messages
@@ -53,8 +53,8 @@ If you need discriminated union support or other advanced features, create a cus
 
 ```go
 type MessageContent struct {
-    Type string `json:"type" pedantigo:"required,enum=text|image|video"`
-    Body string `json:"body" pedantigo:"required"`
+    Type string `json:"type" validate:"required,enum=text|image|video"`
+    Body string `json:"body" validate:"required"`
 }
 
 // Create a validator with custom configuration
@@ -164,8 +164,8 @@ import (
 )
 
 type ChatCompletion struct {
-    Content string `json:"content" pedantigo:"required"`
-    Model   string `json:"model" pedantigo:"required"`
+    Content string `json:"content" validate:"required"`
+    Model   string `json:"model" validate:"required"`
 }
 
 func handleOpenAIStream(ctx context.Context, client *openai.Client) error {
@@ -232,8 +232,8 @@ import (
 )
 
 type ContentBlock struct {
-    Type string `json:"type" pedantigo:"required,enum=text|image"`
-    Text string `json:"text" pedantigo:"required,min=1"`
+    Type string `json:"type" validate:"required,enum=text|image"`
+    Text string `json:"text" validate:"required,min=1"`
 }
 
 func handleAnthropicStream(ctx context.Context, client *anthropic.Client) error {

--- a/docs/concepts/unions.md
+++ b/docs/concepts/unions.md
@@ -30,23 +30,23 @@ Each variant in your union should be a separate struct with appropriate validati
 
 ```go
 type CreditCard struct {
-    Type       string `json:"type" pedantigo:"required"`
-    CardNumber string `json:"cardNumber" pedantigo:"required,pattern=^[0-9]{16}$"`
-    CVC        string `json:"cvc" pedantigo:"required,pattern=^[0-9]{3}$"`
-    ExpiryDate string `json:"expiryDate" pedantigo:"required,pattern=^[0-9]{2}/[0-9]{2}$"`
+    Type       string `json:"type" validate:"required"`
+    CardNumber string `json:"cardNumber" validate:"required,pattern=^[0-9]{16}$"`
+    CVC        string `json:"cvc" validate:"required,pattern=^[0-9]{3}$"`
+    ExpiryDate string `json:"expiryDate" validate:"required,pattern=^[0-9]{2}/[0-9]{2}$"`
 }
 
 type BankTransfer struct {
-    Type           string `json:"type" pedantigo:"required"`
-    AccountNumber  string `json:"accountNumber" pedantigo:"required,pattern=^[0-9]{10,12}$"`
-    RoutingNumber  string `json:"routingNumber" pedantigo:"required,pattern=^[0-9]{9}$"`
-    AccountHolderName string `json:"accountHolderName" pedantigo:"required,min=2"`
+    Type           string `json:"type" validate:"required"`
+    AccountNumber  string `json:"accountNumber" validate:"required,pattern=^[0-9]{10,12}$"`
+    RoutingNumber  string `json:"routingNumber" validate:"required,pattern=^[0-9]{9}$"`
+    AccountHolderName string `json:"accountHolderName" validate:"required,min=2"`
 }
 
 type DigitalWallet struct {
-    Type     string `json:"type" pedantigo:"required"`
-    WalletID string `json:"walletId" pedantigo:"required,min=1"`
-    Provider string `json:"provider" pedantigo:"required,enum=apple_pay|google_pay|paypal"`
+    Type     string `json:"type" validate:"required"`
+    WalletID string `json:"walletId" validate:"required,min=1"`
+    Provider string `json:"provider" validate:"required,enum=apple_pay|google_pay|paypal"`
 }
 ```
 
@@ -227,10 +227,10 @@ Each variant can implement the `Validatable` interface for cross-field checks:
 
 ```go
 type CreditCard struct {
-    Type       string `json:"type" pedantigo:"required"`
-    CardNumber string `json:"cardNumber" pedantigo:"required"`
-    CVC        string `json:"cvc" pedantigo:"required"`
-    ExpiryDate string `json:"expiryDate" pedantigo:"required"`
+    Type       string `json:"type" validate:"required"`
+    CardNumber string `json:"cardNumber" validate:"required"`
+    CVC        string `json:"cvc" validate:"required"`
+    ExpiryDate string `json:"expiryDate" validate:"required"`
 }
 
 func (c CreditCard) Validate() error {
@@ -276,10 +276,10 @@ import (
 
 // Define payment method variants
 type CreditCard struct {
-    Type       string `json:"type" pedantigo:"required"`
-    CardNumber string `json:"cardNumber" pedantigo:"required,pattern=^[0-9]{16}$"`
-    CVC        string `json:"cvc" pedantigo:"required,pattern=^[0-9]{3}$"`
-    ExpiryDate string `json:"expiryDate" pedantigo:"required"`
+    Type       string `json:"type" validate:"required"`
+    CardNumber string `json:"cardNumber" validate:"required,pattern=^[0-9]{16}$"`
+    CVC        string `json:"cvc" validate:"required,pattern=^[0-9]{3}$"`
+    ExpiryDate string `json:"expiryDate" validate:"required"`
 }
 
 func (c CreditCard) Validate() error {
@@ -291,15 +291,15 @@ func (c CreditCard) Validate() error {
 }
 
 type BankTransfer struct {
-    Type           string `json:"type" pedantigo:"required"`
-    AccountNumber  string `json:"accountNumber" pedantigo:"required,pattern=^[0-9]{10,12}$"`
-    RoutingNumber  string `json:"routingNumber" pedantigo:"required,pattern=^[0-9]{9}$"`
+    Type           string `json:"type" validate:"required"`
+    AccountNumber  string `json:"accountNumber" validate:"required,pattern=^[0-9]{10,12}$"`
+    RoutingNumber  string `json:"routingNumber" validate:"required,pattern=^[0-9]{9}$"`
 }
 
 type DigitalWallet struct {
-    Type     string `json:"type" pedantigo:"required"`
-    WalletID string `json:"walletId" pedantigo:"required,min=1"`
-    Provider string `json:"provider" pedantigo:"required,enum=apple_pay|google_pay|paypal"`
+    Type     string `json:"type" validate:"required"`
+    WalletID string `json:"walletId" validate:"required,min=1"`
+    Provider string `json:"provider" validate:"required,enum=apple_pay|google_pay|paypal"`
 }
 
 func main() {
@@ -449,17 +449,17 @@ For scenarios where you don't need streaming support or JSON Schema `oneOf` gene
 
 ```go
 type TV struct {
-    Channel int `json:"channel" pedantigo:"required,min=1,max=999"`
+    Channel int `json:"channel" validate:"required,min=1,max=999"`
 }
 
 type Fan struct {
-    Speed int `json:"speed" pedantigo:"required,min=1,max=5"`
+    Speed int `json:"speed" validate:"required,min=1,max=5"`
 }
 
 type Suite struct {
-    SuiteType string `json:"suite_type" pedantigo:"required,oneof=tv fan"`
-    TV        TV     `json:"tv" pedantigo:"skip_unless=SuiteType tv"`
-    Fan       Fan    `json:"fan" pedantigo:"skip_unless=SuiteType fan"`
+    SuiteType string `json:"suite_type" validate:"required,oneof=tv fan"`
+    TV        TV     `json:"tv" validate:"skip_unless=SuiteType tv"`
+    Fan       Fan    `json:"fan" validate:"skip_unless=SuiteType fan"`
 }
 ```
 

--- a/docs/concepts/validation.md
+++ b/docs/concepts/validation.md
@@ -29,16 +29,16 @@ Validation is controlled with the `pedantigo` struct tag:
 
 ```go
 type User struct {
-    Name     string `json:"name" pedantigo:"required,min=2,max=50"`
-    Email    string `json:"email" pedantigo:"required,email"`
-    Age      int    `json:"age" pedantigo:"min=0,max=150"`
-    Status   string `json:"status" pedantigo:"required,enum=active|inactive|pending"`
-    Verified bool   `json:"verified" pedantigo:"default=false"`
+    Name     string `json:"name" validate:"required,min=2,max=50"`
+    Email    string `json:"email" validate:"required,email"`
+    Age      int    `json:"age" validate:"min=0,max=150"`
+    Status   string `json:"status" validate:"required,enum=active|inactive|pending"`
+    Verified bool   `json:"verified" validate:"default=false"`
 }
 ```
 
 **Key syntax rules:**
-- Constraints are comma-separated: `pedantigo:"constraint1,constraint2=value"`
+- Constraints are comma-separated: `validate:"constraint1,constraint2=value"`
 - Constraints with values use `=`: `min=2`, `max=50`, `default=false`
 - Enum values are pipe-separated: `enum=active|inactive|pending`
 - Multiple constraints stack: `required,email,max=100`
@@ -53,8 +53,8 @@ The Simple API uses automatic caching for best performance:
 
 ```go
 type User struct {
-    Email string `json:"email" pedantigo:"required,email"`
-    Age   int    `json:"age" pedantigo:"min=18"`
+    Email string `json:"email" validate:"required,email"`
+    Age   int    `json:"age" validate:"min=18"`
 }
 
 jsonData := []byte(`{"email":"alice@example.com","age":25}`)
@@ -142,7 +142,7 @@ Example:
 
 ```go
 type Config struct {
-    APIKey string `pedantigo:"required,min=10"`
+    APIKey string `validate:"required,min=10"`
 }
 
 // This passes (Unmarshal): JSON key is present
@@ -165,9 +165,9 @@ Each field is validated independently using constraints:
 
 ```go
 type Product struct {
-    Name  string `pedantigo:"required,max=100"`
-    Price float64 `pedantigo:"gt=0,lt=1000000"`
-    Stock int `pedantigo:"min=0,max=1000"`
+    Name  string `validate:"required,max=100"`
+    Price float64 `validate:"gt=0,lt=1000000"`
+    Stock int `validate:"min=0,max=1000"`
 }
 ```
 
@@ -179,8 +179,8 @@ For validation that involves multiple fields, implement the `Validatable` interf
 
 ```go
 type DateRange struct {
-    StartDate time.Time `json:"start_date" pedantigo:"required"`
-    EndDate   time.Time `json:"end_date" pedantigo:"required"`
+    StartDate time.Time `json:"start_date" validate:"required"`
+    EndDate   time.Time `json:"end_date" validate:"required"`
 }
 
 func (d *DateRange) Validate() error {
@@ -206,9 +206,9 @@ Pedantigo collects all validation errors in one pass, not stopping at the first 
 
 ```go
 type User struct {
-    Email string `json:"email" pedantigo:"required,email,max=100"`
-    Age   int    `json:"age" pedantigo:"required,min=18,max=120"`
-    Name  string `json:"name" pedantigo:"required,min=2"`
+    Email string `json:"email" validate:"required,email,max=100"`
+    Age   int    `json:"age" validate:"required,min=18,max=120"`
+    Name  string `json:"name" validate:"required,min=2"`
 }
 
 jsonData := []byte(`{
@@ -241,10 +241,10 @@ Example:
 
 ```go
 type User struct {
-    FirstName string `json:"first_name" pedantigo:"required"`
-    LastName  string `json:"last_name" pedantigo:"required"`
-    Email     string `json:"email" pedantigo:"required,email"`
-    Age       int    `json:"age" pedantigo:"min=0,max=150"`
+    FirstName string `json:"first_name" validate:"required"`
+    LastName  string `json:"last_name" validate:"required"`
+    Email     string `json:"email" validate:"required,email"`
+    Age       int    `json:"age" validate:"min=0,max=150"`
 }
 
 func (u *User) Validate() error {
@@ -265,9 +265,9 @@ Fields can have default values:
 
 ```go
 type Config struct {
-    Port      int    `json:"port" pedantigo:"default=8080"`
-    Debug     bool   `json:"debug" pedantigo:"default=false"`
-    Environment string `json:"env" pedantigo:"default=development"`
+    Port      int    `json:"port" validate:"default=8080"`
+    Debug     bool   `json:"debug" validate:"default=false"`
+    Environment string `json:"env" validate:"default=development"`
 }
 ```
 
@@ -275,7 +275,7 @@ For slice fields, use **space-separated values** (consistent with `oneof` syntax
 
 ```go
 type APIKeyRequest struct {
-    Scopes []string `json:"scopes" pedantigo:"default=read write,dive,oneof=read write admin"`
+    Scopes []string `json:"scopes" validate:"default=read write,dive,oneof=read write admin"`
 }
 // Missing "scopes" field → defaults to ["read", "write"]
 ```
@@ -284,8 +284,8 @@ Defaults are applied only for missing fields during `Unmarshal`. For dynamic def
 
 ```go
 type Session struct {
-    Token   string    `json:"token" pedantigo:"required,defaultFactory=generateToken"`
-    Created time.Time `json:"created" pedantigo:"defaultFactory=now"`
+    Token   string    `json:"token" validate:"required,defaultFactory=generateToken"`
+    Created time.Time `json:"created" validate:"defaultFactory=now"`
 }
 
 func generateToken() string {
@@ -305,8 +305,8 @@ The factory function is called only if the field is missing in the JSON.
 
 ```go
 type LoginRequest struct {
-    Username string `json:"username" pedantigo:"required,min=3"`
-    Password string `json:"password" pedantigo:"required,min=8"`
+    Username string `json:"username" validate:"required,min=3"`
+    Password string `json:"password" validate:"required,min=8"`
 }
 ```
 
@@ -314,7 +314,7 @@ type LoginRequest struct {
 
 ```go
 type User struct {
-    Email string `json:"email" pedantigo:"required,email"`
+    Email string `json:"email" validate:"required,email"`
 }
 ```
 
@@ -322,8 +322,8 @@ type User struct {
 
 ```go
 type Product struct {
-    Price float64 `json:"price" pedantigo:"gt=0,lt=1000000"`
-    Stock int `json:"stock" pedantigo:"min=0,max=10000"`
+    Price float64 `json:"price" validate:"gt=0,lt=1000000"`
+    Stock int `json:"stock" validate:"min=0,max=10000"`
 }
 ```
 
@@ -331,8 +331,8 @@ type Product struct {
 
 ```go
 type Post struct {
-    Title   string `json:"title" pedantigo:"required,min=5,max=200"`
-    Content string `json:"content" pedantigo:"required,min=10,max=10000"`
+    Title   string `json:"title" validate:"required,min=5,max=200"`
+    Content string `json:"content" validate:"required,min=10,max=10000"`
 }
 ```
 
@@ -340,7 +340,7 @@ type Post struct {
 
 ```go
 type Order struct {
-    Status string `json:"status" pedantigo:"required,enum=pending|processing|shipped|delivered"`
+    Status string `json:"status" validate:"required,enum=pending|processing|shipped|delivered"`
 }
 ```
 
@@ -348,10 +348,10 @@ type Order struct {
 
 ```go
 type Website struct {
-    URL      string `json:"url" pedantigo:"required,url"`
-    IPv4     string `json:"ipv4" pedantigo:"ipv4"`
-    IPv6     string `json:"ipv6" pedantigo:"ipv6"`
-    UUID     string `json:"uuid" pedantigo:"uuid"`
+    URL      string `json:"url" validate:"required,url"`
+    IPv4     string `json:"ipv4" validate:"ipv4"`
+    IPv6     string `json:"ipv6" validate:"ipv6"`
+    UUID     string `json:"uuid" validate:"uuid"`
 }
 ```
 

--- a/docs/constraints/collection.md
+++ b/docs/constraints/collection.md
@@ -24,15 +24,15 @@ Validates the **number of items** (elements) in a slice, array, or map.
 ```go
 type ShoppingCart struct {
     // Must have at least 1 item, at most 100 items
-    Items []Product `json:"items" pedantigo:"required,min=1,max=100"`
+    Items []Product `json:"items" validate:"required,min=1,max=100"`
 
     // Tags collection: 0 to 10 tags
-    Tags []string `json:"tags" pedantigo:"max=10"`
+    Tags []string `json:"tags" validate:"max=10"`
 }
 
 type ConfigMap struct {
     // Must have between 2 and 50 configuration entries
-    Settings map[string]string `json:"settings" pedantigo:"min=2,max=50"`
+    Settings map[string]string `json:"settings" validate:"min=2,max=50"`
 }
 ```
 
@@ -49,12 +49,12 @@ Validates that a collection has an **exact number of items**.
 ```go
 type ChessTournament struct {
     // Exactly 8 players
-    Players []Player `json:"players" pedantigo:"len=8"`
+    Players []Player `json:"players" validate:"len=8"`
 }
 
 type RGBColor struct {
     // Array must have exactly 3 values (red, green, blue)
-    Values [3]int `json:"values" pedantigo:"len=3"`
+    Values [3]int `json:"values" validate:"len=3"`
 }
 ```
 
@@ -72,10 +72,10 @@ Validates that all elements in a collection are **unique** (no duplicates).
 ```go
 type UserGroup struct {
     // All email addresses must be different
-    EmailAddresses []string `json:"emails" pedantigo:"required,unique"`
+    EmailAddresses []string `json:"emails" validate:"required,unique"`
 
     // All product IDs must be unique
-    ProductIDs []int `json:"product_ids" pedantigo:"required,unique"`
+    ProductIDs []int `json:"product_ids" validate:"required,unique"`
 }
 ```
 
@@ -105,17 +105,17 @@ When validating slices of structs, use `unique=fieldName` to ensure all items ha
 ```go
 type UserList struct {
     // All users must have different usernames
-    Users []User `json:"users" pedantigo:"required,unique=Username"`
+    Users []User `json:"users" validate:"required,unique=Username"`
 }
 
 type User struct {
-    Username string `json:"username" pedantigo:"required"`
-    Email    string `json:"email" pedantigo:"required,email"`
+    Username string `json:"username" validate:"required"`
+    Email    string `json:"email" validate:"required,email"`
 }
 
 type InventoryItem struct {
     // All items must have different SKU (stock keeping unit)
-    Items []Product `json:"items" pedantigo:"required,unique=SKU"`
+    Items []Product `json:"items" validate:"required,unique=SKU"`
 }
 
 type Product struct {
@@ -158,10 +158,10 @@ The `dive` constraint tells Pedantigo to apply constraints to each element in a 
 ```go
 type PostRequest struct {
     // Each tag must be lowercase, 3-20 characters
-    Tags []string `json:"tags" pedantigo:"required,dive,lowercase,min=3,max=20"`
+    Tags []string `json:"tags" validate:"required,dive,lowercase,min=3,max=20"`
 
     // Each score must be between 0 and 100
-    Scores []int `json:"scores" pedantigo:"required,dive,min=0,max=100"`
+    Scores []int `json:"scores" validate:"required,dive,min=0,max=100"`
 }
 ```
 
@@ -179,10 +179,10 @@ You can validate both the collection size and individual element properties:
 ```go
 type DocumentUpload struct {
     // Must have 1-10 files, each with 3-50 character filename
-    Files []string `json:"files" pedantigo:"required,min=1,max=10,dive,min=3,max=50"`
+    Files []string `json:"files" validate:"required,min=1,max=10,dive,min=3,max=50"`
 
     // Must have 2-5 categories, each category must be lowercase letters only
-    Categories []string `json:"categories" pedantigo:"required,min=2,max=5,dive,alpha,lowercase"`
+    Categories []string `json:"categories" validate:"required,min=2,max=5,dive,alpha,lowercase"`
 }
 ```
 
@@ -200,13 +200,13 @@ Use `dive` to validate each struct in a collection:
 ```go
 type OrderRequest struct {
     // Each order item must be valid
-    Items []OrderItem `json:"items" pedantigo:"required,min=1,max=100,dive"`
+    Items []OrderItem `json:"items" validate:"required,min=1,max=100,dive"`
 }
 
 type OrderItem struct {
-    SKU      string `json:"sku" pedantigo:"required,len=10"`
-    Quantity int    `json:"quantity" pedantigo:"required,min=1,max=1000"`
-    Price    float64 `json:"price" pedantigo:"required,gt=0"`
+    SKU      string `json:"sku" validate:"required,len=10"`
+    Quantity int    `json:"quantity" validate:"required,min=1,max=1000"`
+    Price    float64 `json:"price" validate:"required,gt=0"`
 }
 ```
 
@@ -232,10 +232,10 @@ Use `keys` and `endkeys` to apply constraints specifically to map keys (not valu
 ```go
 type AppConfig struct {
     // All keys must be lowercase alphanumeric
-    Settings map[string]string `json:"settings" pedantigo:"required,keys,lowercase,alphanum,endkeys"`
+    Settings map[string]string `json:"settings" validate:"required,keys,lowercase,alphanum,endkeys"`
 
     // All keys must be valid email addresses
-    UserPreferences map[string]any `json:"preferences" pedantigo:"keys,email,endkeys"`
+    UserPreferences map[string]any `json:"preferences" validate:"keys,email,endkeys"`
 }
 ```
 
@@ -251,7 +251,7 @@ type AppConfig struct {
 ```go
 type EnvironmentVars struct {
     // Keys must be uppercase, values must be non-empty strings
-    Variables map[string]string `json:"variables" pedantigo:"required,keys,uppercase,alphanum,endkeys,dive,min=1"`
+    Variables map[string]string `json:"variables" validate:"required,keys,uppercase,alphanum,endkeys,dive,min=1"`
 }
 ```
 
@@ -269,10 +269,10 @@ Provides a default value when a collection field is missing from JSON.
 ```go
 type UserPreferences struct {
     // If tags are not provided, default to empty array
-    Tags []string `json:"tags,omitempty" pedantigo:"default="`
+    Tags []string `json:"tags,omitempty" validate:"default="`
 
     // If not provided, defaults to a predefined list
-    Regions []string `json:"regions" pedantigo:"default=us-east-1 us-west-2"`
+    Regions []string `json:"regions" validate:"default=us-east-1 us-west-2"`
 }
 ```
 
@@ -297,34 +297,34 @@ import (
 )
 
 type BlogPost struct {
-    Title string `json:"title" pedantigo:"required,min=5,max=200"`
+    Title string `json:"title" validate:"required,min=5,max=200"`
 
     // 1-1000 tags, each 2-30 lowercase characters
-    Tags []string `json:"tags" pedantigo:"min=1,max=1000,dive,min=2,max=30,lowercase"`
+    Tags []string `json:"tags" validate:"min=1,max=1000,dive,min=2,max=30,lowercase"`
 
     // 1-10 authors, all with different emails
-    Authors []Author `json:"authors" pedantigo:"required,min=1,max=10,dive,unique=Email"`
+    Authors []Author `json:"authors" validate:"required,min=1,max=10,dive,unique=Email"`
 
     // Map of translations: keys must be language codes (2 chars uppercase)
     // Values must be 10+ characters
-    Translations map[string]string `json:"translations" pedantigo:"keys,len=2,uppercase,alphanum,endkeys,dive,min=10"`
+    Translations map[string]string `json:"translations" validate:"keys,len=2,uppercase,alphanum,endkeys,dive,min=10"`
 
     // Each comment must be valid
-    Comments []Comment `json:"comments" pedantigo:"max=500,dive"`
+    Comments []Comment `json:"comments" validate:"max=500,dive"`
 
     // Related post URLs: all must be unique, each must be valid URL
-    RelatedPosts []string `json:"related_posts" pedantigo:"max=5,dive,unique,url"`
+    RelatedPosts []string `json:"related_posts" validate:"max=5,dive,unique,url"`
 }
 
 type Author struct {
-    Name  string `json:"name" pedantigo:"required,min=2,max=100"`
-    Email string `json:"email" pedantigo:"required,email"`
+    Name  string `json:"name" validate:"required,min=2,max=100"`
+    Email string `json:"email" validate:"required,email"`
 }
 
 type Comment struct {
-    Author  string `json:"author" pedantigo:"required,min=1,max=50"`
-    Text    string `json:"text" pedantigo:"required,min=10,max=5000"`
-    Rating  int    `json:"rating" pedantigo:"required,min=1,max=5"`
+    Author  string `json:"author" validate:"required,min=1,max=50"`
+    Text    string `json:"text" validate:"required,min=10,max=5000"`
+    Rating  int    `json:"rating" validate:"required,min=1,max=5"`
 }
 
 func main() {
@@ -445,17 +445,17 @@ func main() {
 ```go
 type Project struct {
     // Tasks with assigned users, validated deeply
-    Tasks []Task `json:"tasks" pedantigo:"required,min=1,max=500,dive"`
+    Tasks []Task `json:"tasks" validate:"required,min=1,max=500,dive"`
 }
 
 type Task struct {
-    Title       string   `json:"title" pedantigo:"required,min=3,max=100"`
-    AssignedTo  []User   `json:"assigned_to" pedantigo:"max=10,dive"`
-    SubTasks    []Task   `json:"subtasks" pedantigo:"max=50,dive"`  // Recursive validation
+    Title       string   `json:"title" validate:"required,min=3,max=100"`
+    AssignedTo  []User   `json:"assigned_to" validate:"max=10,dive"`
+    SubTasks    []Task   `json:"subtasks" validate:"max=50,dive"`  // Recursive validation
 }
 
 type User struct {
-    Username string `json:"username" pedantigo:"required,alphanum,min=3,max=20"`
+    Username string `json:"username" validate:"required,alphanum,min=3,max=20"`
 }
 ```
 
@@ -464,10 +464,10 @@ type User struct {
 ```go
 type DataSet struct {
     // Unique identifiers - enforces set semantics
-    IDs []string `json:"ids" pedantigo:"required,unique,dive,uuid"`
+    IDs []string `json:"ids" validate:"required,unique,dive,uuid"`
 
     // Unique enum values
-    Statuses []string `json:"statuses" pedantigo:"required,unique,dive,oneof=active inactive pending"`
+    Statuses []string `json:"statuses" validate:"required,unique,dive,oneof=active inactive pending"`
 }
 ```
 
@@ -476,9 +476,9 @@ type DataSet struct {
 ```go
 type NotificationConfig struct {
     // 1-5 unique email addresses for notifications
-    EmailRecipients []string `json:"recipients" pedantigo:"required,min=1,max=5,unique,dive,email"`
+    EmailRecipients []string `json:"recipients" validate:"required,min=1,max=5,unique,dive,email"`
 
     // 1-10 webhook URLs, all unique and valid
-    WebhookURLs []string `json:"webhooks" pedantigo:"min=1,max=10,unique,dive,url,startswith=https://"`
+    WebhookURLs []string `json:"webhooks" validate:"min=1,max=10,unique,dive,url,startswith=https://"`
 }
 ```

--- a/docs/constraints/format.md
+++ b/docs/constraints/format.md
@@ -15,9 +15,9 @@ Validates that a string is a **valid email address** following RFC 5322 specific
 ```go
 type Contact struct {
     // Email must be a valid email address
-    Email string `json:"email" pedantigo:"required,email"`
+    Email string `json:"email" validate:"required,email"`
     // Backup email is optional but must be valid if provided
-    BackupEmail string `json:"backup_email,omitempty" pedantigo:"email"`
+    BackupEmail string `json:"backup_email,omitempty" validate:"email"`
 }
 ```
 
@@ -31,9 +31,9 @@ Validates that a string is a **valid URL** with a scheme (http, https, ftp, etc.
 ```go
 type SocialProfile struct {
     // Website URL must be valid
-    Website string `json:"website" pedantigo:"required,url"`
+    Website string `json:"website" validate:"required,url"`
     // Optional portfolio URL
-    Portfolio string `json:"portfolio,omitempty" pedantigo:"url"`
+    Portfolio string `json:"portfolio,omitempty" validate:"url"`
 }
 ```
 
@@ -47,7 +47,7 @@ Validates that a string is a **valid URI** (Uniform Resource Identifier) with an
 ```go
 type DatabaseConfig struct {
     // Database connection URI (any scheme allowed)
-    ConnectionString string `json:"connection_string" pedantigo:"required,uri"`
+    ConnectionString string `json:"connection_string" validate:"required,uri"`
 }
 ```
 
@@ -70,9 +70,9 @@ Validates that a string is a **valid UUID** (Universally Unique Identifier) in s
 ```go
 type Document struct {
     // Unique document identifier must be a valid UUID
-    ID string `json:"id" pedantigo:"required,uuid"`
+    ID string `json:"id" validate:"required,uuid"`
     // Correlation ID for tracking, optional but must be UUID if provided
-    CorrelationID string `json:"correlation_id,omitempty" pedantigo:"uuid"`
+    CorrelationID string `json:"correlation_id,omitempty" validate:"uuid"`
 }
 ```
 
@@ -86,7 +86,7 @@ Validates that a string is a **valid ULID** (Universally Unique Lexicographicall
 ```go
 type Order struct {
     // ULID provides sortable unique ID with timestamp
-    ID string `json:"id" pedantigo:"required,ulid"`
+    ID string `json:"id" validate:"required,ulid"`
 }
 ```
 
@@ -102,7 +102,7 @@ Validates that a string is a **valid IP address** (IPv4 or IPv6).
 ```go
 type NetworkConfig struct {
     // Accept any valid IP version
-    Address string `json:"address" pedantigo:"required,ip"`
+    Address string `json:"address" validate:"required,ip"`
 }
 ```
 
@@ -116,7 +116,7 @@ Validates that a string is a **valid IPv4 address**.
 ```go
 type ServerConfig struct {
     // IPv4 address for legacy systems
-    IPv4Address string `json:"ipv4_address" pedantigo:"required,ipv4"`
+    IPv4Address string `json:"ipv4_address" validate:"required,ipv4"`
 }
 ```
 
@@ -130,7 +130,7 @@ Validates that a string is a **valid IPv6 address**.
 ```go
 type ModernNetworkConfig struct {
     // IPv6 address for modern networks
-    Address string `json:"address" pedantigo:"required,ipv6"`
+    Address string `json:"address" validate:"required,ipv6"`
 }
 ```
 
@@ -144,7 +144,7 @@ Validates that a string is a **valid CIDR notation** for IPv4 or IPv6.
 ```go
 type NetworkRoute struct {
     // CIDR block for routing, accepts both IPv4 and IPv6
-    Network string `json:"network" pedantigo:"required,cidr"`
+    Network string `json:"network" validate:"required,cidr"`
 }
 ```
 
@@ -158,7 +158,7 @@ Validates that a string is a **valid IPv4 CIDR notation**.
 ```go
 type SubnetConfig struct {
     // IPv4 CIDR notation for subnet specification
-    Subnet string `json:"subnet" pedantigo:"required,cidrv4"`
+    Subnet string `json:"subnet" validate:"required,cidrv4"`
 }
 ```
 
@@ -172,7 +172,7 @@ Validates that a string is a **valid IPv6 CIDR notation**.
 ```go
 type IPv6Network struct {
     // IPv6 CIDR notation for modern networks
-    Prefix string `json:"prefix" pedantigo:"required,cidrv6"`
+    Prefix string `json:"prefix" validate:"required,cidrv6"`
 }
 ```
 
@@ -186,7 +186,7 @@ Validates that a string is a **valid MAC address**.
 ```go
 type NetworkInterface struct {
     // MAC address for device identification
-    HardwareAddress string `json:"mac_address" pedantigo:"required,mac"`
+    HardwareAddress string `json:"mac_address" validate:"required,mac"`
 }
 ```
 
@@ -200,7 +200,7 @@ Validates that a string is a **valid hostname** (flexible format).
 ```go
 type ServerInfo struct {
     // Hostname for the server
-    Hostname string `json:"hostname" pedantigo:"required,hostname"`
+    Hostname string `json:"hostname" validate:"required,hostname"`
 }
 ```
 
@@ -214,7 +214,7 @@ Validates that a string is a **valid RFC 1123 hostname** (stricter standard).
 ```go
 type DNSRecord struct {
     // RFC 1123 compliant hostname
-    Name string `json:"name" pedantigo:"required,hostname_rfc1123"`
+    Name string `json:"name" validate:"required,hostname_rfc1123"`
 }
 ```
 
@@ -228,7 +228,7 @@ Validates that a string is a **fully qualified domain name**.
 ```go
 type DomainConfig struct {
     // Must be a complete domain name
-    Domain string `json:"domain" pedantigo:"required,fqdn"`
+    Domain string `json:"domain" validate:"required,fqdn"`
 }
 ```
 
@@ -242,9 +242,9 @@ Validates that a string or integer is a **valid port number** (1-65535).
 ```go
 type ServiceEndpoint struct {
     // Port number must be in valid range
-    Port int `json:"port" pedantigo:"required,port"`
+    Port int `json:"port" validate:"required,port"`
     // Also works with strings
-    PortString string `json:"port_string" pedantigo:"required,port"`
+    PortString string `json:"port_string" validate:"required,port"`
 }
 ```
 
@@ -258,7 +258,7 @@ Validates that a string is a **valid TCP address** in `host:port` format.
 ```go
 type TCPConnection struct {
     // TCP address for server connection
-    Address string `json:"address" pedantigo:"required,tcp_addr"`
+    Address string `json:"address" validate:"required,tcp_addr"`
 }
 ```
 
@@ -272,7 +272,7 @@ Validates that a string is a **valid UDP address** in `host:port` format.
 ```go
 type UDPConnection struct {
     // UDP address for datagram communication
-    Address string `json:"address" pedantigo:"required,udp_addr"`
+    Address string `json:"address" validate:"required,udp_addr"`
 }
 ```
 
@@ -286,7 +286,7 @@ Validates that a string is a **valid IPv4 TCP address**.
 ```go
 type IPv4TCPEndpoint struct {
     // IPv4 TCP endpoint
-    Endpoint string `json:"endpoint" pedantigo:"required,tcp4_addr"`
+    Endpoint string `json:"endpoint" validate:"required,tcp4_addr"`
 }
 ```
 
@@ -302,7 +302,7 @@ Validates that a string is a **valid credit card number** using Luhn algorithm.
 ```go
 type PaymentInfo struct {
     // Credit card number must pass Luhn validation
-    CardNumber string `json:"card_number" pedantigo:"required,credit_card"`
+    CardNumber string `json:"card_number" validate:"required,credit_card"`
 }
 ```
 
@@ -318,7 +318,7 @@ Validates that a string **passes the Luhn algorithm** checksum.
 ```go
 type AccountVerification struct {
     // Account number must pass Luhn validation
-    AccountNumber string `json:"account_number" pedantigo:"required,luhn_checksum"`
+    AccountNumber string `json:"account_number" validate:"required,luhn_checksum"`
 }
 ```
 
@@ -332,7 +332,7 @@ Validates that a string is a **valid Bitcoin address** (P2PKH or P2SH format).
 ```go
 type CryptoWallet struct {
     // Bitcoin address for receiving payments
-    BTCAddress string `json:"btc_address" pedantigo:"required,btc_addr"`
+    BTCAddress string `json:"btc_address" validate:"required,btc_addr"`
 }
 ```
 
@@ -346,7 +346,7 @@ Validates that a string is a **valid Bech32-encoded Bitcoin address** (SegWit fo
 ```go
 type ModernWallet struct {
     // SegWit Bitcoin address
-    Address string `json:"address" pedantigo:"required,btc_addr_bech32"`
+    Address string `json:"address" validate:"required,btc_addr_bech32"`
 }
 ```
 
@@ -360,7 +360,7 @@ Validates that a string is a **valid Ethereum address** (0x prefix with 40 hex c
 ```go
 type EthereumWallet struct {
     // Ethereum address for contract interactions
-    Address string `json:"address" pedantigo:"required,eth_addr"`
+    Address string `json:"address" validate:"required,eth_addr"`
 }
 ```
 
@@ -376,11 +376,11 @@ Validates that a string is a **valid ISBN** (International Standard Book Number)
 ```go
 type Book struct {
     // Accept either ISBN-10 or ISBN-13
-    ISBN string `json:"isbn" pedantigo:"required,isbn"`
+    ISBN string `json:"isbn" validate:"required,isbn"`
     // Specifically ISBN-13
-    ISBN13 string `json:"isbn_13" pedantigo:"required,isbn13"`
+    ISBN13 string `json:"isbn_13" validate:"required,isbn13"`
     // Specifically ISBN-10
-    ISBN10 string `json:"isbn_10,omitempty" pedantigo:"isbn10"`
+    ISBN10 string `json:"isbn_10,omitempty" validate:"isbn10"`
 }
 ```
 
@@ -397,7 +397,7 @@ Validates that a string is a **valid ISSN** (International Standard Serial Numbe
 ```go
 type Magazine struct {
     // ISSN for identifying the journal
-    ISSN string `json:"issn" pedantigo:"required,issn"`
+    ISSN string `json:"issn" validate:"required,issn"`
 }
 ```
 
@@ -411,7 +411,7 @@ Validates that a string is a **valid US Social Security Number** format.
 ```go
 type EmployeeInfo struct {
     // US Social Security Number
-    SSN string `json:"ssn" pedantigo:"required,ssn"`
+    SSN string `json:"ssn" validate:"required,ssn"`
 }
 ```
 
@@ -425,7 +425,7 @@ Validates that a string is a **valid US Employer Identification Number** format.
 ```go
 type CompanyInfo struct {
     // US EIN for business identification
-    EIN string `json:"ein" pedantigo:"required,ein"`
+    EIN string `json:"ein" validate:"required,ein"`
 }
 ```
 
@@ -439,7 +439,7 @@ Validates that a string is a **valid E.164 phone number format** (+country code 
 ```go
 type ContactInfo struct {
     // International phone number in E.164 format
-    Phone string `json:"phone" pedantigo:"required,e164"`
+    Phone string `json:"phone" validate:"required,e164"`
 }
 ```
 
@@ -455,7 +455,7 @@ Validates that a string is a **valid JWT** (JSON Web Token) structure.
 ```go
 type AuthToken struct {
     // JWT bearer token
-    Token string `json:"token" pedantigo:"required,jwt"`
+    Token string `json:"token" validate:"required,jwt"`
 }
 ```
 
@@ -469,7 +469,7 @@ Validates that a string is **valid JSON** format.
 ```go
 type ConfigData struct {
     // String containing valid JSON
-    MetadataJSON string `json:"metadata" pedantigo:"required,json"`
+    MetadataJSON string `json:"metadata" validate:"required,json"`
 }
 ```
 
@@ -483,11 +483,11 @@ Validates that a string is **valid Base64 encoding**.
 ```go
 type EncodedData struct {
     // Standard Base64 (may have padding)
-    Data string `json:"data" pedantigo:"required,base64"`
+    Data string `json:"data" validate:"required,base64"`
     // URL-safe Base64 (may have padding)
-    URLSafe string `json:"url_safe" pedantigo:"required,base64url"`
+    URLSafe string `json:"url_safe" validate:"required,base64url"`
     // URL-safe Base64 without padding
-    RawURL string `json:"raw_url" pedantigo:"required,base64rawurl"`
+    RawURL string `json:"raw_url" validate:"required,base64rawurl"`
 }
 ```
 
@@ -507,11 +507,11 @@ Validates that a string is a **valid hash** in the specified algorithm format.
 ```go
 type FileIntegrity struct {
     // MD5 hash (128-bit, 32 hex chars)
-    MD5 string `json:"md5" pedantigo:"required,md5"`
+    MD5 string `json:"md5" validate:"required,md5"`
     // SHA256 hash (256-bit, 64 hex chars)
-    SHA256 string `json:"sha256" pedantigo:"required,sha256"`
+    SHA256 string `json:"sha256" validate:"required,sha256"`
     // SHA512 hash (512-bit, 128 hex chars)
-    SHA512 string `json:"sha512" pedantigo:"required,sha512"`
+    SHA512 string `json:"sha512" validate:"required,sha512"`
 }
 ```
 
@@ -529,7 +529,7 @@ Validates that a string is a **valid MongoDB ObjectID** (24 hex characters).
 ```go
 type MongoDocument struct {
     // MongoDB document identifier
-    ID string `json:"id" pedantigo:"required,mongodb"`
+    ID string `json:"id" validate:"required,mongodb"`
 }
 ```
 
@@ -545,9 +545,9 @@ Validates that a string is a **valid ISO 3166-1 country code**.
 ```go
 type Address struct {
     // ISO 3166-1 alpha-2 code (US, GB, FR, etc.)
-    CountryCode2 string `json:"country_code_2" pedantigo:"required,iso3166_alpha2"`
+    CountryCode2 string `json:"country_code_2" validate:"required,iso3166_alpha2"`
     // ISO 3166-1 alpha-3 code (USA, GBR, FRA, etc.)
-    CountryCode3 string `json:"country_code_3" pedantigo:"required,iso3166_alpha3"`
+    CountryCode3 string `json:"country_code_3" validate:"required,iso3166_alpha3"`
 }
 ```
 
@@ -564,7 +564,7 @@ Validates that a string is a **valid ISO 3166-1 numeric country code**.
 ```go
 type CountryNumeric struct {
     // ISO 3166-1 numeric code (840 for USA, 826 for GB, etc.)
-    Code string `json:"code" pedantigo:"required,iso3166_numeric"`
+    Code string `json:"code" validate:"required,iso3166_numeric"`
 }
 ```
 
@@ -578,7 +578,7 @@ Validates that a string is a **valid ISO 3166-2 subdivision code** (country-subd
 ```go
 type SubdivisionInfo struct {
     // ISO 3166-2 code like US-CA (California), GB-ENG (England)
-    Code string `json:"subdivision" pedantigo:"required,iso3166_2"`
+    Code string `json:"subdivision" validate:"required,iso3166_2"`
 }
 ```
 
@@ -592,7 +592,7 @@ Validates that a string is a **valid ISO 3166-1 code for EU member states only**
 ```go
 type EUAddress struct {
     // Must be an EU country (alpha-2)
-    CountryCode string `json:"country_code" pedantigo:"required,iso3166_alpha2_eu"`
+    CountryCode string `json:"country_code" validate:"required,iso3166_alpha2_eu"`
 }
 ```
 
@@ -608,9 +608,9 @@ Validates that a string is a **valid ISO 4217 currency code**.
 ```go
 type PriceInfo struct {
     // ISO 4217 3-letter currency code
-    Currency string `json:"currency" pedantigo:"required,iso4217"`
+    Currency string `json:"currency" validate:"required,iso4217"`
     // ISO 4217 numeric code
-    CurrencyNumeric string `json:"currency_numeric" pedantigo:"required,iso4217_numeric"`
+    CurrencyNumeric string `json:"currency_numeric" validate:"required,iso4217_numeric"`
 }
 ```
 
@@ -627,11 +627,11 @@ Validates that a string is a **valid postal code** for a specific country. Both 
 ```go
 type InternationalAddress struct {
     // US zipcode (5 or 9 digits)
-    ZipUS string `json:"zip" pedantigo:"required,postcode=US"`
+    ZipUS string `json:"zip" validate:"required,postcode=US"`
     // UK postcode format (using alias)
-    PostcodeUK string `json:"postcode" pedantigo:"required,postcode_iso3166_alpha2=GB"`
+    PostcodeUK string `json:"postcode" validate:"required,postcode_iso3166_alpha2=GB"`
     // Canadian postal code format
-    PostcodeCA string `json:"postal_code" pedantigo:"required,postcode=CA"`
+    PostcodeCA string `json:"postal_code" validate:"required,postcode=CA"`
 }
 ```
 
@@ -649,7 +649,7 @@ Validates that a string is a **valid BCP 47 language tag**.
 ```go
 type LocalizationSettings struct {
     // BCP 47 language tag (en, fr-CA, zh-Hans-CN, etc.)
-    Language string `json:"language" pedantigo:"required,bcp47"`
+    Language string `json:"language" validate:"required,bcp47"`
 }
 ```
 
@@ -665,9 +665,9 @@ Validates that a string or number is a **valid geographic coordinate**.
 ```go
 type GeoLocation struct {
     // Latitude: -90 to 90 degrees
-    Latitude float64 `json:"latitude" pedantigo:"required,latitude"`
+    Latitude float64 `json:"latitude" validate:"required,latitude"`
     // Longitude: -180 to 180 degrees
-    Longitude float64 `json:"longitude" pedantigo:"required,longitude"`
+    Longitude float64 `json:"longitude" validate:"required,longitude"`
 }
 ```
 
@@ -686,11 +686,11 @@ Validates that a string is a **valid color format**.
 ```go
 type ThemeConfig struct {
     // Hexadecimal color
-    PrimaryColor string `json:"primary" pedantigo:"required,hexcolor"`
+    PrimaryColor string `json:"primary" validate:"required,hexcolor"`
     // RGB color
-    SecondaryColor string `json:"secondary" pedantigo:"required,rgb"`
+    SecondaryColor string `json:"secondary" validate:"required,rgb"`
     // RGBA color with transparency
-    TransparentColor string `json:"transparent" pedantigo:"rgba"`
+    TransparentColor string `json:"transparent" validate:"rgba"`
 }
 ```
 
@@ -710,8 +710,8 @@ Validates that a string is a **valid color in any CSS format**. This is a conven
 ```go
 type ThemeConfig struct {
     // Accept any valid CSS color format
-    PrimaryColor string `json:"primary" pedantigo:"required,iscolor"`
-    AccentColor  string `json:"accent" pedantigo:"iscolor"`
+    PrimaryColor string `json:"primary" validate:"required,iscolor"`
+    AccentColor  string `json:"accent" validate:"iscolor"`
 }
 ```
 
@@ -734,7 +734,7 @@ Validates that a string **contains HTML markup**.
 ```go
 type BlogPost struct {
     // Post content must contain HTML
-    Content string `json:"content" pedantigo:"required,html"`
+    Content string `json:"content" validate:"required,html"`
 }
 ```
 
@@ -748,7 +748,7 @@ Validates that a string is a **valid cron expression**.
 ```go
 type ScheduledTask struct {
     // Cron schedule for task execution
-    Schedule string `json:"schedule" pedantigo:"required,cron"`
+    Schedule string `json:"schedule" validate:"required,cron"`
 }
 ```
 
@@ -762,7 +762,7 @@ Validates that a string is a **valid Semantic Version** (major.minor.patch).
 ```go
 type PackageInfo struct {
     // Semantic version for package
-    Version string `json:"version" pedantigo:"required,semver"`
+    Version string `json:"version" validate:"required,semver"`
 }
 ```
 
@@ -776,13 +776,13 @@ Validates that a string matches a **Go time layout format**.
 ```go
 type Event struct {
     // ISO 8601 date format
-    Date string `json:"date" pedantigo:"required,datetime=2006-01-02"`
+    Date string `json:"date" validate:"required,datetime=2006-01-02"`
 
     // Full datetime with seconds
-    Timestamp string `json:"timestamp" pedantigo:"required,datetime=2006-01-02 15:04:05"`
+    Timestamp string `json:"timestamp" validate:"required,datetime=2006-01-02 15:04:05"`
 
     // RFC 3339 format
-    CreatedAt string `json:"created_at" pedantigo:"datetime=2006-01-02T15:04:05Z07:00"`
+    CreatedAt string `json:"created_at" validate:"datetime=2006-01-02T15:04:05Z07:00"`
 }
 ```
 
@@ -807,9 +807,9 @@ Validates that a string is a **valid file or directory path**.
 ```go
 type FileConfig struct {
     // Path to a file
-    FilePath string `json:"file" pedantigo:"required,filepath"`
+    FilePath string `json:"file" validate:"required,filepath"`
     // Path to a directory
-    DirPath string `json:"directory" pedantigo:"required,dirpath"`
+    DirPath string `json:"directory" validate:"required,dirpath"`
 }
 ```
 
@@ -826,9 +826,9 @@ Validates that a path **exists** and is a file or directory respectively.
 ```go
 type ExistingFileConfig struct {
     // File must exist on filesystem
-    ExistingFile string `json:"existing_file" pedantigo:"required,file"`
+    ExistingFile string `json:"existing_file" validate:"required,file"`
     // Directory must exist on filesystem
-    ExistingDir string `json:"existing_dir" pedantigo:"required,dir"`
+    ExistingDir string `json:"existing_dir" validate:"required,dir"`
 }
 ```
 
@@ -842,7 +842,7 @@ Validates that a file path points to a **valid image file** by checking magic by
 ```go
 type UserProfile struct {
     // Avatar must be a valid image file
-    Avatar string `json:"avatar" pedantigo:"required,image"`
+    Avatar string `json:"avatar" validate:"required,image"`
 }
 ```
 
@@ -867,67 +867,67 @@ import (
 
 type UserAccount struct {
     // UUID identifier
-    ID string `json:"id" pedantigo:"required,uuid"`
+    ID string `json:"id" validate:"required,uuid"`
 
     // Email address
-    Email string `json:"email" pedantigo:"required,email"`
+    Email string `json:"email" validate:"required,email"`
 
     // Personal website
-    Website string `json:"website,omitempty" pedantigo:"url"`
+    Website string `json:"website,omitempty" validate:"url"`
 
     // International phone
-    Phone string `json:"phone" pedantigo:"required,e164"`
+    Phone string `json:"phone" validate:"required,e164"`
 
     // Country location
-    Country string `json:"country" pedantigo:"required,iso3166_alpha2"`
+    Country string `json:"country" validate:"required,iso3166_alpha2"`
 
     // Preferred language
-    Language string `json:"language" pedantigo:"required,bcp47"`
+    Language string `json:"language" validate:"required,bcp47"`
 
     // Birth coordinates
-    BirthLatitude float64 `json:"birth_latitude,omitempty" pedantigo:"latitude"`
-    BirthLongitude float64 `json:"birth_longitude,omitempty" pedantigo:"longitude"`
+    BirthLatitude float64 `json:"birth_latitude,omitempty" validate:"latitude"`
+    BirthLongitude float64 `json:"birth_longitude,omitempty" validate:"longitude"`
 
     // Authentication
-    JWTToken string `json:"jwt" pedantigo:"required,jwt"`
+    JWTToken string `json:"jwt" validate:"required,jwt"`
 }
 
 type CompanyInfo struct {
     // Company identifier
-    ID string `json:"id" pedantigo:"required,uuid"`
+    ID string `json:"id" validate:"required,uuid"`
 
     // Official website
-    Website string `json:"website" pedantigo:"required,url"`
+    Website string `json:"website" validate:"required,url"`
 
     // Tax identifier
-    EIN string `json:"ein" pedantigo:"required,ein"`
+    EIN string `json:"ein" validate:"required,ein"`
 
     // Company country (EU only)
-    Country string `json:"country" pedantigo:"required,iso3166_alpha2_eu"`
+    Country string `json:"country" validate:"required,iso3166_alpha2_eu"`
 
     // Operating currency
-    Currency string `json:"currency" pedantigo:"required,iso4217"`
+    Currency string `json:"currency" validate:"required,iso4217"`
 
     // Server IP address
-    ServerIP string `json:"server_ip" pedantigo:"required,ipv4"`
+    ServerIP string `json:"server_ip" validate:"required,ipv4"`
 
     // Network subnet
-    Subnet string `json:"subnet" pedantigo:"required,cidrv4"`
+    Subnet string `json:"subnet" validate:"required,cidrv4"`
 
     // Network interface MAC
-    MacAddress string `json:"mac" pedantigo:"required,mac"`
+    MacAddress string `json:"mac" validate:"required,mac"`
 
     // DNS hostname
-    Hostname string `json:"hostname" pedantigo:"required,hostname_rfc1123"`
+    Hostname string `json:"hostname" validate:"required,hostname_rfc1123"`
 
     // Primary contact port
-    ContactPort int `json:"contact_port" pedantigo:"required,port"`
+    ContactPort int `json:"contact_port" validate:"required,port"`
 
     // Brand color scheme
-    PrimaryColor string `json:"primary_color" pedantigo:"required,hexcolor"`
+    PrimaryColor string `json:"primary_color" validate:"required,hexcolor"`
 
     // Release version
-    SoftwareVersion string `json:"version" pedantigo:"required,semver"`
+    SoftwareVersion string `json:"version" validate:"required,semver"`
 }
 
 func main() {

--- a/docs/constraints/numeric.md
+++ b/docs/constraints/numeric.md
@@ -15,9 +15,9 @@ Validates the **numeric value** is within the specified range (inclusive).
 ```go
 type Product struct {
     // Price must be at least 0.01 and at most 999,999.99
-    Price float64 `json:"price" pedantigo:"required,min=0.01,max=999999.99"`
+    Price float64 `json:"price" validate:"required,min=0.01,max=999999.99"`
     // Quantity must be between 1 and 1000
-    Quantity int `json:"quantity" pedantigo:"required,min=1,max=1000"`
+    Quantity int `json:"quantity" validate:"required,min=1,max=1000"`
 }
 ```
 
@@ -39,13 +39,13 @@ Validates numeric values with exclusive or inclusive comparison bounds.
 ```go
 type SurveyRating struct {
     // Rating must be strictly greater than 0
-    Score int `json:"score" pedantigo:"required,gt=0"`
+    Score int `json:"score" validate:"required,gt=0"`
     // Confidence must be at least 0.5
-    Confidence float64 `json:"confidence" pedantigo:"required,gte=0.5"`
+    Confidence float64 `json:"confidence" validate:"required,gte=0.5"`
     // Days until expiration must be less than 365
-    DaysUntilExpiry int `json:"days_until_expiry" pedantigo:"required,lt=365"`
+    DaysUntilExpiry int `json:"days_until_expiry" validate:"required,lt=365"`
     // Discount percentage must be at most 50
-    DiscountPercent int `json:"discount_percent" pedantigo:"required,lte=50"`
+    DiscountPercent int `json:"discount_percent" validate:"required,lte=50"`
 }
 ```
 
@@ -64,9 +64,9 @@ Validates that a numeric value is **strictly greater than zero** (> 0).
 ```go
 type BankAccount struct {
     // Balance can be positive (credits) or zero, but not negative
-    Balance float64 `json:"balance" pedantigo:"required,positive"`
+    Balance float64 `json:"balance" validate:"required,positive"`
     // Withdrawal amount must be positive
-    WithdrawalAmount float64 `json:"withdrawal_amount" pedantigo:"required,positive"`
+    WithdrawalAmount float64 `json:"withdrawal_amount" validate:"required,positive"`
 }
 ```
 
@@ -82,9 +82,9 @@ Validates that a numeric value is **strictly less than zero** (< 0).
 ```go
 type TemperatureReading struct {
     // Temperature below freezing point
-    BelowFreezing float64 `json:"below_freezing" pedantigo:"negative"`
+    BelowFreezing float64 `json:"below_freezing" validate:"negative"`
     // Temperature change (decrease)
-    TemperatureChange float64 `json:"temperature_change" pedantigo:"negative"`
+    TemperatureChange float64 `json:"temperature_change" validate:"negative"`
 }
 ```
 
@@ -102,17 +102,17 @@ Validates that a numeric value is **evenly divisible** by the specified number.
 ```go
 type TimeSlot struct {
     // Meeting duration in minutes must be divisible by 15
-    DurationMinutes int `json:"duration_minutes" pedantigo:"required,multiple_of=15"`
+    DurationMinutes int `json:"duration_minutes" validate:"required,multiple_of=15"`
 }
 
 type ShoppingCart struct {
     // Pack size: items must be divisible by 6 (half-dozen)
-    Quantity int `json:"quantity" pedantigo:"required,min=6,multiple_of=6"`
+    Quantity int `json:"quantity" validate:"required,min=6,multiple_of=6"`
 }
 
 type PercentageDiscount struct {
     // Discount must be in 5% increments
-    DiscountPercent float64 `json:"discount_percent" pedantigo:"required,min=0,max=100,multiple_of=5"`
+    DiscountPercent float64 `json:"discount_percent" validate:"required,min=0,max=100,multiple_of=5"`
 }
 ```
 
@@ -133,12 +133,12 @@ Validates that a numeric value has **at most N total digits** (excluding the dec
 ```go
 type ProductSKU struct {
     // Product code: maximum 8 digits
-    Code int64 `json:"code" pedantigo:"required,max_digits=8"`
+    Code int64 `json:"code" validate:"required,max_digits=8"`
 }
 
 type BudgetAmount struct {
     // Budget: at most 10 total digits (e.g., 9,999,999,999.99)
-    Amount float64 `json:"amount" pedantigo:"required,max_digits=10"`
+    Amount float64 `json:"amount" validate:"required,max_digits=10"`
 }
 ```
 
@@ -158,17 +158,17 @@ Validates that a numeric value has **at most N decimal places** (digits after de
 ```go
 type MoneyAmount struct {
     // Price in USD: maximum 2 decimal places
-    Price float64 `json:"price" pedantigo:"required,decimal_places=2"`
+    Price float64 `json:"price" validate:"required,decimal_places=2"`
 }
 
 type ExchangeRate struct {
     // Exchange rate: at most 6 decimal places
-    Rate float64 `json:"rate" pedantigo:"required,min=0,decimal_places=6"`
+    Rate float64 `json:"rate" validate:"required,min=0,decimal_places=6"`
 }
 
 type MeasurementValue struct {
     // Measurement: at most 4 decimal places
-    Meters float64 `json:"meters" pedantigo:"required,decimal_places=4"`
+    Meters float64 `json:"meters" validate:"required,decimal_places=4"`
 }
 ```
 
@@ -191,14 +191,14 @@ Validates that a floating-point value is **neither infinity nor NaN** (Not a Num
 ```go
 type SensorData struct {
     // Sensor reading must be a valid number
-    Temperature float64 `json:"temperature" pedantigo:"required,disallow_inf_nan"`
+    Temperature float64 `json:"temperature" validate:"required,disallow_inf_nan"`
     // Altitude must be finite
-    Altitude float64 `json:"altitude" pedantigo:"required,disallow_inf_nan"`
+    Altitude float64 `json:"altitude" validate:"required,disallow_inf_nan"`
 }
 
 type CalculationResult struct {
     // Result of division must be a valid number
-    Result float64 `json:"result" pedantigo:"required,disallow_inf_nan"`
+    Result float64 `json:"result" validate:"required,disallow_inf_nan"`
 }
 ```
 
@@ -218,32 +218,32 @@ Numeric constraints can be combined to create powerful validation rules:
 ```go
 type BankAccount struct {
     // Account balance: must be at least 0, at most 999 billion
-    Balance float64 `json:"balance" pedantigo:"required,min=0,max=999000000000,decimal_places=2"`
+    Balance float64 `json:"balance" validate:"required,min=0,max=999000000000,decimal_places=2"`
 }
 
 type AgeVerification struct {
     // Age: must be between 18 and 150
-    Age int `json:"age" pedantigo:"required,min=18,max=150"`
+    Age int `json:"age" validate:"required,min=18,max=150"`
 }
 
 type PercentageScore struct {
     // Score: 0-100 with one decimal place
-    Score float64 `json:"score" pedantigo:"required,min=0,max=100,decimal_places=1"`
+    Score float64 `json:"score" validate:"required,min=0,max=100,decimal_places=1"`
 }
 
 type RatingScale struct {
     // 5-star rating: 1 to 5, in increments of 0.5
-    Rating float64 `json:"rating" pedantigo:"required,min=1,max=5,multiple_of=0.5"`
+    Rating float64 `json:"rating" validate:"required,min=1,max=5,multiple_of=0.5"`
 }
 
 type PaymentAmount struct {
     // Payment: at least 0.01, at most 999,999.99, exactly 2 decimal places
-    Amount float64 `json:"amount" pedantigo:"required,min=0.01,max=999999.99,decimal_places=2"`
+    Amount float64 `json:"amount" validate:"required,min=0.01,max=999999.99,decimal_places=2"`
 }
 
 type ApiKeyID struct {
     // API key ID: exactly 32 digits, no sign
-    KeyID int64 `json:"key_id" pedantigo:"required,max_digits=32"`
+    KeyID int64 `json:"key_id" validate:"required,max_digits=32"`
 }
 ```
 
@@ -261,39 +261,39 @@ import (
 
 type ECommerceProduct struct {
     // Product ID: positive integer, at most 10 digits
-    ID int64 `json:"id" pedantigo:"required,positive,max_digits=10"`
+    ID int64 `json:"id" validate:"required,positive,max_digits=10"`
 
     // Product name: required, 3-100 characters
-    Name string `json:"name" pedantigo:"required,min=3,max=100"`
+    Name string `json:"name" validate:"required,min=3,max=100"`
 
     // Price in USD: required, at least 0.01, exactly 2 decimal places
-    Price float64 `json:"price" pedantigo:"required,min=0.01,decimal_places=2"`
+    Price float64 `json:"price" validate:"required,min=0.01,decimal_places=2"`
 
     // Cost basis: optional, for internal tracking
-    CostBasis float64 `json:"cost_basis,omitempty" pedantigo:"min=0,decimal_places=2"`
+    CostBasis float64 `json:"cost_basis,omitempty" validate:"min=0,decimal_places=2"`
 
     // Stock quantity: non-negative, less than 1 million
-    StockQuantity int `json:"stock_quantity" pedantigo:"required,min=0,max=999999"`
+    StockQuantity int `json:"stock_quantity" validate:"required,min=0,max=999999"`
 
     // Rating: 0-5 stars, one decimal place
-    Rating float64 `json:"rating,omitempty" pedantigo:"min=0,max=5,decimal_places=1"`
+    Rating float64 `json:"rating,omitempty" validate:"min=0,max=5,decimal_places=1"`
 
     // Review count: non-negative
-    ReviewCount int `json:"review_count,omitempty" pedantigo:"min=0"`
+    ReviewCount int `json:"review_count,omitempty" validate:"min=0"`
 
     // Discount percentage: 0-100, whole numbers only
-    DiscountPercent int `json:"discount_percent,omitempty" pedantigo:"min=0,max=100"`
+    DiscountPercent int `json:"discount_percent,omitempty" validate:"min=0,max=100"`
 
     // Weight in kilograms: positive, 4 decimal places
-    WeightKg float64 `json:"weight_kg,omitempty" pedantigo:"positive,decimal_places=4"`
+    WeightKg float64 `json:"weight_kg,omitempty" validate:"positive,decimal_places=4"`
 
     // Dimensions in centimeters: all positive
-    WidthCm  float64 `json:"width_cm,omitempty" pedantigo:"positive,decimal_places=1"`
-    HeightCm float64 `json:"height_cm,omitempty" pedantigo:"positive,decimal_places=1"`
-    DepthCm  float64 `json:"depth_cm,omitempty" pedantigo:"positive,decimal_places=1"`
+    WidthCm  float64 `json:"width_cm,omitempty" validate:"positive,decimal_places=1"`
+    HeightCm float64 `json:"height_cm,omitempty" validate:"positive,decimal_places=1"`
+    DepthCm  float64 `json:"depth_cm,omitempty" validate:"positive,decimal_places=1"`
 
     // Warranty period in months: 0 to 36, multiple of 3
-    WarrantyMonths int `json:"warranty_months,omitempty" pedantigo:"min=0,max=36,multiple_of=3"`
+    WarrantyMonths int `json:"warranty_months,omitempty" validate:"min=0,max=36,multiple_of=3"`
 }
 
 func main() {
@@ -393,27 +393,27 @@ func main() {
 
 **E-commerce:**
 ```go
-Price float64 `json:"price" pedantigo:"required,min=0.01,decimal_places=2"`
-Quantity int `json:"quantity" pedantigo:"required,min=1,max=1000"`
-DiscountPercent int `json:"discount" pedantigo:"min=0,max=100"`
+Price float64 `json:"price" validate:"required,min=0.01,decimal_places=2"`
+Quantity int `json:"quantity" validate:"required,min=1,max=1000"`
+DiscountPercent int `json:"discount" validate:"min=0,max=100"`
 ```
 
 **Banking:**
 ```go
-Balance float64 `json:"balance" pedantigo:"required,decimal_places=2,max_digits=15"`
-WithdrawalAmount float64 `json:"amount" pedantigo:"required,positive,decimal_places=2"`
-InterestRate float64 `json:"rate" pedantigo:"required,min=0,decimal_places=4"`
+Balance float64 `json:"balance" validate:"required,decimal_places=2,max_digits=15"`
+WithdrawalAmount float64 `json:"amount" validate:"required,positive,decimal_places=2"`
+InterestRate float64 `json:"rate" validate:"required,min=0,decimal_places=4"`
 ```
 
 **Scientific/Measurements:**
 ```go
-Temperature float64 `json:"temp_celsius" pedantigo:"disallow_inf_nan"`
-PressurePa float64 `json:"pressure" pedantigo:"required,positive"`
-PH float64 `json:"ph" pedantigo:"required,min=0,max=14,decimal_places=2"`
+Temperature float64 `json:"temp_celsius" validate:"disallow_inf_nan"`
+PressurePa float64 `json:"pressure" validate:"required,positive"`
+PH float64 `json:"ph" validate:"required,min=0,max=14,decimal_places=2"`
 ```
 
 **Rating Systems:**
 ```go
-Stars float64 `json:"stars" pedantigo:"min=0,max=5,multiple_of=0.5"`
-Percentage int `json:"percentage" pedantigo:"required,min=0,max=100"`
+Stars float64 `json:"stars" validate:"min=0,max=5,multiple_of=0.5"`
+Percentage int `json:"percentage" validate:"required,min=0,max=100"`
 ```

--- a/docs/constraints/string.md
+++ b/docs/constraints/string.md
@@ -15,9 +15,9 @@ Validates the **number of characters** (runes) in the string.
 ```go
 type Post struct {
     // Username must be 3-20 characters
-    Username string `json:"username" pedantigo:"required,min=3,max=20"`
+    Username string `json:"username" validate:"required,min=3,max=20"`
     // Bio can be empty or up to 500 characters
-    Bio      string `json:"bio" pedantigo:"max=500"`
+    Bio      string `json:"bio" validate:"max=500"`
 }
 ```
 
@@ -32,7 +32,7 @@ Validates that a string has an **exact number of characters**.
 ```go
 type License struct {
     // License key must be exactly 32 characters
-    Key string `json:"key" pedantigo:"len=32"`
+    Key string `json:"key" validate:"len=32"`
 }
 ```
 
@@ -50,8 +50,8 @@ Validates that a string contains **only alphabetic characters** (A-Z, a-z).
 ```go
 type Person struct {
     // FirstName must be letters only
-    FirstName string `json:"first_name" pedantigo:"required,alpha"`
-    LastName  string `json:"last_name" pedantigo:"required,alpha"`
+    FirstName string `json:"first_name" validate:"required,alpha"`
+    LastName  string `json:"last_name" validate:"required,alpha"`
 }
 ```
 
@@ -65,7 +65,7 @@ Validates that a string contains **only alphabetic characters and digits** (A-Z,
 ```go
 type Username struct {
     // Username can contain letters and numbers only
-    Handle string `json:"handle" pedantigo:"required,alphanum,min=3,max=20"`
+    Handle string `json:"handle" validate:"required,alphanum,min=3,max=20"`
 }
 ```
 
@@ -79,7 +79,7 @@ Validates that a string contains **only ASCII characters** (character codes 0-12
 ```go
 type APIKey struct {
     // API key must be ASCII-compatible
-    Token string `json:"token" pedantigo:"required,ascii"`
+    Token string `json:"token" validate:"required,ascii"`
 }
 ```
 
@@ -95,7 +95,7 @@ Validates that a string **contains a specific substring**.
 ```go
 type DocumentTag struct {
     // Tag must contain the word "archive"
-    Label string `json:"label" pedantigo:"required,contains=archive"`
+    Label string `json:"label" validate:"required,contains=archive"`
 }
 ```
 
@@ -109,12 +109,12 @@ Validates that a string **contains a specific Unicode character (rune)**.
 ```go
 type Email struct {
     // Email must contain @ symbol
-    Address string `json:"address" pedantigo:"required,containsrune=@"`
+    Address string `json:"address" validate:"required,containsrune=@"`
 }
 
 type Cafe struct {
     // Name must contain é
-    Name string `json:"name" pedantigo:"containsrune=é"`
+    Name string `json:"name" validate:"containsrune=é"`
 }
 ```
 
@@ -130,7 +130,7 @@ Validates that a string **does NOT contain a specific substring**.
 ```go
 type Comment struct {
     // Comment must not contain profanity
-    Text string `json:"text" pedantigo:"required,excludes=badword"`
+    Text string `json:"text" validate:"required,excludes=badword"`
 }
 ```
 
@@ -144,7 +144,7 @@ Validates that a string **starts with a specific prefix**.
 ```go
 type OrderID struct {
     // Order ID must start with "ORD-"
-    ID string `json:"id" pedantigo:"required,startswith=ORD-"`
+    ID string `json:"id" validate:"required,startswith=ORD-"`
 }
 ```
 
@@ -158,7 +158,7 @@ Validates that a string **ends with a specific suffix**.
 ```go
 type EmailAddress struct {
     // Email must end with company domain
-    Email string `json:"email" pedantigo:"required,endswith=@company.com"`
+    Email string `json:"email" validate:"required,endswith=@company.com"`
 }
 ```
 
@@ -174,7 +174,7 @@ Validates that a string is **entirely lowercase**.
 ```go
 type Hostname struct {
     // Hostname must be lowercase
-    Domain string `json:"domain" pedantigo:"required,lowercase"`
+    Domain string `json:"domain" validate:"required,lowercase"`
 }
 ```
 
@@ -188,7 +188,7 @@ Validates that a string is **entirely uppercase**.
 ```go
 type CountryCode struct {
     // Country code must be uppercase
-    Code string `json:"code" pedantigo:"required,uppercase,len=2"`
+    Code string `json:"code" validate:"required,uppercase,len=2"`
 }
 ```
 
@@ -204,7 +204,7 @@ Validates that a string has **no leading or trailing whitespace** in validation 
 ```go
 type TagName struct {
     // Tag must not have leading/trailing whitespace
-    Tag string `json:"tag" pedantigo:"required,strip_whitespace"`
+    Tag string `json:"tag" validate:"required,strip_whitespace"`
 }
 ```
 
@@ -222,17 +222,17 @@ Validates that a string matches a **custom regular expression pattern**.
 ```go
 type PhoneNumber struct {
     // Phone must match pattern (flexible for various formats)
-    Phone string `json:"phone" pedantigo:"regexp=^\\+?[0-9\\s\\-\\(\\)]+$"`
+    Phone string `json:"phone" validate:"regexp=^\\+?[0-9\\s\\-\\(\\)]+$"`
 }
 
 type Username struct {
     // Username: letters, numbers, hyphens, underscores, 3-20 chars
-    Username string `json:"username" pedantigo:"regexp=^[a-zA-Z0-9_-]{3,20}$"`
+    Username string `json:"username" validate:"regexp=^[a-zA-Z0-9_-]{3,20}$"`
 }
 
 type Zipcode struct {
     // US Zipcode: 5 or 9 digits
-    Zipcode string `json:"zipcode" pedantigo:"regexp=^\\d{5}(-\\d{4})?$"`
+    Zipcode string `json:"zipcode" validate:"regexp=^\\d{5}(-\\d{4})?$"`
 }
 ```
 
@@ -273,34 +273,34 @@ import (
 
 type UserProfile struct {
     // Username: lowercase alphanumeric, 3-20 chars, no leading spaces
-    Username string `json:"username" pedantigo:"required,lowercase,alphanum,min=3,max=20"`
+    Username string `json:"username" validate:"required,lowercase,alphanum,min=3,max=20"`
 
     // Email: valid format
-    Email string `json:"email" pedantigo:"required,email"`
+    Email string `json:"email" validate:"required,email"`
 
     // Bio: optional, max 500 chars
-    Bio string `json:"bio,omitempty" pedantigo:"max=500"`
+    Bio string `json:"bio,omitempty" validate:"max=500"`
 
     // Country: exactly 2 uppercase letters
-    Country string `json:"country" pedantigo:"required,uppercase,len=2,alpha"`
+    Country string `json:"country" validate:"required,uppercase,len=2,alpha"`
 
     // Website: optional URL starting with https
-    Website string `json:"website,omitempty" pedantigo:"url,startswith=https://"`
+    Website string `json:"website,omitempty" validate:"url,startswith=https://"`
 
     // Nickname: letters only, 2-50 chars
-    Nickname string `json:"nickname" pedantigo:"alpha,min=2,max=50"`
+    Nickname string `json:"nickname" validate:"alpha,min=2,max=50"`
 
     // Status: one of specific values
-    Status string `json:"status" pedantigo:"required,oneof=active inactive suspended"`
+    Status string `json:"status" validate:"required,oneof=active inactive suspended"`
 
     // ApiKey: 32 ASCII characters
-    ApiKey string `json:"api_key" pedantigo:"required,len=32,ascii"`
+    ApiKey string `json:"api_key" validate:"required,len=32,ascii"`
 
     // AccountID: exactly 10 digits
-    AccountID string `json:"account_id" pedantigo:"required,regexp=^\\d{10}$"`
+    AccountID string `json:"account_id" validate:"required,regexp=^\\d{10}$"`
 
     // Preferences: no leading/trailing whitespace
-    Preferences string `json:"preferences,omitempty" pedantigo:"strip_whitespace"`
+    Preferences string `json:"preferences,omitempty" validate:"strip_whitespace"`
 }
 
 func main() {
@@ -358,22 +358,22 @@ String constraints can be combined to create powerful validation rules:
 ```go
 type SecurePassword struct {
     // Must be 12+ chars, contain uppercase, numbers, special chars
-    Password string `json:"password" pedantigo:"required,min=12,regexp=^(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%])`
+    Password string `json:"password" validate:"required,min=12,regexp=^(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%])`
 }
 
 type EuropeanPhoneNumber struct {
     // Format: +CC-XXX-XXX-XXXX where CC is country code
-    Phone string `json:"phone" pedantigo:"required,regexp=^\\+\\d{1,3}-\\d{3}-\\d{3}-\\d{4}$"`
+    Phone string `json:"phone" validate:"required,regexp=^\\+\\d{1,3}-\\d{3}-\\d{3}-\\d{4}$"`
 }
 
 type FileExtension struct {
     // Must be exactly 3 chars, lowercase, representing file type
-    Extension string `json:"ext" pedantigo:"required,len=3,lowercase,alpha"`
+    Extension string `json:"ext" validate:"required,len=3,lowercase,alpha"`
 }
 
 type SlugURL struct {
     // URL-friendly slug: lowercase, hyphens, no spaces or special chars
-    Slug string `json:"slug" pedantigo:"required,lowercase,regexp=^[a-z0-9-]+$"`
+    Slug string `json:"slug" validate:"required,lowercase,regexp=^[a-z0-9-]+$"`
 }
 ```
 

--- a/docs/examples/api-validation.md
+++ b/docs/examples/api-validation.md
@@ -17,9 +17,9 @@ Pedantigo works with any Go HTTP framework. The pattern is simple:
 
 ```go
 type CreateUserRequest struct {
-    Email    string `json:"email" pedantigo:"required,email"`
-    Username string `json:"username" pedantigo:"required,min=3,max=20"`
-    Age      int    `json:"age" pedantigo:"min=18,max=120"`
+    Email    string `json:"email" validate:"required,email"`
+    Username string `json:"username" validate:"required,min=3,max=20"`
+    Age      int    `json:"age" validate:"min=18,max=120"`
 }
 
 // Works with any HTTP framework
@@ -48,9 +48,9 @@ import (
 )
 
 type CreateUserRequest struct {
-    Email    string `json:"email" pedantigo:"required,email"`
-    Username string `json:"username" pedantigo:"required,min=3,max=20"`
-    Age      int    `json:"age" pedantigo:"required,min=18,max=120"`
+    Email    string `json:"email" validate:"required,email"`
+    Username string `json:"username" validate:"required,min=3,max=20"`
+    Age      int    `json:"age" validate:"required,min=18,max=120"`
 }
 
 type ErrorResponse struct {
@@ -149,9 +149,9 @@ import (
 )
 
 type CreateUserRequest struct {
-    Email    string `json:"email" pedantigo:"required,email"`
-    Username string `json:"username" pedantigo:"required,min=3,max=20"`
-    Age      int    `json:"age" pedantigo:"required,min=18,max=120"`
+    Email    string `json:"email" validate:"required,email"`
+    Username string `json:"username" validate:"required,min=3,max=20"`
+    Age      int    `json:"age" validate:"required,min=18,max=120"`
 }
 
 type ErrorResponse struct {
@@ -224,9 +224,9 @@ import (
 )
 
 type CreateUserRequest struct {
-    Email    string `json:"email" pedantigo:"required,email"`
-    Username string `json:"username" pedantigo:"required,min=3,max=20"`
-    Age      int    `json:"age" pedantigo:"required,min=18,max=120"`
+    Email    string `json:"email" validate:"required,email"`
+    Username string `json:"username" validate:"required,min=3,max=20"`
+    Age      int    `json:"age" validate:"required,min=18,max=120"`
 }
 
 type ErrorResponse struct {
@@ -320,14 +320,14 @@ For nested structs, field paths include the full path:
 
 ```go
 type Address struct {
-    Street string `json:"street" pedantigo:"required,min=5"`
-    City   string `json:"city" pedantigo:"required,min=2"`
-    Zip    string `json:"zip" pedantigo:"required,pattern=^\\d{5}$"`
+    Street string `json:"street" validate:"required,min=5"`
+    City   string `json:"city" validate:"required,min=2"`
+    Zip    string `json:"zip" validate:"required,pattern=^\\d{5}$"`
 }
 
 type CreateUserRequest struct {
-    Email   string  `json:"email" pedantigo:"required,email"`
-    Address Address `json:"address" pedantigo:"required"`
+    Email   string  `json:"email" validate:"required,email"`
+    Address Address `json:"address" validate:"required"`
 }
 
 // Invalid request:
@@ -349,13 +349,13 @@ For validation errors in array elements, the field path includes the index:
 
 ```go
 type CreateOrderRequest struct {
-    Items []OrderItem `json:"items" pedantigo:"required,minItems=1,maxItems=100"`
+    Items []OrderItem `json:"items" validate:"required,minItems=1,maxItems=100"`
 }
 
 type OrderItem struct {
-    ProductID string `json:"product_id" pedantigo:"required,uuid"`
-    Quantity  int    `json:"quantity" pedantigo:"required,min=1,max=999"`
-    Price     float64 `json:"price" pedantigo:"required,gt=0"`
+    ProductID string `json:"product_id" validate:"required,uuid"`
+    Quantity  int    `json:"quantity" validate:"required,min=1,max=999"`
+    Price     float64 `json:"price" validate:"required,gt=0"`
 }
 
 // Error paths:
@@ -381,25 +381,25 @@ import (
 
 // Request types
 type CreateProductRequest struct {
-    Name        string  `json:"name" pedantigo:"required,min=1,max=200"`
-    Description string  `json:"description" pedantigo:"max=2000"`
-    Price       float64 `json:"price" pedantigo:"required,gt=0"`
-    SKU         string  `json:"sku" pedantigo:"required,pattern=^[A-Z0-9-]+$"`
+    Name        string  `json:"name" validate:"required,min=1,max=200"`
+    Description string  `json:"description" validate:"max=2000"`
+    Price       float64 `json:"price" validate:"required,gt=0"`
+    SKU         string  `json:"sku" validate:"required,pattern=^[A-Z0-9-]+$"`
 }
 
 // Response types
 type Product struct {
-    ID          string  `json:"id" pedantigo:"required,uuid"`
-    Name        string  `json:"name" pedantigo:"required"`
+    ID          string  `json:"id" validate:"required,uuid"`
+    Name        string  `json:"name" validate:"required"`
     Description string  `json:"description"`
-    Price       float64 `json:"price" pedantigo:"required,gt=0"`
-    SKU         string  `json:"sku" pedantigo:"required"`
-    CreatedAt   string  `json:"created_at" pedantigo:"required,datetime"`
+    Price       float64 `json:"price" validate:"required,gt=0"`
+    SKU         string  `json:"sku" validate:"required"`
+    CreatedAt   string  `json:"created_at" validate:"required,datetime"`
 }
 
 type CreateProductResponse struct {
-    Success bool    `json:"success" pedantigo:"required"`
-    Product Product `json:"product" pedantigo:"required"`
+    Success bool    `json:"success" validate:"required"`
+    Product Product `json:"product" validate:"required"`
     Message string  `json:"message"`
 }
 
@@ -472,21 +472,21 @@ import (
 )
 
 type CreateUserRequest struct {
-    Email    string `json:"email" pedantigo:"required,email"`
-    Username string `json:"username" pedantigo:"required,min=3,max=20"`
-    Age      int    `json:"age" pedantigo:"required,min=18,max=120"`
+    Email    string `json:"email" validate:"required,email"`
+    Username string `json:"username" validate:"required,min=3,max=20"`
+    Age      int    `json:"age" validate:"required,min=18,max=120"`
 }
 
 type User struct {
-    ID        string `json:"id" pedantigo:"required,uuid"`
-    Email     string `json:"email" pedantigo:"required,email"`
-    Username  string `json:"username" pedantigo:"required"`
-    Age       int    `json:"age" pedantigo:"required"`
-    CreatedAt string `json:"created_at" pedantigo:"required,datetime"`
+    ID        string `json:"id" validate:"required,uuid"`
+    Email     string `json:"email" validate:"required,email"`
+    Username  string `json:"username" validate:"required"`
+    Age       int    `json:"age" validate:"required"`
+    CreatedAt string `json:"created_at" validate:"required,datetime"`
 }
 
 type APIResponse struct {
-    Success bool   `json:"success" pedantigo:"required"`
+    Success bool   `json:"success" validate:"required"`
     Data    *User  `json:"data"`
     Message string `json:"message"`
 }
@@ -658,38 +658,38 @@ import (
 
 // Request DTOs
 type CreateProductRequest struct {
-    Name        string  `json:"name" pedantigo:"required,min=1,max=200"`
-    Description string  `json:"description" pedantigo:"max=2000"`
-    Price       float64 `json:"price" pedantigo:"required,gt=0"`
-    StockQty    int     `json:"stock_qty" pedantigo:"required,min=0"`
+    Name        string  `json:"name" validate:"required,min=1,max=200"`
+    Description string  `json:"description" validate:"max=2000"`
+    Price       float64 `json:"price" validate:"required,gt=0"`
+    StockQty    int     `json:"stock_qty" validate:"required,min=0"`
 }
 
 type UpdateProductRequest struct {
-    Name        *string  `json:"name" pedantigo:"min=1,max=200"`
-    Description *string  `json:"description" pedantigo:"max=2000"`
-    Price       *float64 `json:"price" pedantigo:"gt=0"`
-    StockQty    *int     `json:"stock_qty" pedantigo:"min=0"`
+    Name        *string  `json:"name" validate:"min=1,max=200"`
+    Description *string  `json:"description" validate:"max=2000"`
+    Price       *float64 `json:"price" validate:"gt=0"`
+    StockQty    *int     `json:"stock_qty" validate:"min=0"`
 }
 
 // Response DTOs
 type Product struct {
-    ID          string  `json:"id" pedantigo:"required,uuid"`
-    Name        string  `json:"name" pedantigo:"required"`
+    ID          string  `json:"id" validate:"required,uuid"`
+    Name        string  `json:"name" validate:"required"`
     Description string  `json:"description"`
-    Price       float64 `json:"price" pedantigo:"required,gt=0"`
-    StockQty    int     `json:"stock_qty" pedantigo:"required,min=0"`
-    CreatedAt   string  `json:"created_at" pedantigo:"required"`
+    Price       float64 `json:"price" validate:"required,gt=0"`
+    StockQty    int     `json:"stock_qty" validate:"required,min=0"`
+    CreatedAt   string  `json:"created_at" validate:"required"`
 }
 
 type ListResponse struct {
-    Success bool      `json:"success" pedantigo:"required"`
-    Data    []Product `json:"data" pedantigo:"required"`
-    Count   int       `json:"count" pedantigo:"required,min=0"`
+    Success bool      `json:"success" validate:"required"`
+    Data    []Product `json:"data" validate:"required"`
+    Count   int       `json:"count" validate:"required,min=0"`
 }
 
 type SingleResponse struct {
-    Success bool    `json:"success" pedantigo:"required"`
-    Data    Product `json:"data" pedantigo:"required"`
+    Success bool    `json:"success" validate:"required"`
+    Data    Product `json:"data" validate:"required"`
 }
 
 // Database (simulated)

--- a/docs/examples/basic.md
+++ b/docs/examples/basic.md
@@ -22,10 +22,10 @@ import (
 )
 
 type User struct {
-    Username            string `json:"username" pedantigo:"required,alphanum,min=3,max=20"`
-    Email               string `json:"email" pedantigo:"required,email"`
-    Password            string `json:"password" pedantigo:"required,min=8"`
-    PasswordConfirm     string `json:"password_confirm" pedantigo:"required"`
+    Username            string `json:"username" validate:"required,alphanum,min=3,max=20"`
+    Email               string `json:"email" validate:"required,email"`
+    Password            string `json:"password" validate:"required,min=8"`
+    PasswordConfirm     string `json:"password_confirm" validate:"required"`
 }
 
 func main() {
@@ -103,11 +103,11 @@ import (
 )
 
 type Product struct {
-    Name     string  `json:"name" pedantigo:"required,max=200"`
-    Price    float64 `json:"price" pedantigo:"required,positive"`
-    Quantity int     `json:"quantity" pedantigo:"required,gte=0"`
-    Category string  `json:"category" pedantigo:"required,oneof=electronics|clothing|books|home"`
-    SKU      string  `json:"sku" pedantigo:"required,pattern=^[A-Z0-9]{3}-[A-Z0-9]{3}-[A-Z0-9]{4}$"`
+    Name     string  `json:"name" validate:"required,max=200"`
+    Price    float64 `json:"price" validate:"required,positive"`
+    Quantity int     `json:"quantity" validate:"required,gte=0"`
+    Category string  `json:"category" validate:"required,oneof=electronics|clothing|books|home"`
+    SKU      string  `json:"sku" validate:"required,pattern=^[A-Z0-9]{3}-[A-Z0-9]{3}-[A-Z0-9]{4}$"`
 }
 
 func main() {
@@ -205,19 +205,19 @@ import (
 )
 
 type Config struct {
-    Server  ServerConfig  `json:"server" pedantigo:"required"`
-    API     APIConfig     `json:"api" pedantigo:"required"`
-    Timeout time.Duration `json:"timeout" pedantigo:"required,positive"`
+    Server  ServerConfig  `json:"server" validate:"required"`
+    API     APIConfig     `json:"api" validate:"required"`
+    Timeout time.Duration `json:"timeout" validate:"required,positive"`
 }
 
 type ServerConfig struct {
-    Host string `json:"host" pedantigo:"required,hostname"`
-    Port int    `json:"port" pedantigo:"required,port"`
+    Host string `json:"host" validate:"required,hostname"`
+    Port int    `json:"port" validate:"required,port"`
 }
 
 type APIConfig struct {
-    Key         string `json:"key" pedantigo:"required,min=32"`
-    Environment string `json:"env" pedantigo:"required,oneof=development|staging|production"`
+    Key         string `json:"key" validate:"required,min=32"`
+    Environment string `json:"env" validate:"required,oneof=development|staging|production"`
 }
 
 func main() {
@@ -309,11 +309,11 @@ import (
 )
 
 type BlogPost struct {
-    Title       string    `json:"title" pedantigo:"required,min=5,max=200"`
-    Content     string    `json:"content" pedantigo:"required,min=100"`
-    Author      string    `json:"author" pedantigo:"required,email"`
-    Tags        []string  `json:"tags" pedantigo:"required,min=1,max=10,unique"`
-    PublishedAt *time.Time `json:"published_at,omitempty" pedantigo:""`
+    Title       string    `json:"title" validate:"required,min=5,max=200"`
+    Content     string    `json:"content" validate:"required,min=100"`
+    Author      string    `json:"author" validate:"required,email"`
+    Tags        []string  `json:"tags" validate:"required,min=1,max=10,unique"`
+    PublishedAt *time.Time `json:"published_at,omitempty"`
 }
 
 func main() {
@@ -414,11 +414,11 @@ import (
 )
 
 type Address struct {
-    Street  string `json:"street" pedantigo:"required,min=5,max=100"`
-    City    string `json:"city" pedantigo:"required,alpha,min=2"`
-    State   string `json:"state" pedantigo:"required,len=2,alpha"`
-    ZipCode string `json:"zip_code" pedantigo:"required,pattern=^[0-9]{5}(-[0-9]{4})?$"`
-    Country string `json:"country" pedantigo:"required,iso3166_alpha2"`
+    Street  string `json:"street" validate:"required,min=5,max=100"`
+    City    string `json:"city" validate:"required,alpha,min=2"`
+    State   string `json:"state" validate:"required,len=2,alpha"`
+    ZipCode string `json:"zip_code" validate:"required,pattern=^[0-9]{5}(-[0-9]{4})?$"`
+    Country string `json:"country" validate:"required,iso3166_alpha2"`
 }
 
 func main() {
@@ -546,11 +546,11 @@ import (
 )
 
 type Payment struct {
-    Amount      float64 `json:"amount" pedantigo:"required,positive"`
-    Currency    string  `json:"currency" pedantigo:"required,iso4217"`
-    CardNumber  string  `json:"card_number" pedantigo:"required,credit_card"`
-    CVV         string  `json:"cvv" pedantigo:"required,oneof=len:3|len:4"`
-    CardHolder  string  `json:"card_holder" pedantigo:"required,alpha"`
+    Amount      float64 `json:"amount" validate:"required,positive"`
+    Currency    string  `json:"currency" validate:"required,iso4217"`
+    CardNumber  string  `json:"card_number" validate:"required,credit_card"`
+    CVV         string  `json:"cvv" validate:"required,oneof=len:3|len:4"`
+    CardHolder  string  `json:"card_holder" validate:"required,alpha"`
 }
 
 func main() {

--- a/docs/examples/llm-streaming.md
+++ b/docs/examples/llm-streaming.md
@@ -30,12 +30,12 @@ import (
 )
 
 type ToolCall struct {
-    Name   string         `json:"name" pedantigo:"required"`
-    Args   map[string]any `json:"args" pedantigo:"required"`
+    Name   string         `json:"name" validate:"required"`
+    Args   map[string]any `json:"args" validate:"required"`
 }
 
 type FunctionResponse struct {
-    ToolCalls []ToolCall `json:"tool_calls" pedantigo:"min_items=1,max_items=5"`
+    ToolCalls []ToolCall `json:"tool_calls" validate:"min_items=1,max_items=5"`
 }
 
 func main() {
@@ -75,9 +75,9 @@ Anthropic's API streams text and structured outputs. Validate multi-field respon
 
 ```go
 type AgentResponse struct {
-    Thought string `json:"thought" pedantigo:"required,min=10"`
-    Action  string `json:"action" pedantigo:"required,oneof=search calculate respond think"`
-    Query   string `json:"query" pedantigo:"min=1,max=500"`
+    Thought string `json:"thought" validate:"required,min=10"`
+    Action  string `json:"action" validate:"required,oneof=search calculate respond think"`
+    Query   string `json:"query" validate:"min=1,max=500"`
     Result  string `json:"result"`
 }
 
@@ -118,10 +118,10 @@ Include the JSON schema in your LLM prompt so it knows the expected format:
 
 ```go
 type ExtractedData struct {
-    Title       string   `json:"title" pedantigo:"required,max=200"`
-    Description string   `json:"description" pedantigo:"max=2000"`
-    Tags        []string `json:"tags" pedantigo:"max_items=10"`
-    Confidence  float64  `json:"confidence" pedantigo:"ge=0,le=1"`
+    Title       string   `json:"title" validate:"required,max=200"`
+    Description string   `json:"description" validate:"max=2000"`
+    Tags        []string `json:"tags" validate:"max_items=10"`
+    Confidence  float64  `json:"confidence" validate:"ge=0,le=1"`
 }
 
 func getSystemPrompt() string {
@@ -149,8 +149,8 @@ LLMs occasionally generate invalid JSON. Implement graceful error handling:
 
 ```go
 type ExtractionResult struct {
-    Content string `json:"content" pedantigo:"required"`
-    Score   float64 `json:"score" pedantigo:"ge=0,le=1"`
+    Content string `json:"content" validate:"required"`
+    Score   float64 `json:"score" validate:"ge=0,le=1"`
 }
 
 func extractWithRetry(llm *LLMClient, text string, maxRetries int) (*ExtractionResult, error) {
@@ -191,19 +191,19 @@ For agents that return different response types based on an action field, use di
 
 ```go
 type SearchAction struct {
-    Action string   `json:"action" pedantigo:"required,eq=search"`
-    Query  string   `json:"query" pedantigo:"required,min=1"`
-    Limit  int      `json:"limit" pedantigo:"min=1,max=100"`
+    Action string   `json:"action" validate:"required,eq=search"`
+    Query  string   `json:"query" validate:"required,min=1"`
+    Limit  int      `json:"limit" validate:"min=1,max=100"`
 }
 
 type CalculateAction struct {
-    Action     string `json:"action" pedantigo:"required,eq=calculate"`
-    Expression string `json:"expression" pedantigo:"required"`
+    Action     string `json:"action" validate:"required,eq=calculate"`
+    Expression string `json:"expression" validate:"required"`
 }
 
 type RespondAction struct {
-    Action   string `json:"action" pedantigo:"required,eq=respond"`
-    Response string `json:"response" pedantigo:"required,min=1"`
+    Action   string `json:"action" validate:"required,eq=respond"`
+    Response string `json:"response" validate:"required,min=1"`
 }
 
 func processAgentAction(jsonData []byte) {
@@ -284,9 +284,9 @@ A full example showing an agent that streams responses and validates them:
 
 ```go
 type AgentStep struct {
-    Reasoning string `json:"reasoning" pedantigo:"required,min=5"`
-    Action    string `json:"action" pedantigo:"required,oneof=think search call respond complete"`
-    Details   string `json:"details" pedantigo:"max=1000"`
+    Reasoning string `json:"reasoning" validate:"required,min=5"`
+    Action    string `json:"action" validate:"required,oneof=think search call respond complete"`
+    Details   string `json:"details" validate:"max=1000"`
 }
 
 type AgentLoop struct {
@@ -360,9 +360,9 @@ LLMs may include fields you didn't request. Use [ExtraAllow](../api/initializati
 
 ```go
 type LLMResponse struct {
-    Answer     string         `json:"answer" pedantigo:"required"`
+    Answer     string         `json:"answer" validate:"required"`
     Confidence float64        `json:"confidence"`
-    Extras     map[string]any `json:"-" pedantigo:"extra_fields"` // Captures unexpected fields
+    Extras     map[string]any `json:"-" validate:"extra_fields"` // Captures unexpected fields
 }
 
 func processLLMOutput(output []byte) {

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -27,7 +27,7 @@ import (
 )
 
 type User struct {
-    Email string `json:"email" pedantigo:"required,email"`
+    Email string `json:"email" validate:"required,email"`
 }
 
 func main() {

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -25,10 +25,10 @@ package main
 import "github.com/smrutai/pedantigo"
 
 type User struct {
-    Email    string `json:"email" pedantigo:"required,email"`
-    Age      int    `json:"age" pedantigo:"required,min=18,max=120"`
-    Username string `json:"username" pedantigo:"required,min=3,max=20"`
-    Website  string `json:"website,omitempty" pedantigo:"url"`
+    Email    string `json:"email" validate:"required,email"`
+    Age      int    `json:"age" validate:"required,min=18,max=120"`
+    Username string `json:"username" validate:"required,min=3,max=20"`
+    Website  string `json:"website,omitempty" validate:"url"`
 }
 ```
 
@@ -176,18 +176,18 @@ Field: username, Error: field is required
 
 | Constraint | Example | Description |
 |------------|---------|-------------|
-| `required` | `pedantigo:"required"` | Field must be present (not missing) |
-| `email` | `pedantigo:"email"` | Must be valid email format |
-| `url` | `pedantigo:"url"` | Must be valid URL |
-| `min`/`max` | `pedantigo:"min=0,max=100"` | Numeric range (int, float) |
-| `minLength`/`maxLength` | `pedantigo:"minLength=3,maxLength=20"` | String length |
-| `minItems`/`maxItems` | `pedantigo:"minItems=1,maxItems=10"` | Array/slice size |
-| `pattern` | `pedantigo:"pattern=^[a-z]+$"` | Regex pattern match |
-| `oneof` | `pedantigo:"oneof=red green blue"` | Must be one of values |
-| `uuid` | `pedantigo:"uuid"` | Valid UUID format |
-| `alpha` | `pedantigo:"alpha"` | Only letters |
-| `alphanumeric` | `pedantigo:"alphanumeric"` | Letters and numbers only |
-| `numeric` | `pedantigo:"numeric"` | Only numbers (string) |
+| `required` | `validate:"required"` | Field must be present (not missing) |
+| `email` | `validate:"email"` | Must be valid email format |
+| `url` | `validate:"url"` | Must be valid URL |
+| `min`/`max` | `validate:"min=0,max=100"` | Numeric range (int, float) |
+| `minLength`/`maxLength` | `validate:"minLength=3,maxLength=20"` | String length |
+| `minItems`/`maxItems` | `validate:"minItems=1,maxItems=10"` | Array/slice size |
+| `pattern` | `validate:"pattern=^[a-z]+$"` | Regex pattern match |
+| `oneof` | `validate:"oneof=red green blue"` | Must be one of values |
+| `uuid` | `validate:"uuid"` | Valid UUID format |
+| `alpha` | `validate:"alpha"` | Only letters |
+| `alphanumeric` | `validate:"alphanumeric"` | Letters and numbers only |
+| `numeric` | `validate:"numeric"` | Only numbers (string) |
 
 See the [Constraints Reference](/docs/concepts/constraints) for the complete list.
 
@@ -205,11 +205,11 @@ import (
 )
 
 type User struct {
-    Email    string `json:"email" pedantigo:"required,email"`
-    Age      int    `json:"age" pedantigo:"required,min=18,max=120"`
-    Username string `json:"username" pedantigo:"required,minLength=3,maxLength=20,alphanumeric"`
-    Website  string `json:"website,omitempty" pedantigo:"url"`
-    Role     string `json:"role" pedantigo:"required,oneof=admin user guest"`
+    Email    string `json:"email" validate:"required,email"`
+    Age      int    `json:"age" validate:"required,min=18,max=120"`
+    Username string `json:"username" validate:"required,minLength=3,maxLength=20,alphanumeric"`
+    Website  string `json:"website,omitempty" validate:"url"`
+    Role     string `json:"role" validate:"required,oneof=admin user guest"`
 }
 
 func main() {

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -8,6 +8,10 @@ import TabItem from '@theme/TabItem';
 
 # Welcome to Pedantigo
 
+:::note v2: default tag changed to `validate`
+This is v2 documentation. The default struct tag changed from `pedantigo` to `validate` — no other behavior changed. If you're upgrading from v1, read the [migration guide](./migration/v1-to-v2) first.
+:::
+
 **Type-safe JSON validation for Go, inspired by Pydantic**
 
 Pedantigo brings Pydantic's elegant validation patterns to Go with a reflection-based design that feels natural in the Go ecosystem.
@@ -30,7 +34,7 @@ package main
 
 import (
     "fmt"
-    "github.com/smrutai/pedantigo"
+    "github.com/SmrutAI/pedantigo/v2"
 )
 
 type User struct {

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -34,9 +34,9 @@ import (
 )
 
 type User struct {
-    Email string `json:"email" pedantigo:"required,email"`
-    Age   int    `json:"age" pedantigo:"min=18,max=120"`
-    Role  string `json:"role" pedantigo:"oneof=admin user guest"`
+    Email string `json:"email" validate:"required,email"`
+    Age   int    `json:"age" validate:"min=18,max=120"`
+    Role  string `json:"role" validate:"oneof=admin user guest"`
 }
 
 func main() {

--- a/docs/migration/from-validator.md
+++ b/docs/migration/from-validator.md
@@ -1,135 +1,59 @@
 ---
 sidebar_position: 1
 title: From go-playground/validator
-description: Step-by-step guide to migrate from go-playground/validator to Pedantigo
+description: What actually changes when migrating from go-playground/validator to Pedantigo
 ---
 
 # Migrating from go-playground/validator
 
-This guide helps you migrate from [go-playground/validator](https://github.com/go-playground/validator) to Pedantigo.
+Pedantigo's default struct tag is `validate` — the same tag name go-playground/validator uses. If you're migrating, **your existing struct tags need no changes.** Tag syntax is ~127/147 identical (see [API Parity](./api-parity.md)), and any validator-only tag pedantigo doesn't recognize (`omitnil`, `structonly`, etc.) is silently ignored rather than erroring.
+
+Migration is two steps. Step 1 gets you running with a near-rename; step 2 is an optional, later upgrade for high-throughput code paths.
+
+**Caution:** if your codebase already has unrelated `validate:"..."` tags on structs (leftover from another library, or dead annotations), Pedantigo will now read and enforce them by default.
 
 ---
 
-## Quick Migration (One Line)
-
-For most codebases, migration requires only one line:
-
-```go
-func init() {
-    pedantigo.SetTagName("validate")
-}
-```
-
-This tells Pedantigo to read your existing `validate:"..."` struct tags instead of `pedantigo:"..."`.
-
-Your existing structs work unchanged:
-
-```go
-type User struct {
-    Email string `json:"email" validate:"required,email"`
-    Age   int    `json:"age" validate:"min=18,max=120"`
-}
-
-// Works with Pedantigo
-user, err := pedantigo.Unmarshal[User](jsonData)
-```
-
----
-
-## Supported Tags (Zero Changes Needed)
-
-These validator tags work identically in Pedantigo:
-
-### Core Constraints
-`required`, `min`, `max`, `len`, `eq`, `ne`, `gt`, `gte`, `lt`, `lte`
-
-### String Constraints
-`email`, `url`, `uri`, `uuid`, `uuid3`, `uuid4`, `uuid5`, `alpha`, `alphanum`, `alphaunicode`, `alphanumunicode`, `numeric`, `number`, `hexadecimal`, `ascii`, `printascii`, `multibyte`, `lowercase`, `uppercase`, `contains`, `excludes`, `startswith`, `endswith`, `startsnotwith`, `endsnotwith`, `containsany`, `containsrune`, `excludesall`, `excludesrune`, `eq_ignore_case`, `ne_ignore_case`
-
-### Enum/Choice
-`oneof`, `oneofci`
-
-### Field Comparisons
-`eqfield`, `nefield`, `gtfield`, `gtefield`, `ltfield`, `ltefield`, `eqcsfield`, `necsfield`, `gtcsfield`, `gtecsfield`, `ltcsfield`, `ltecsfield`
-
-### Conditional Validation
-`required_if`, `required_unless`, `required_with`, `required_without`, `required_with_all`, `required_without_all`, `excluded_if`, `excluded_unless`, `excluded_with`, `excluded_without`, `excluded_with_all`, `excluded_without_all`, `skip_unless`
-
-### Network
-`ip`, `ipv4`, `ipv6`, `cidr`, `cidrv4`, `cidrv6`, `mac`, `hostname`, `hostname_rfc1123`, `fqdn`, `tcp_addr`, `udp_addr`, `hostname_port`, `http_url`, `https_url`
-
-### Format Validators
-`datetime`, `timezone`, `credit_card`, `isbn`, `isbn10`, `isbn13`, `issn`, `ssn`, `ein`, `e164`, `base64`, `base64url`, `base64rawurl`, `base32`, `datauri`, `urn_rfc2141`, `json`, `jwt`, `html`, `hexcolor`, `rgb`, `rgba`, `hsl`, `hsla`, `latitude`, `longitude`, `md4`, `md5`, `sha256`, `sha384`, `sha512`, `mongodb`, `cron`, `semver`, `ulid`, `luhn_checksum`, `bitcoin_addr`, `bitcoin_addr_bech32`, `ethereum_addr`, `image`
-
-### ISO Codes
-`iso3166_1_alpha2`, `iso3166_1_alpha3`, `iso3166_1_alpha_numeric`, `iso4217`, `bcp47_language_tag`, `postcode_iso3166_alpha2`
-
-### Collections
-`dive`, `unique`
-
-### OR Operator
-`hexcolor|rgb|rgba` (validates if ANY matches)
-
-### Aliases
-`iscolor` (expands to `hexcolor|rgb|rgba|hsl|hsla`)
-
----
-
-## Tags You Can Remove
-
-These validator tags are **not needed** in Pedantigo:
-
-| Tag             | Why Not Needed                                                                        |
-|-----------------|---------------------------------------------------------------------------------------|
-| `omitnil`       | Nil pointers are handled automatically.                                               |
-| `omitzero`      | Zero values skip validation unless `required`.                                        |
-| `-`             | Simply don't add a tag.                                                               |
-| `structonly`    | Not needed - Pedantigo validates all fields by default.                               |
-| `nostructlevel` | Not needed.                                                                           |
-| `isdefault`     | Not needed - check for zero value in code.                                            |
-
-### `omitempty` — Supported Natively with Explicit Semantics
-
-Unlike `go-playground/validator`, where `omitempty` is a special-cased tag name, Pedantigo supports `omitempty` as a first-class **validation constraint** in the `pedantigo` tag. The behaviour is explicit and predictable:
-
-- **Regular constraints** (`min`, `max`, `oneof`, `email`, etc.) are skipped when the field is at its zero value.
-- **Cross-field constraints** (`required_with`, `required_if`, `eqfield`, etc.) always run, even for zero-value fields.
+## Step 1: Switch to the Simple API
 
 ```go
 // go-playground/validator
-Email string `validate:"omitempty,email"`
+validate := validator.New()
+err := validate.Struct(user)
 
-// pedantigo — omitempty is a real constraint with the same effect for this case
-Email string `pedantigo:"omitempty,email"`
-
-// But the behavior is now explicit: if Email is "", email validation is skipped.
-// If Email is "invalid", email validation runs and fails.
+// pedantigo Simple API — drop-in, no setup (internally cached per type via sync.Map)
+err := pedantigo.Validate(user)
+// or, to parse + validate in one step:
+user, err := pedantigo.Unmarshal[User](jsonBytes)
 ```
 
-If a field was previously tagged with `validate:"omitempty,email"` only to suppress errors on empty strings, you can migrate it as-is. If the intent was simply that the field is optional with no format constraint, remove the constraint entirely:
+This is a near-rename: no validator to construct, no cache to manage. Benchmarked cost is a ~200ns `sync.Map` lookup per call, ~2-5µs total with unmarshal — negligible below roughly 100k req/sec. This is the recommended default for 99% of applications ([full benchmarks](/docs/advanced/performance)).
+
+## Step 2 (optional): Upgrade to the Core API for hot paths
 
 ```go
-// No constraint needed — optional field, no format check
-Notes string `json:"notes,omitempty"`
+// Declare once, at package/startup scope
+var userValidator = pedantigo.New[User]()
+
+// Call directly — skips the Simple API's cache lookup
+err := userValidator.Validate(user)
+user, err := userValidator.Unmarshal(jsonBytes)
+```
+
+Benchmarked saving is ~200ns/call (the `sync.Map` lookup Step 1 pays on every call). Only worth it if profiling shows that lookup in a flame graph — the performance guide's own recommendation is "profile first." Everything else (tags, custom validators, `omitempty`, cross-field constraints) behaves identically between the Simple and Core API; only the construction call-site changes.
+
+## Behavior difference: `omitempty` is a real constraint, not a parser special case
+
+- **Regular constraints** (`min`, `max`, `oneof`, `email`, etc.) are skipped when the field is at its zero value — same effect as validator.
+- **Cross-field constraints** (`required_with`, `required_if`, `eqfield`, etc.) always run, even for zero-value fields — this is the one behavioral difference to test for.
+
+```go
+Email string `validate:"omitempty,email"` // identical effect in both libraries
 ```
 
 See [omitempty as a Validation Constraint](/docs/api/initialization#pedantigo-omitempty) for the full reference.
 
----
-
-## Custom Validator Registration
-
-### RegisterAlias
-
-```go
-// validator
-validate.RegisterAlias("is_active", "oneof=active enabled")
-
-// pedantigo (identical)
-pedantigo.RegisterAlias("is_active", "oneof=active enabled")
-```
-
-### Custom Validators
+## API difference: custom validator registration signatures
 
 ```go
 // validator
@@ -140,6 +64,28 @@ pedantigo.RegisterConstraint("custom", func(value string) (constraints.Constrain
     return &myCustomConstraint{}, true
 })
 ```
+
+---
+
+## Tags that are safe no-ops
+
+These validator-only tags are silently ignored by pedantigo — harmless to leave, but fine to delete for clarity:
+
+`omitnil`, `omitzero`, `-`, `structonly`, `nostructlevel`, `isdefault`. (See "Behavior difference" above for `omitempty`, which is not in this list.)
+
+---
+
+## RegisterAlias
+
+```go
+// validator
+validate.RegisterAlias("is_active", "oneof=active enabled")
+
+// pedantigo (identical)
+pedantigo.RegisterAlias("is_active", "oneof=active enabled")
+```
+
+(See "API difference" above for custom validator registration via `RegisterConstraint`.)
 
 ---
 
@@ -220,39 +166,12 @@ Pedantigo provides features not available in validator:
 
 ---
 
-## Step-by-Step Migration
+## Checklist
 
-1. **Add the tag override:**
-   ```go
-   func init() {
-       pedantigo.SetTagName("validate")
-   }
-   ```
-
-2. **Replace validation calls:**
-   ```go
-   // Before (validator)
-   validate := validator.New()
-   err := validate.Struct(user)
-
-   // After (pedantigo)
-   user, err := pedantigo.Unmarshal[User](jsonData)
-   // or
-   err := pedantigo.Validate(&user)
-   ```
-
-3. **Remove unnecessary tags:**
-   - Delete `omitnil`, `omitzero` — handled automatically by Pedantigo
-   - Delete `-` tags (just remove the tag entirely)
-   - For `omitempty`: keep it if you want explicit zero-value skip semantics (see [omitempty as a Validation Constraint](/docs/api/initialization#pedantigo-omitempty)); remove it if the field is simply optional with no format constraint
-
-4. **Test your structs:**
-   ```go
-   go test ./...
-   ```
-
-5. **Optional: Migrate tag name:**
-   Once validated, you can gradually rename `validate` to `pedantigo` tags if desired.
+- [ ] Swap `validator.New()` + `.Struct()` calls for the Simple API (Step 1) — struct tags need no edits
+- [ ] Run `go test ./...` and confirm behavior on zero-value fields with cross-field constraints (the one behavioral difference — see above)
+- [ ] Delete any now-unnecessary validator-only tags for clarity (optional — they're harmless no-ops either way)
+- [ ] Profile before considering Step 2 (Core API) — only relevant at high request volume
 
 ---
 

--- a/docs/migration/v1-to-v2.md
+++ b/docs/migration/v1-to-v2.md
@@ -1,0 +1,79 @@
+---
+sidebar_position: 3
+title: v1 to v2
+description: What changed in Pedantigo v2 and how to upgrade
+---
+
+# Migrating from v1 to v2
+
+Pedantigo v2 changes the **default struct tag** from `pedantigo` to `validate`. This is the only breaking change in v2 — everything else (constraint syntax, the Simple API, the Core API) is unchanged.
+
+---
+
+## Why this changed
+
+`validate` is the tag name used by [go-playground/validator](https://github.com/go-playground/validator), the most widely used Go validation library, and Pedantigo already tracks its constraint syntax closely. Matching the tag name too means structs written for that ecosystem now work under Pedantigo with zero tag edits.
+
+It also makes Pedantigo-validated structs visible to tooling that reads `validate` tags. [swaggo/swag](https://github.com/swaggo/swag), the standard tool for generating OpenAPI specs from Go source, reads `validate:"required"` to mark fields required (and has partial support for `oneof`/`min`/`max`). A struct tagged `pedantigo:"..."` was invisible to swag; the same struct tagged `validate:"..."` now produces a more accurate OpenAPI spec, and by extension more accurate generated client SDKs, with no extra annotation work.
+
+---
+
+## What breaks
+
+If your structs rely on the implicit default — no `SetTagName()` call, tags written as `pedantigo:"..."` — upgrading to v2 does **not** produce a compile error or a panic. It fails silently: Pedantigo v2 looks for `validate` tags by default, finds none on your fields, and treats them as unconstrained. Validation that used to run stops running, with no error to signal it.
+
+This is the dangerous case. Audit for it before upgrading — search your codebase for `pedantigo:"` tags.
+
+**Caution, the reverse case:** if your codebase already has unrelated `validate:"..."` tags on structs — left over from a different library, or dead annotations — Pedantigo v2 will now read and enforce them by default. Check for this too.
+
+---
+
+## Import path
+
+Per [Go's module versioning rules](https://go.dev/ref/mod), a v2+ release requires a new import path:
+
+```go
+// v1
+import "github.com/SmrutAI/pedantigo"
+
+// v2
+import "github.com/SmrutAI/pedantigo/v2"
+```
+
+```bash
+go get github.com/SmrutAI/pedantigo/v2
+```
+
+v1 (`v1.1.4` and earlier) remains available and frozen at its last tag — no further v1.x.x patches are planned. There is no forced upgrade timeline; move to v2 when ready.
+
+---
+
+## How to migrate
+
+Pick one:
+
+**Option A — rename your tags (recommended).** Change `pedantigo:"..."` to `validate:"..."` throughout your structs. This aligns with the new default and the ecosystem-compatibility benefit above.
+
+```go
+// Before
+Email string `json:"email" pedantigo:"required,email"`
+
+// After
+Email string `json:"email" validate:"required,email"`
+```
+
+**Option B — keep your tags, override the default.** Call `SetTagName("pedantigo")` once, before creating any validator, to preserve v1 behavior without touching your structs:
+
+```go
+func init() {
+    pedantigo.SetTagName("pedantigo")
+}
+```
+
+Option A is the better long-term choice — it gets you the tooling compatibility this release is for. Option B is a valid stopgap if you need to defer the tag rename.
+
+---
+
+## Everything else is unchanged
+
+Constraint syntax, the Simple API (`pedantigo.Unmarshal`, `pedantigo.Validate`), the Core API (`pedantigo.New[T]()`), schema generation, and custom validator registration all work exactly as they did in v1. This is a one-line-of-behavior change, not a rewrite.

--- a/documents/UNSUPPORTED_FEATURES.md
+++ b/documents/UNSUPPORTED_FEATURES.md
@@ -230,9 +230,9 @@ In Go, struct tags allow ONE type to serve multiple purposes:
 ```go
 // GORM, JSON, and Pedantigo use the SAME struct
 type User struct {
-    ID    uint   `gorm:"primaryKey" json:"id" pedantigo:"required"`
-    Name  string `gorm:"column:name" json:"name" pedantigo:"min=1,max=100"`
-    Email string `gorm:"uniqueIndex" json:"email" pedantigo:"required,email"`
+    ID    uint   `gorm:"primaryKey" json:"id" validate:"required"`
+    Name  string `gorm:"column:name" json:"name" validate:"min=1,max=100"`
+    Email string `gorm:"uniqueIndex" json:"email" validate:"required,email"`
 }
 
 // Query from database
@@ -367,8 +367,8 @@ validator := pedantigo.New[[]User]()
 ```go
 type Outer struct {
     Inner Inner
-    Max   int `pedantigo:"gtfield=Inner.Value"`  // Compare across nested structs
-    Check int `pedantigo:"eqfield=Inner.MinValue"` // Works with deep nesting too
+    Max   int `validate:"gtfield=Inner.Value"`  // Compare across nested structs
+    Check int `validate:"eqfield=Inner.MinValue"` // Works with deep nesting too
 }
 ```
 
@@ -401,7 +401,7 @@ validate.RegisterValidationCtx("custom", func(ctx context.Context, fl validator.
 ```go
 type Request struct {
     UserID string  // Include context as field
-    Data   string `pedantigo:"required"`
+    Data   string `validate:"required"`
 }
 
 func (r *Request) Validate() error {

--- a/documents/nuances/other_nuances.md
+++ b/documents/nuances/other_nuances.md
@@ -30,8 +30,8 @@ class User(BaseModel):
 
 ```go
 type User struct {
-    Role      string    `pedantigo:"default=user"`              // Static
-    CreatedAt time.Time `pedantigo:"defaultFactory=Now"`        // Dynamic
+    Role      string    `validate:"default=user"`              // Static
+    CreatedAt time.Time `validate:"defaultFactory=Now"`        // Dynamic
 }
 
 // Method must have signature: func (t *T) MethodName() (FieldType, error)
@@ -68,8 +68,8 @@ class User(BaseModel):
 
 ```go
 type User struct {
-    Email string `pedantigo:"required,email"`
-    Age   int    `pedantigo:"required,min=0,max=120"`
+    Email string `validate:"required,email"`
+    Age   int    `validate:"required,min=0,max=120"`
 }
 ```
 
@@ -102,8 +102,8 @@ class DateRange(BaseModel):
 ```go
 // Simple field comparison - use declarative tags
 type DateRange struct {
-    StartDate time.Time `pedantigo:"required"`
-    EndDate   time.Time `pedantigo:"required,gtfield=StartDate"`
+    StartDate time.Time `validate:"required"`
+    EndDate   time.Time `validate:"required,gtfield=StartDate"`
 }
 
 // Complex conditional logic - implement Validate()
@@ -416,7 +416,7 @@ type BaseUser struct {
 
 type AdminUser struct {
     BaseUser  // Embedded - fields are "promoted" to outer struct
-    Role string `json:"role" pedantigo:"default=admin"`
+    Role string `json:"role" validate:"default=admin"`
 }
 ```
 
@@ -428,8 +428,8 @@ Embedded fields are promoted to the outer struct, achieving similar ergonomics w
 
 | Feature | Pydantic v2 | Pedantigo |
 |---------|-------------|-----------|
-| **Defaults** | `Field(default=...)`, `Field(default_factory=...)` | `pedantigo:"default=..."`, `pedantigo:"defaultFactory=Method"` |
-| **Validators** | `@field_validator` decorator | `pedantigo:"email,min=5,max=100"` tags |
+| **Defaults** | `Field(default=...)`, `Field(default_factory=...)` | `validate:"default=..."`, `validate:"defaultFactory=Method"` |
+| **Validators** | `@field_validator` decorator | `validate:"email,min=5,max=100"` tags |
 | **Cross-field** | `@model_validator` decorator | Cross-field tags or `Validate() error` method |
 | **Type Coercion** | Automatic | Strict (no coercion) |
 | **Optional** | `Optional[T]` or `T \| None` | `*T` (pointer types) |

--- a/extra_fields_test.go
+++ b/extra_fields_test.go
@@ -14,15 +14,15 @@ import (
 
 // UserWithExtras is a top-level struct with extra_fields tag.
 type UserWithExtras struct {
-	Name   string         `json:"name" pedantigo:"required"`
+	Name   string         `json:"name" validate:"required"`
 	Age    int            `json:"age"`
-	Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+	Extras map[string]any `json:"-" validate:"extra_fields"`
 }
 
 // NestedWithExtra is a nested struct with extras.
 type NestedWithExtra struct {
 	Value  string         `json:"value"`
-	Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+	Extras map[string]any `json:"-" validate:"extra_fields"`
 }
 
 // NestedNoExtra is a nested struct without extras.
@@ -34,7 +34,7 @@ type NestedNoExtra struct {
 type TopOnlyExtras struct {
 	Name   string         `json:"name"`
 	Nested NestedNoExtra  `json:"nested"`
-	Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+	Extras map[string]any `json:"-" validate:"extra_fields"`
 }
 
 // TopNoExtras is where nested only has extras.
@@ -47,7 +47,7 @@ type TopNoExtras struct {
 type BothHaveExtras struct {
 	Name   string          `json:"name"`
 	Nested NestedWithExtra `json:"nested"`
-	Extras map[string]any  `json:"-" pedantigo:"extra_fields"`
+	Extras map[string]any  `json:"-" validate:"extra_fields"`
 }
 
 // NoExtraFieldStruct is missing extra_fields field (for panic test).
@@ -60,31 +60,31 @@ type MultipleNestedExtras struct {
 	Name    string          `json:"name"`
 	Primary NestedWithExtra `json:"primary"`
 	Backup  NestedWithExtra `json:"backup"`
-	Extras  map[string]any  `json:"-" pedantigo:"extra_fields"`
+	Extras  map[string]any  `json:"-" validate:"extra_fields"`
 }
 
 // SliceWithExtras is a struct for slice testing.
 type SliceWithExtras struct {
 	Items  []NestedWithExtra `json:"items"`
-	Extras map[string]any    `json:"-" pedantigo:"extra_fields"`
+	Extras map[string]any    `json:"-" validate:"extra_fields"`
 }
 
 // DeepNestingLevel3 represents three levels of nesting (level 3).
 type DeepNestingLevel3 struct {
 	Data   string         `json:"data"`
-	Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+	Extras map[string]any `json:"-" validate:"extra_fields"`
 }
 
 type DeepNestingLevel2 struct {
 	Info   string            `json:"info"`
 	Level3 DeepNestingLevel3 `json:"level3"`
-	Extras map[string]any    `json:"-" pedantigo:"extra_fields"`
+	Extras map[string]any    `json:"-" validate:"extra_fields"`
 }
 
 type DeepNestingLevel1 struct {
 	Title  string            `json:"title"`
 	Level2 DeepNestingLevel2 `json:"level2"`
-	Extras map[string]any    `json:"-" pedantigo:"extra_fields"`
+	Extras map[string]any    `json:"-" validate:"extra_fields"`
 }
 
 // ==================================================
@@ -92,7 +92,7 @@ type DeepNestingLevel1 struct {
 // ==================================================
 
 // TestNew_ExtraAllow_WithField_Success tests that New() succeeds when ExtraAllow
-// is set and the struct has a field with pedantigo:"extra_fields" tag.
+// is set and the struct has a field with validate:"extra_fields" tag.
 func TestNew_ExtraAllow_WithField_Success(t *testing.T) {
 	validator := New[UserWithExtras](ValidatorOptions{
 		ExtraFields: ExtraAllow,
@@ -737,7 +737,7 @@ func TestUnmarshal_ExtraAllow_NullExtraValue(t *testing.T) {
 // BenchmarkUnmarshal_ExtraIgnore_Baseline establishes baseline performance with ExtraIgnore.
 func BenchmarkUnmarshal_ExtraIgnore_Baseline(b *testing.B) {
 	type SimpleUser struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 		Age  int    `json:"age"`
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/SmrutAI/pedantigo
+module github.com/SmrutAI/pedantigo/v2
 
 go 1.21
 

--- a/internal/constraints/comparison_coverage_test.go
+++ b/internal/constraints/comparison_coverage_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	. "github.com/SmrutAI/pedantigo"
+	. "github.com/SmrutAI/pedantigo/v2"
 )
 
 // TestCrossFieldComparison_IncompatibleTypes tests that cross-field comparisons

--- a/internal/constraints/comparison_coverage_test.go
+++ b/internal/constraints/comparison_coverage_test.go
@@ -15,7 +15,7 @@ func TestCrossFieldComparison_IncompatibleTypes(t *testing.T) {
 	t.Run("eqfield: int vs string incompatible", func(t *testing.T) {
 		type MixedTypes struct {
 			IntField    int    `json:"int_field"`
-			StringField string `json:"string_field" pedantigo:"eqfield=IntField"`
+			StringField string `json:"string_field" validate:"eqfield=IntField"`
 		}
 
 		validator := New[MixedTypes]()
@@ -42,7 +42,7 @@ func TestCrossFieldComparison_IncompatibleTypes(t *testing.T) {
 	t.Run("nefield: float vs string incompatible", func(t *testing.T) {
 		type MixedTypes struct {
 			FloatField  float64 `json:"float_field"`
-			StringField string  `json:"string_field" pedantigo:"nefield=FloatField"`
+			StringField string  `json:"string_field" validate:"nefield=FloatField"`
 		}
 
 		validator := New[MixedTypes]()
@@ -62,7 +62,7 @@ func TestCrossFieldComparison_IncompatibleTypes(t *testing.T) {
 	t.Run("gtfield: bool vs int incompatible", func(t *testing.T) {
 		type MixedTypes struct {
 			IntField  int  `json:"int_field"`
-			BoolField bool `json:"bool_field" pedantigo:"gtfield=IntField"`
+			BoolField bool `json:"bool_field" validate:"gtfield=IntField"`
 		}
 
 		validator := New[MixedTypes]()
@@ -78,7 +78,7 @@ func TestCrossFieldComparison_IncompatibleTypes(t *testing.T) {
 	t.Run("gtefield: string vs float incompatible", func(t *testing.T) {
 		type MixedTypes struct {
 			FloatField  float64 `json:"float_field"`
-			StringField string  `json:"string_field" pedantigo:"gtefield=FloatField"`
+			StringField string  `json:"string_field" validate:"gtefield=FloatField"`
 		}
 
 		validator := New[MixedTypes]()
@@ -94,7 +94,7 @@ func TestCrossFieldComparison_IncompatibleTypes(t *testing.T) {
 	t.Run("ltfield: uint vs string incompatible", func(t *testing.T) {
 		type MixedTypes struct {
 			UintField   uint   `json:"uint_field"`
-			StringField string `json:"string_field" pedantigo:"ltfield=UintField"`
+			StringField string `json:"string_field" validate:"ltfield=UintField"`
 		}
 
 		validator := New[MixedTypes]()
@@ -110,7 +110,7 @@ func TestCrossFieldComparison_IncompatibleTypes(t *testing.T) {
 	t.Run("ltefield: int vs bool incompatible", func(t *testing.T) {
 		type MixedTypes struct {
 			BoolField bool `json:"bool_field"`
-			IntField  int  `json:"int_field" pedantigo:"ltefield=BoolField"`
+			IntField  int  `json:"int_field" validate:"ltefield=BoolField"`
 		}
 
 		validator := New[MixedTypes]()
@@ -126,7 +126,7 @@ func TestCrossFieldComparison_IncompatibleTypes(t *testing.T) {
 	t.Run("eqfield: slice vs string incompatible", func(t *testing.T) {
 		type MixedTypes struct {
 			SliceField  []int  `json:"slice_field"`
-			StringField string `json:"string_field" pedantigo:"eqfield=SliceField"`
+			StringField string `json:"string_field" validate:"eqfield=SliceField"`
 		}
 
 		validator := New[MixedTypes]()
@@ -142,7 +142,7 @@ func TestCrossFieldComparison_IncompatibleTypes(t *testing.T) {
 	t.Run("nefield: map vs string incompatible", func(t *testing.T) {
 		type MixedTypes struct {
 			MapField    map[string]int `json:"map_field"`
-			StringField string         `json:"string_field" pedantigo:"nefield=MapField"`
+			StringField string         `json:"string_field" validate:"nefield=MapField"`
 		}
 
 		validator := New[MixedTypes]()
@@ -164,7 +164,7 @@ func TestCrossFieldComparison_NestedFieldPath(t *testing.T) {
 		}
 		type Outer struct {
 			Inner   Inner  `json:"inner"`
-			Compare string `json:"compare" pedantigo:"eqfield=Inner.Value"`
+			Compare string `json:"compare" validate:"eqfield=Inner.Value"`
 		}
 
 		validator := New[Outer]()
@@ -183,7 +183,7 @@ func TestCrossFieldComparison_NestedFieldPath(t *testing.T) {
 		}
 		type Outer struct {
 			Inner Inner `json:"inner"`
-			Max   int   `json:"max" pedantigo:"gtfield=Inner.Min"`
+			Max   int   `json:"max" validate:"gtfield=Inner.Min"`
 		}
 
 		validator := New[Outer]()
@@ -202,7 +202,7 @@ func TestCrossFieldComparison_NestedFieldPath(t *testing.T) {
 		}
 		type Outer struct {
 			Inner Inner `json:"inner"`
-			Min   int   `json:"min" pedantigo:"ltfield=Inner.Max"`
+			Min   int   `json:"min" validate:"ltfield=Inner.Max"`
 		}
 
 		validator := New[Outer]()
@@ -221,7 +221,7 @@ func TestCrossFieldComparison_PointerTypes(t *testing.T) {
 	t.Run("eqfield: pointer to non-pointer compatible", func(t *testing.T) {
 		type PointerTest struct {
 			IntPtr *int `json:"int_ptr"`
-			IntVal int  `json:"int_val" pedantigo:"eqfield=IntPtr"`
+			IntVal int  `json:"int_val" validate:"eqfield=IntPtr"`
 		}
 
 		validator := New[PointerTest]()
@@ -238,7 +238,7 @@ func TestCrossFieldComparison_PointerTypes(t *testing.T) {
 	t.Run("gtfield: pointer to non-pointer compatible", func(t *testing.T) {
 		type PointerTest struct {
 			MinPtr *int `json:"min_ptr"`
-			MaxVal int  `json:"max_val" pedantigo:"gtfield=MinPtr"`
+			MaxVal int  `json:"max_val" validate:"gtfield=MinPtr"`
 		}
 
 		validator := New[PointerTest]()

--- a/internal/constraints/coverage_additional_test.go
+++ b/internal/constraints/coverage_additional_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	. "github.com/SmrutAI/pedantigo"
+	. "github.com/SmrutAI/pedantigo/v2"
 )
 
 // TestISO3166NumericConstraint_EdgeCases tests edge cases for ISO 3166-1 numeric constraint.

--- a/internal/constraints/coverage_additional_test.go
+++ b/internal/constraints/coverage_additional_test.go
@@ -13,7 +13,7 @@ import (
 func TestISO3166NumericConstraint_EdgeCases(t *testing.T) {
 	t.Run("valid int country code", func(t *testing.T) {
 		type Country struct {
-			Code int `json:"code" pedantigo:"iso3166_1_alpha_numeric"`
+			Code int `json:"code" validate:"iso3166_1_alpha_numeric"`
 		}
 
 		validator := New[Country]()
@@ -25,7 +25,7 @@ func TestISO3166NumericConstraint_EdgeCases(t *testing.T) {
 
 	t.Run("valid uint country code", func(t *testing.T) {
 		type Country struct {
-			Code uint `json:"code" pedantigo:"iso3166_1_alpha_numeric"`
+			Code uint `json:"code" validate:"iso3166_1_alpha_numeric"`
 		}
 
 		validator := New[Country]()
@@ -37,7 +37,7 @@ func TestISO3166NumericConstraint_EdgeCases(t *testing.T) {
 
 	t.Run("uint country code exceeds 999", func(t *testing.T) {
 		type Country struct {
-			Code uint `json:"code" pedantigo:"iso3166_1_alpha_numeric"`
+			Code uint `json:"code" validate:"iso3166_1_alpha_numeric"`
 		}
 
 		validator := New[Country]()
@@ -49,7 +49,7 @@ func TestISO3166NumericConstraint_EdgeCases(t *testing.T) {
 
 	t.Run("invalid string type", func(t *testing.T) {
 		type Country struct {
-			Code string `json:"code" pedantigo:"iso3166_1_alpha_numeric"`
+			Code string `json:"code" validate:"iso3166_1_alpha_numeric"`
 		}
 
 		validator := New[Country]()
@@ -61,7 +61,7 @@ func TestISO3166NumericConstraint_EdgeCases(t *testing.T) {
 
 	t.Run("invalid country code", func(t *testing.T) {
 		type Country struct {
-			Code int `json:"code" pedantigo:"iso3166_1_alpha_numeric"`
+			Code int `json:"code" validate:"iso3166_1_alpha_numeric"`
 		}
 
 		validator := New[Country]()
@@ -76,7 +76,7 @@ func TestISO3166NumericConstraint_EdgeCases(t *testing.T) {
 func TestISO4217NumericConstraint_EdgeCases(t *testing.T) {
 	t.Run("valid int currency code", func(t *testing.T) {
 		type Currency struct {
-			Code int `json:"code" pedantigo:"iso4217_numeric"`
+			Code int `json:"code" validate:"iso4217_numeric"`
 		}
 
 		validator := New[Currency]()
@@ -88,7 +88,7 @@ func TestISO4217NumericConstraint_EdgeCases(t *testing.T) {
 
 	t.Run("valid uint currency code", func(t *testing.T) {
 		type Currency struct {
-			Code uint `json:"code" pedantigo:"iso4217_numeric"`
+			Code uint `json:"code" validate:"iso4217_numeric"`
 		}
 
 		validator := New[Currency]()
@@ -100,7 +100,7 @@ func TestISO4217NumericConstraint_EdgeCases(t *testing.T) {
 
 	t.Run("uint currency code exceeds 999", func(t *testing.T) {
 		type Currency struct {
-			Code uint `json:"code" pedantigo:"iso4217_numeric"`
+			Code uint `json:"code" validate:"iso4217_numeric"`
 		}
 
 		validator := New[Currency]()
@@ -112,7 +112,7 @@ func TestISO4217NumericConstraint_EdgeCases(t *testing.T) {
 
 	t.Run("invalid string type", func(t *testing.T) {
 		type Currency struct {
-			Code string `json:"code" pedantigo:"iso4217_numeric"`
+			Code string `json:"code" validate:"iso4217_numeric"`
 		}
 
 		validator := New[Currency]()
@@ -124,7 +124,7 @@ func TestISO4217NumericConstraint_EdgeCases(t *testing.T) {
 
 	t.Run("invalid currency code", func(t *testing.T) {
 		type Currency struct {
-			Code int `json:"code" pedantigo:"iso4217_numeric"`
+			Code int `json:"code" validate:"iso4217_numeric"`
 		}
 
 		validator := New[Currency]()
@@ -139,7 +139,7 @@ func TestISO4217NumericConstraint_EdgeCases(t *testing.T) {
 func TestLenConstraint_Coverage(t *testing.T) {
 	t.Run("exact string length valid", func(t *testing.T) {
 		type Data struct {
-			Code string `json:"code" pedantigo:"len=5"`
+			Code string `json:"code" validate:"len=5"`
 		}
 
 		validator := New[Data]()
@@ -151,7 +151,7 @@ func TestLenConstraint_Coverage(t *testing.T) {
 
 	t.Run("exact string length invalid short", func(t *testing.T) {
 		type Data struct {
-			Code string `json:"code" pedantigo:"len=5"`
+			Code string `json:"code" validate:"len=5"`
 		}
 
 		validator := New[Data]()
@@ -163,7 +163,7 @@ func TestLenConstraint_Coverage(t *testing.T) {
 
 	t.Run("exact string length invalid long", func(t *testing.T) {
 		type Data struct {
-			Code string `json:"code" pedantigo:"len=5"`
+			Code string `json:"code" validate:"len=5"`
 		}
 
 		validator := New[Data]()
@@ -178,7 +178,7 @@ func TestLenConstraint_Coverage(t *testing.T) {
 func TestISSNConstraint_Coverage(t *testing.T) {
 	t.Run("valid ISSN", func(t *testing.T) {
 		type Journal struct {
-			ISSN string `json:"issn" pedantigo:"issn"`
+			ISSN string `json:"issn" validate:"issn"`
 		}
 
 		validator := New[Journal]()
@@ -190,7 +190,7 @@ func TestISSNConstraint_Coverage(t *testing.T) {
 
 	t.Run("invalid ISSN wrong checksum", func(t *testing.T) {
 		type Journal struct {
-			ISSN string `json:"issn" pedantigo:"issn"`
+			ISSN string `json:"issn" validate:"issn"`
 		}
 
 		validator := New[Journal]()
@@ -202,7 +202,7 @@ func TestISSNConstraint_Coverage(t *testing.T) {
 
 	t.Run("invalid ISSN format", func(t *testing.T) {
 		type Journal struct {
-			ISSN string `json:"issn" pedantigo:"issn"`
+			ISSN string `json:"issn" validate:"issn"`
 		}
 
 		validator := New[Journal]()
@@ -214,7 +214,7 @@ func TestISSNConstraint_Coverage(t *testing.T) {
 
 	t.Run("empty ISSN skips validation", func(t *testing.T) {
 		type Journal struct {
-			ISSN string `json:"issn" pedantigo:"issn"`
+			ISSN string `json:"issn" validate:"issn"`
 		}
 
 		validator := New[Journal]()
@@ -229,7 +229,7 @@ func TestISSNConstraint_Coverage(t *testing.T) {
 func TestCronConstraint_Coverage(t *testing.T) {
 	t.Run("valid cron expression", func(t *testing.T) {
 		type Schedule struct {
-			Cron string `json:"cron" pedantigo:"cron"`
+			Cron string `json:"cron" validate:"cron"`
 		}
 
 		validator := New[Schedule]()
@@ -241,7 +241,7 @@ func TestCronConstraint_Coverage(t *testing.T) {
 
 	t.Run("valid cron with ranges", func(t *testing.T) {
 		type Schedule struct {
-			Cron string `json:"cron" pedantigo:"cron"`
+			Cron string `json:"cron" validate:"cron"`
 		}
 
 		validator := New[Schedule]()
@@ -253,7 +253,7 @@ func TestCronConstraint_Coverage(t *testing.T) {
 
 	t.Run("valid cron with steps", func(t *testing.T) {
 		type Schedule struct {
-			Cron string `json:"cron" pedantigo:"cron"`
+			Cron string `json:"cron" validate:"cron"`
 		}
 
 		validator := New[Schedule]()
@@ -265,7 +265,7 @@ func TestCronConstraint_Coverage(t *testing.T) {
 
 	t.Run("invalid cron expression", func(t *testing.T) {
 		type Schedule struct {
-			Cron string `json:"cron" pedantigo:"cron"`
+			Cron string `json:"cron" validate:"cron"`
 		}
 
 		validator := New[Schedule]()
@@ -277,7 +277,7 @@ func TestCronConstraint_Coverage(t *testing.T) {
 
 	t.Run("invalid cron range out of bounds", func(t *testing.T) {
 		type Schedule struct {
-			Cron string `json:"cron" pedantigo:"cron"`
+			Cron string `json:"cron" validate:"cron"`
 		}
 
 		validator := New[Schedule]()
@@ -292,7 +292,7 @@ func TestCronConstraint_Coverage(t *testing.T) {
 func TestOrConstraint_Coverage(t *testing.T) {
 	t.Run("or constraint hexcolor|rgb first matches", func(t *testing.T) {
 		type Data struct {
-			Color string `json:"color" pedantigo:"hexcolor|rgb"`
+			Color string `json:"color" validate:"hexcolor|rgb"`
 		}
 
 		validator := New[Data]()
@@ -304,7 +304,7 @@ func TestOrConstraint_Coverage(t *testing.T) {
 
 	t.Run("or constraint hexcolor|rgb second matches", func(t *testing.T) {
 		type Data struct {
-			Color string `json:"color" pedantigo:"hexcolor|rgb"`
+			Color string `json:"color" validate:"hexcolor|rgb"`
 		}
 
 		validator := New[Data]()
@@ -316,7 +316,7 @@ func TestOrConstraint_Coverage(t *testing.T) {
 
 	t.Run("or constraint hexcolor|rgb none matches", func(t *testing.T) {
 		type Data struct {
-			Color string `json:"color" pedantigo:"hexcolor|rgb"`
+			Color string `json:"color" validate:"hexcolor|rgb"`
 		}
 
 		validator := New[Data]()
@@ -331,7 +331,7 @@ func TestOrConstraint_Coverage(t *testing.T) {
 func TestColorConstraint_Coverage(t *testing.T) {
 	t.Run("valid hex color", func(t *testing.T) {
 		type Style struct {
-			Color string `json:"color" pedantigo:"hexcolor"`
+			Color string `json:"color" validate:"hexcolor"`
 		}
 
 		validator := New[Style]()
@@ -343,7 +343,7 @@ func TestColorConstraint_Coverage(t *testing.T) {
 
 	t.Run("valid short hex color", func(t *testing.T) {
 		type Style struct {
-			Color string `json:"color" pedantigo:"hexcolor"`
+			Color string `json:"color" validate:"hexcolor"`
 		}
 
 		validator := New[Style]()
@@ -355,7 +355,7 @@ func TestColorConstraint_Coverage(t *testing.T) {
 
 	t.Run("invalid hex color", func(t *testing.T) {
 		type Style struct {
-			Color string `json:"color" pedantigo:"hexcolor"`
+			Color string `json:"color" validate:"hexcolor"`
 		}
 
 		validator := New[Style]()
@@ -367,7 +367,7 @@ func TestColorConstraint_Coverage(t *testing.T) {
 
 	t.Run("valid rgb color", func(t *testing.T) {
 		type Style struct {
-			Color string `json:"color" pedantigo:"rgb"`
+			Color string `json:"color" validate:"rgb"`
 		}
 
 		validator := New[Style]()
@@ -379,7 +379,7 @@ func TestColorConstraint_Coverage(t *testing.T) {
 
 	t.Run("invalid rgb color out of range", func(t *testing.T) {
 		type Style struct {
-			Color string `json:"color" pedantigo:"rgb"`
+			Color string `json:"color" validate:"rgb"`
 		}
 
 		validator := New[Style]()
@@ -391,7 +391,7 @@ func TestColorConstraint_Coverage(t *testing.T) {
 
 	t.Run("valid hsl color", func(t *testing.T) {
 		type Style struct {
-			Color string `json:"color" pedantigo:"hsl"`
+			Color string `json:"color" validate:"hsl"`
 		}
 
 		validator := New[Style]()
@@ -406,7 +406,7 @@ func TestColorConstraint_Coverage(t *testing.T) {
 func TestUniqueConstraint_Coverage(t *testing.T) {
 	t.Run("unique slice valid", func(t *testing.T) {
 		type Data struct {
-			Items []string `json:"items" pedantigo:"unique"`
+			Items []string `json:"items" validate:"unique"`
 		}
 
 		validator := New[Data]()
@@ -418,7 +418,7 @@ func TestUniqueConstraint_Coverage(t *testing.T) {
 
 	t.Run("unique slice invalid duplicates", func(t *testing.T) {
 		type Data struct {
-			Items []string `json:"items" pedantigo:"unique"`
+			Items []string `json:"items" validate:"unique"`
 		}
 
 		validator := New[Data]()
@@ -430,7 +430,7 @@ func TestUniqueConstraint_Coverage(t *testing.T) {
 
 	t.Run("unique map values valid", func(t *testing.T) {
 		type Data struct {
-			Mapping map[string]int `json:"mapping" pedantigo:"unique"`
+			Mapping map[string]int `json:"mapping" validate:"unique"`
 		}
 
 		validator := New[Data]()
@@ -442,7 +442,7 @@ func TestUniqueConstraint_Coverage(t *testing.T) {
 
 	t.Run("unique map values invalid", func(t *testing.T) {
 		type Data struct {
-			Mapping map[string]int `json:"mapping" pedantigo:"unique"`
+			Mapping map[string]int `json:"mapping" validate:"unique"`
 		}
 
 		validator := New[Data]()
@@ -458,7 +458,7 @@ func TestUniqueConstraint_Coverage(t *testing.T) {
 			Name string `json:"name"`
 		}
 		type Data struct {
-			Items []Item `json:"items" pedantigo:"unique=ID"`
+			Items []Item `json:"items" validate:"unique=ID"`
 		}
 
 		validator := New[Data]()
@@ -474,7 +474,7 @@ func TestUniqueConstraint_Coverage(t *testing.T) {
 			Name string `json:"name"`
 		}
 		type Data struct {
-			Items []Item `json:"items" pedantigo:"unique=ID"`
+			Items []Item `json:"items" validate:"unique=ID"`
 		}
 
 		validator := New[Data]()
@@ -489,7 +489,7 @@ func TestUniqueConstraint_Coverage(t *testing.T) {
 func TestEncodingConstraint_Coverage(t *testing.T) {
 	t.Run("valid base64 standard", func(t *testing.T) {
 		type Data struct {
-			Encoded string `json:"encoded" pedantigo:"base64"`
+			Encoded string `json:"encoded" validate:"base64"`
 		}
 
 		validator := New[Data]()
@@ -501,7 +501,7 @@ func TestEncodingConstraint_Coverage(t *testing.T) {
 
 	t.Run("invalid base64", func(t *testing.T) {
 		type Data struct {
-			Encoded string `json:"encoded" pedantigo:"base64"`
+			Encoded string `json:"encoded" validate:"base64"`
 		}
 
 		validator := New[Data]()
@@ -513,7 +513,7 @@ func TestEncodingConstraint_Coverage(t *testing.T) {
 
 	t.Run("valid base64url", func(t *testing.T) {
 		type Data struct {
-			Encoded string `json:"encoded" pedantigo:"base64url"`
+			Encoded string `json:"encoded" validate:"base64url"`
 		}
 
 		validator := New[Data]()
@@ -525,7 +525,7 @@ func TestEncodingConstraint_Coverage(t *testing.T) {
 
 	t.Run("valid base64rawurl", func(t *testing.T) {
 		type Data struct {
-			Encoded string `json:"encoded" pedantigo:"base64rawurl"`
+			Encoded string `json:"encoded" validate:"base64rawurl"`
 		}
 
 		validator := New[Data]()
@@ -540,7 +540,7 @@ func TestEncodingConstraint_Coverage(t *testing.T) {
 func TestNumericConstraint_EdgeCases(t *testing.T) {
 	t.Run("positive constraint valid", func(t *testing.T) {
 		type Data struct {
-			Value int `json:"value" pedantigo:"positive"`
+			Value int `json:"value" validate:"positive"`
 		}
 
 		validator := New[Data]()
@@ -552,7 +552,7 @@ func TestNumericConstraint_EdgeCases(t *testing.T) {
 
 	t.Run("positive constraint invalid zero", func(t *testing.T) {
 		type Data struct {
-			Value int `json:"value" pedantigo:"positive"`
+			Value int `json:"value" validate:"positive"`
 		}
 
 		validator := New[Data]()
@@ -564,7 +564,7 @@ func TestNumericConstraint_EdgeCases(t *testing.T) {
 
 	t.Run("negative constraint valid", func(t *testing.T) {
 		type Data struct {
-			Value int `json:"value" pedantigo:"negative"`
+			Value int `json:"value" validate:"negative"`
 		}
 
 		validator := New[Data]()
@@ -576,7 +576,7 @@ func TestNumericConstraint_EdgeCases(t *testing.T) {
 
 	t.Run("nonnegative constraint valid zero", func(t *testing.T) {
 		type Data struct {
-			Value int `json:"value" pedantigo:"nonnegative"`
+			Value int `json:"value" validate:"nonnegative"`
 		}
 
 		validator := New[Data]()
@@ -588,7 +588,7 @@ func TestNumericConstraint_EdgeCases(t *testing.T) {
 
 	t.Run("nonpositive constraint valid zero", func(t *testing.T) {
 		type Data struct {
-			Value int `json:"value" pedantigo:"nonpositive"`
+			Value int `json:"value" validate:"nonpositive"`
 		}
 
 		validator := New[Data]()

--- a/internal/constraints/coverage_final_test.go
+++ b/internal/constraints/coverage_final_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	. "github.com/SmrutAI/pedantigo"
+	. "github.com/SmrutAI/pedantigo/v2"
 )
 
 // coverage_final_test.go - Final coverage improvement tests

--- a/internal/constraints/coverage_final_test.go
+++ b/internal/constraints/coverage_final_test.go
@@ -29,7 +29,7 @@ func TestCrossFieldComparison_IncompatibleTypesAllOperators(t *testing.T) {
 	t.Run("eqfield: string vs int incompatible", func(t *testing.T) {
 		type MixedEq struct {
 			IntField    int    `json:"int_field"`
-			StringField string `json:"string_field" pedantigo:"eqfield=IntField"`
+			StringField string `json:"string_field" validate:"eqfield=IntField"`
 		}
 
 		validator := New[MixedEq]()
@@ -46,7 +46,7 @@ func TestCrossFieldComparison_IncompatibleTypesAllOperators(t *testing.T) {
 	t.Run("nefield: bool vs string incompatible", func(t *testing.T) {
 		type MixedNe struct {
 			BoolField   bool   `json:"bool_field"`
-			StringField string `json:"string_field" pedantigo:"nefield=BoolField"`
+			StringField string `json:"string_field" validate:"nefield=BoolField"`
 		}
 
 		validator := New[MixedNe]()
@@ -63,7 +63,7 @@ func TestCrossFieldComparison_IncompatibleTypesAllOperators(t *testing.T) {
 	t.Run("gtfield: slice vs int incompatible", func(t *testing.T) {
 		type MixedGt struct {
 			IntField   int   `json:"int_field"`
-			SliceField []int `json:"slice_field" pedantigo:"gtfield=IntField"`
+			SliceField []int `json:"slice_field" validate:"gtfield=IntField"`
 		}
 
 		validator := New[MixedGt]()
@@ -80,7 +80,7 @@ func TestCrossFieldComparison_IncompatibleTypesAllOperators(t *testing.T) {
 	t.Run("gtefield: map vs float incompatible", func(t *testing.T) {
 		type MixedGte struct {
 			FloatField float64        `json:"float_field"`
-			MapField   map[string]int `json:"map_field" pedantigo:"gtefield=FloatField"`
+			MapField   map[string]int `json:"map_field" validate:"gtefield=FloatField"`
 		}
 
 		validator := New[MixedGte]()
@@ -97,7 +97,7 @@ func TestCrossFieldComparison_IncompatibleTypesAllOperators(t *testing.T) {
 	t.Run("ltfield: int vs bool incompatible", func(t *testing.T) {
 		type MixedLt struct {
 			BoolField bool `json:"bool_field"`
-			IntField  int  `json:"int_field" pedantigo:"ltfield=BoolField"`
+			IntField  int  `json:"int_field" validate:"ltfield=BoolField"`
 		}
 
 		validator := New[MixedLt]()
@@ -117,7 +117,7 @@ func TestCrossFieldComparison_IncompatibleTypesAllOperators(t *testing.T) {
 		}
 		type MixedLte struct {
 			InnerField Inner   `json:"inner_field"`
-			FloatField float64 `json:"float_field" pedantigo:"ltefield=InnerField"`
+			FloatField float64 `json:"float_field" validate:"ltefield=InnerField"`
 		}
 
 		validator := New[MixedLte]()
@@ -139,7 +139,7 @@ func TestSkipUnless_ValidateCrossFieldNoOp(t *testing.T) {
 	t.Run("skip_unless ValidateCrossField is no-op", func(t *testing.T) {
 		type Form struct {
 			Status string `json:"status"`
-			Data   string `json:"data" pedantigo:"skip_unless=Status active,required"`
+			Data   string `json:"data" validate:"skip_unless=Status active,required"`
 		}
 
 		validator := New[Form]()
@@ -168,7 +168,7 @@ func TestSkipUnless_ShouldSkip_CompareFnNil(t *testing.T) {
 	t.Run("skip_unless with normal compareFn", func(t *testing.T) {
 		type Form struct {
 			Type string `json:"type"`
-			Data string `json:"data" pedantigo:"skip_unless=Type admin,required"`
+			Data string `json:"data" validate:"skip_unless=Type admin,required"`
 		}
 
 		validator := New[Form]()
@@ -201,7 +201,7 @@ func TestSkipUnless_ShouldSkip_CompareFnNil(t *testing.T) {
 func TestISO31661AlphaNumeric_AdditionalUintTypes(t *testing.T) {
 	t.Run("iso3166_1_alpha_numeric: uint16 over 999 fails", func(t *testing.T) {
 		type Country struct {
-			Code uint16 `json:"code" pedantigo:"iso3166_1_alpha_numeric"`
+			Code uint16 `json:"code" validate:"iso3166_1_alpha_numeric"`
 		}
 
 		validator := New[Country]()
@@ -214,7 +214,7 @@ func TestISO31661AlphaNumeric_AdditionalUintTypes(t *testing.T) {
 
 	t.Run("iso3166_1_alpha_numeric: uint32 over 999 fails", func(t *testing.T) {
 		type Country struct {
-			Code uint32 `json:"code" pedantigo:"iso3166_1_alpha_numeric"`
+			Code uint32 `json:"code" validate:"iso3166_1_alpha_numeric"`
 		}
 
 		validator := New[Country]()
@@ -227,7 +227,7 @@ func TestISO31661AlphaNumeric_AdditionalUintTypes(t *testing.T) {
 
 	t.Run("iso3166_1_alpha_numeric: uint64 over 999 fails", func(t *testing.T) {
 		type Country struct {
-			Code uint64 `json:"code" pedantigo:"iso3166_1_alpha_numeric"`
+			Code uint64 `json:"code" validate:"iso3166_1_alpha_numeric"`
 		}
 
 		validator := New[Country]()
@@ -244,7 +244,7 @@ func TestISO31661AlphaNumeric_AdditionalUintTypes(t *testing.T) {
 func TestISO4217Numeric_AdditionalUintTypes(t *testing.T) {
 	t.Run("iso4217_numeric: uint16 over 999 fails", func(t *testing.T) {
 		type Currency struct {
-			Code uint16 `json:"code" pedantigo:"iso4217_numeric"`
+			Code uint16 `json:"code" validate:"iso4217_numeric"`
 		}
 
 		validator := New[Currency]()
@@ -257,7 +257,7 @@ func TestISO4217Numeric_AdditionalUintTypes(t *testing.T) {
 
 	t.Run("iso4217_numeric: uint32 over 999 fails", func(t *testing.T) {
 		type Currency struct {
-			Code uint32 `json:"code" pedantigo:"iso4217_numeric"`
+			Code uint32 `json:"code" validate:"iso4217_numeric"`
 		}
 
 		validator := New[Currency]()
@@ -270,7 +270,7 @@ func TestISO4217Numeric_AdditionalUintTypes(t *testing.T) {
 
 	t.Run("iso4217_numeric: uint64 over 999 fails", func(t *testing.T) {
 		type Currency struct {
-			Code uint64 `json:"code" pedantigo:"iso4217_numeric"`
+			Code uint64 `json:"code" validate:"iso4217_numeric"`
 		}
 
 		validator := New[Currency]()
@@ -292,7 +292,7 @@ func TestISO4217Numeric_AdditionalUintTypes(t *testing.T) {
 func TestISSN_XChecksum(t *testing.T) {
 	t.Run("issn: X checksum valid", func(t *testing.T) {
 		type Publication struct {
-			ISSN string `json:"issn" pedantigo:"issn"`
+			ISSN string `json:"issn" validate:"issn"`
 		}
 
 		validator := New[Publication]()
@@ -316,7 +316,7 @@ func TestISSN_XChecksum(t *testing.T) {
 
 	t.Run("issn: X at wrong position invalid", func(t *testing.T) {
 		type Publication struct {
-			ISSN string `json:"issn" pedantigo:"issn"`
+			ISSN string `json:"issn" validate:"issn"`
 		}
 
 		validator := New[Publication]()
@@ -334,7 +334,7 @@ func TestISSN_XChecksum(t *testing.T) {
 
 	t.Run("issn: X checksum without dash", func(t *testing.T) {
 		type Publication struct {
-			ISSN string `json:"issn" pedantigo:"issn"`
+			ISSN string `json:"issn" validate:"issn"`
 		}
 
 		validator := New[Publication]()
@@ -355,7 +355,7 @@ func TestISSN_XChecksum(t *testing.T) {
 func TestISSN_EdgeCases(t *testing.T) {
 	t.Run("issn: checksum validation", func(t *testing.T) {
 		type Publication struct {
-			ISSN string `json:"issn" pedantigo:"issn"`
+			ISSN string `json:"issn" validate:"issn"`
 		}
 
 		validator := New[Publication]()

--- a/internal/constraints/crossfield_all_test.go
+++ b/internal/constraints/crossfield_all_test.go
@@ -17,7 +17,7 @@ func TestRequiredWithAll(t *testing.T) {
 		A      string `json:"a"`
 		B      string `json:"b"`
 		C      string `json:"c"`
-		Target string `json:"target" pedantigo:"required_with_all=A B C"`
+		Target string `json:"target" validate:"required_with_all=A B C"`
 	}
 
 	// Test 1: All present, target present - pass
@@ -53,7 +53,7 @@ func TestRequiredWithAll(t *testing.T) {
 		type Form2 struct {
 			A      string `json:"a"`
 			B      string `json:"b"`
-			Target string `json:"target" pedantigo:"required_with_all=A B"`
+			Target string `json:"target" validate:"required_with_all=A B"`
 		}
 		validator := pedantigo.New[Form2]()
 		err := validator.Validate(&Form2{A: "1", B: "2", Target: ""})
@@ -98,7 +98,7 @@ func TestRequiredWithoutAll(t *testing.T) {
 		A      string `json:"a"`
 		B      string `json:"b"`
 		C      string `json:"c"`
-		Target string `json:"target" pedantigo:"required_without_all=A B C"`
+		Target string `json:"target" validate:"required_without_all=A B C"`
 	}
 
 	// Test 1: All absent, target present - pass
@@ -134,7 +134,7 @@ func TestRequiredWithoutAll(t *testing.T) {
 		type Form2 struct {
 			A      string `json:"a"`
 			B      string `json:"b"`
-			Target string `json:"target" pedantigo:"required_without_all=A B"`
+			Target string `json:"target" validate:"required_without_all=A B"`
 		}
 		validator := pedantigo.New[Form2]()
 		err := validator.Validate(&Form2{A: "", B: "", Target: ""})
@@ -179,7 +179,7 @@ func TestExcludedWithAll(t *testing.T) {
 		A      string `json:"a"`
 		B      string `json:"b"`
 		C      string `json:"c"`
-		Target string `json:"target" pedantigo:"excluded_with_all=A B C"`
+		Target string `json:"target" validate:"excluded_with_all=A B C"`
 	}
 
 	// Test 1: All present, target present - fail
@@ -215,7 +215,7 @@ func TestExcludedWithAll(t *testing.T) {
 		type Form2 struct {
 			A      string `json:"a"`
 			B      string `json:"b"`
-			Target string `json:"target" pedantigo:"excluded_with_all=A B"`
+			Target string `json:"target" validate:"excluded_with_all=A B"`
 		}
 		validator := pedantigo.New[Form2]()
 		err := validator.Validate(&Form2{A: "1", B: "2", Target: "value"})
@@ -267,7 +267,7 @@ func TestExcludedWithoutAll(t *testing.T) {
 		A      string `json:"a"`
 		B      string `json:"b"`
 		C      string `json:"c"`
-		Target string `json:"target" pedantigo:"excluded_without_all=A B C"`
+		Target string `json:"target" validate:"excluded_without_all=A B C"`
 	}
 
 	// Test 1: All absent, target present - fail
@@ -303,7 +303,7 @@ func TestExcludedWithoutAll(t *testing.T) {
 		type Form2 struct {
 			A      string `json:"a"`
 			B      string `json:"b"`
-			Target string `json:"target" pedantigo:"excluded_without_all=A B"`
+			Target string `json:"target" validate:"excluded_without_all=A B"`
 		}
 		validator := pedantigo.New[Form2]()
 		err := validator.Validate(&Form2{A: "", B: "", Target: "value"})
@@ -354,7 +354,7 @@ func TestAllConstraintsWithIntegers(t *testing.T) {
 	type Form struct {
 		Count1 int    `json:"count1"`
 		Count2 int    `json:"count2"`
-		Target string `json:"target" pedantigo:"required_with_all=Count1 Count2"`
+		Target string `json:"target" validate:"required_with_all=Count1 Count2"`
 	}
 
 	// Zero is considered absent for integers
@@ -387,7 +387,7 @@ func TestAllConstraintsWithBooleans(t *testing.T) {
 	type Form struct {
 		Flag1  bool   `json:"flag1"`
 		Flag2  bool   `json:"flag2"`
-		Target string `json:"target" pedantigo:"required_with_all=Flag1 Flag2"`
+		Target string `json:"target" validate:"required_with_all=Flag1 Flag2"`
 	}
 
 	// false is considered absent for booleans
@@ -420,7 +420,7 @@ func TestAllConstraintsWithFloats(t *testing.T) {
 	type Form struct {
 		Price1 float64 `json:"price1"`
 		Price2 float64 `json:"price2"`
-		Target string  `json:"target" pedantigo:"required_with_all=Price1 Price2"`
+		Target string  `json:"target" validate:"required_with_all=Price1 Price2"`
 	}
 
 	t.Run("float zero is absent", func(t *testing.T) {
@@ -448,7 +448,7 @@ func TestAllConstraintsMixedTypes(t *testing.T) {
 		IntField    int     `json:"int_field"`
 		BoolField   bool    `json:"bool_field"`
 		FloatField  float64 `json:"float_field"`
-		Target      string  `json:"target" pedantigo:"required_with_all=StringField IntField BoolField FloatField"`
+		Target      string  `json:"target" validate:"required_with_all=StringField IntField BoolField FloatField"`
 	}
 
 	t.Run("mixed all present", func(t *testing.T) {
@@ -515,7 +515,7 @@ func TestAllConstraintsMixedTypes(t *testing.T) {
 func TestAllConstraintsSingleField(t *testing.T) {
 	type Form struct {
 		A      string `json:"a"`
-		Target string `json:"target" pedantigo:"required_with_all=A"`
+		Target string `json:"target" validate:"required_with_all=A"`
 	}
 
 	t.Run("single field present", func(t *testing.T) {
@@ -543,7 +543,7 @@ func TestExcludedWithAllComplexScenario(t *testing.T) {
 		CVV        string `json:"cvv"`
 		ExpiryDate string `json:"expiry_date"`
 		// CashAmount should not be present if all credit card fields are present
-		CashAmount string `json:"cash_amount" pedantigo:"excluded_with_all=CreditCard CVV ExpiryDate"`
+		CashAmount string `json:"cash_amount" validate:"excluded_with_all=CreditCard CVV ExpiryDate"`
 	}
 
 	t.Run("credit card payment - no cash", func(t *testing.T) {
@@ -597,7 +597,7 @@ func TestRequiredWithoutAllComplexScenario(t *testing.T) {
 		Email    string `json:"email"`
 		Phone    string `json:"phone"`
 		// If none of the identifiers are present, OTP is required
-		OTP string `json:"otp" pedantigo:"required_without_all=Username Email Phone"`
+		OTP string `json:"otp" validate:"required_without_all=Username Email Phone"`
 	}
 
 	t.Run("no identifiers - otp required", func(t *testing.T) {
@@ -650,10 +650,10 @@ func TestAllConstraintsMultipleOnSameStruct(t *testing.T) {
 		A       string `json:"a"`
 		B       string `json:"b"`
 		C       string `json:"c"`
-		Target1 string `json:"target1" pedantigo:"required_with_all=A B"`
-		Target2 string `json:"target2" pedantigo:"excluded_with_all=A B C"`
-		Target3 string `json:"target3" pedantigo:"required_without_all=A B C"`
-		Target4 string `json:"target4" pedantigo:"excluded_without_all=A B C"`
+		Target1 string `json:"target1" validate:"required_with_all=A B"`
+		Target2 string `json:"target2" validate:"excluded_with_all=A B C"`
+		Target3 string `json:"target3" validate:"required_without_all=A B C"`
+		Target4 string `json:"target4" validate:"excluded_without_all=A B C"`
 	}
 
 	t.Run("all fields present", func(t *testing.T) {
@@ -705,14 +705,14 @@ func TestAllConstraintsFieldOrdering(t *testing.T) {
 		A      string `json:"a"`
 		B      string `json:"b"`
 		C      string `json:"c"`
-		Target string `json:"target" pedantigo:"required_with_all=A B C"`
+		Target string `json:"target" validate:"required_with_all=A B C"`
 	}
 
 	type Form2 struct {
 		A      string `json:"a"`
 		B      string `json:"b"`
 		C      string `json:"c"`
-		Target string `json:"target" pedantigo:"required_with_all=C B A"`
+		Target string `json:"target" validate:"required_with_all=C B A"`
 	}
 
 	t.Run("forward order", func(t *testing.T) {
@@ -732,7 +732,7 @@ func TestAllConstraintsWithPointers(t *testing.T) {
 	type Form struct {
 		A      *string `json:"a"`
 		B      *string `json:"b"`
-		Target string  `json:"target" pedantigo:"required_with_all=A B"`
+		Target string  `json:"target" validate:"required_with_all=A B"`
 	}
 
 	a := "value_a"

--- a/internal/constraints/crossfield_all_test.go
+++ b/internal/constraints/crossfield_all_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	pedantigo "github.com/SmrutAI/pedantigo"
+	pedantigo "github.com/SmrutAI/pedantigo/v2"
 )
 
 // ============================================================================

--- a/internal/constraints/crossfield_comparison_test.go
+++ b/internal/constraints/crossfield_comparison_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	. "github.com/SmrutAI/pedantigo"
+	. "github.com/SmrutAI/pedantigo/v2"
 )
 
 // TestCrossFieldComparison tests all cross-field comparison constraints.

--- a/internal/constraints/crossfield_comparison_test.go
+++ b/internal/constraints/crossfield_comparison_test.go
@@ -23,8 +23,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "eqfield: string equality valid",
 			testFunc: func(t *testing.T) {
 				type PasswordChange struct {
-					Password string `pedantigo:"required"`
-					Confirm  string `pedantigo:"required,eqfield=Password"`
+					Password string `validate:"required"`
+					Confirm  string `validate:"required,eqfield=Password"`
 				}
 
 				validator := New[PasswordChange]()
@@ -42,8 +42,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "eqfield: string equality invalid",
 			testFunc: func(t *testing.T) {
 				type PasswordChange struct {
-					Password string `pedantigo:"required"`
-					Confirm  string `pedantigo:"required,eqfield=Password"`
+					Password string `validate:"required"`
+					Confirm  string `validate:"required,eqfield=Password"`
 				}
 
 				validator := New[PasswordChange]()
@@ -72,8 +72,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "eqfield: email equality valid",
 			testFunc: func(t *testing.T) {
 				type SignUp struct {
-					Email      string `pedantigo:"required,email"`
-					EmailCheck string `pedantigo:"required,email,eqfield=Email"`
+					Email      string `validate:"required,email"`
+					EmailCheck string `validate:"required,email,eqfield=Email"`
 				}
 
 				validator := New[SignUp]()
@@ -91,8 +91,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "eqfield: int equality valid",
 			testFunc: func(t *testing.T) {
 				type TransactionVerify struct {
-					Amount  int `pedantigo:"gt=0"`
-					Confirm int `pedantigo:"gt=0,eqfield=Amount"`
+					Amount  int `validate:"gt=0"`
+					Confirm int `validate:"gt=0,eqfield=Amount"`
 				}
 
 				validator := New[TransactionVerify]()
@@ -110,8 +110,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "eqfield: float equality valid",
 			testFunc: func(t *testing.T) {
 				type PriceMatch struct {
-					ExpectedPrice float64 `pedantigo:"gt=0"`
-					ActualPrice   float64 `pedantigo:"gt=0,eqfield=ExpectedPrice"`
+					ExpectedPrice float64 `validate:"gt=0"`
+					ActualPrice   float64 `validate:"gt=0,eqfield=ExpectedPrice"`
 				}
 
 				validator := New[PriceMatch]()
@@ -129,8 +129,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "eqfield: zero values equal valid",
 			testFunc: func(t *testing.T) {
 				type ZeroComparison struct {
-					Field1 int `pedantigo:"eqfield=Field2"`
-					Field2 int `pedantigo:"eqfield=Field1"`
+					Field1 int `validate:"eqfield=Field2"`
+					Field2 int `validate:"eqfield=Field1"`
 				}
 
 				validator := New[ZeroComparison]()
@@ -150,8 +150,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "nefield: float inequality valid",
 			testFunc: func(t *testing.T) {
 				type DiscountCode struct {
-					OriginalPrice   float64 `pedantigo:"gt=0"`
-					DiscountedPrice float64 `pedantigo:"gt=0,nefield=OriginalPrice"`
+					OriginalPrice   float64 `validate:"gt=0"`
+					DiscountedPrice float64 `validate:"gt=0,nefield=OriginalPrice"`
 				}
 
 				validator := New[DiscountCode]()
@@ -169,8 +169,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "nefield: float inequality invalid",
 			testFunc: func(t *testing.T) {
 				type DiscountCode struct {
-					OriginalPrice   float64 `pedantigo:"gt=0"`
-					DiscountedPrice float64 `pedantigo:"gt=0,nefield=OriginalPrice"`
+					OriginalPrice   float64 `validate:"gt=0"`
+					DiscountedPrice float64 `validate:"gt=0,nefield=OriginalPrice"`
 				}
 
 				validator := New[DiscountCode]()
@@ -188,8 +188,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "nefield: string inequality valid",
 			testFunc: func(t *testing.T) {
 				type UniqueLogins struct {
-					Username string `pedantigo:"required,min=3"`
-					Nickname string `pedantigo:"required,min=1,nefield=Username"`
+					Username string `validate:"required,min=3"`
+					Nickname string `validate:"required,min=1,nefield=Username"`
 				}
 
 				validator := New[UniqueLogins]()
@@ -207,8 +207,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "nefield: zero values inequality invalid",
 			testFunc: func(t *testing.T) {
 				type UnequalCheck struct {
-					Field1 int `pedantigo:"nefield=Field2"`
-					Field2 int `pedantigo:"nefield=Field1"`
+					Field1 int `validate:"nefield=Field2"`
+					Field2 int `validate:"nefield=Field1"`
 				}
 
 				validator := New[UnequalCheck]()
@@ -226,8 +226,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "nefield: zero values inequality valid",
 			testFunc: func(t *testing.T) {
 				type UnequalCheck struct {
-					Field1 int `pedantigo:"nefield=Field2"`
-					Field2 int `pedantigo:"nefield=Field1"`
+					Field1 int `validate:"nefield=Field2"`
+					Field2 int `validate:"nefield=Field1"`
 				}
 
 				validator := New[UnequalCheck]()
@@ -247,8 +247,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "gtfield: int greater than valid",
 			testFunc: func(t *testing.T) {
 				type DateRange struct {
-					StartYear int `pedantigo:"min=1900"`
-					EndYear   int `pedantigo:"min=1900,gtfield=StartYear"`
+					StartYear int `validate:"min=1900"`
+					EndYear   int `validate:"min=1900,gtfield=StartYear"`
 				}
 
 				validator := New[DateRange]()
@@ -266,8 +266,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "gtfield: int greater than invalid equal",
 			testFunc: func(t *testing.T) {
 				type DateRange struct {
-					StartYear int `pedantigo:"min=1900"`
-					EndYear   int `pedantigo:"min=1900,gtfield=StartYear"`
+					StartYear int `validate:"min=1900"`
+					EndYear   int `validate:"min=1900,gtfield=StartYear"`
 				}
 
 				validator := New[DateRange]()
@@ -285,8 +285,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "gtfield: float greater than valid",
 			testFunc: func(t *testing.T) {
 				type PriceComparison struct {
-					MinPrice float64 `pedantigo:"gt=0"`
-					MaxPrice float64 `pedantigo:"gt=0,gtfield=MinPrice"`
+					MinPrice float64 `validate:"gt=0"`
+					MaxPrice float64 `validate:"gt=0,gtfield=MinPrice"`
 				}
 
 				validator := New[PriceComparison]()
@@ -304,8 +304,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "gtfield: string greater than valid",
 			testFunc: func(t *testing.T) {
 				type StringComparison struct {
-					FirstName  string `pedantigo:"required"`
-					SecondName string `pedantigo:"required,gtfield=FirstName"`
+					FirstName  string `validate:"required"`
+					SecondName string `validate:"required,gtfield=FirstName"`
 				}
 
 				validator := New[StringComparison]()
@@ -323,7 +323,7 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "gtfield: negative numbers greater than valid",
 			testFunc: func(t *testing.T) {
 				type NegativeComparison struct {
-					Lower int `pedantigo:"gtfield=Upper"`
+					Lower int `validate:"gtfield=Upper"`
 					Upper int
 				}
 
@@ -344,8 +344,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "gtefield: int greater or equal valid greater",
 			testFunc: func(t *testing.T) {
 				type VersionComparison struct {
-					MinVersion int `pedantigo:"gt=0"`
-					MaxVersion int `pedantigo:"gt=0,gtefield=MinVersion"`
+					MinVersion int `validate:"gt=0"`
+					MaxVersion int `validate:"gt=0,gtefield=MinVersion"`
 				}
 
 				validator := New[VersionComparison]()
@@ -363,8 +363,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "gtefield: int greater or equal valid equal",
 			testFunc: func(t *testing.T) {
 				type VersionComparison struct {
-					MinVersion int `pedantigo:"gt=0"`
-					MaxVersion int `pedantigo:"gt=0,gtefield=MinVersion"`
+					MinVersion int `validate:"gt=0"`
+					MaxVersion int `validate:"gt=0,gtefield=MinVersion"`
 				}
 
 				validator := New[VersionComparison]()
@@ -382,8 +382,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "gtefield: int greater or equal invalid",
 			testFunc: func(t *testing.T) {
 				type VersionComparison struct {
-					MinVersion int `pedantigo:"gt=0"`
-					MaxVersion int `pedantigo:"gt=0,gtefield=MinVersion"`
+					MinVersion int `validate:"gt=0"`
+					MaxVersion int `validate:"gt=0,gtefield=MinVersion"`
 				}
 
 				validator := New[VersionComparison]()
@@ -401,8 +401,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "gtefield: float greater or equal valid equal",
 			testFunc: func(t *testing.T) {
 				type ScoreComparison struct {
-					MinScore float64 `pedantigo:"gte=0"`
-					MaxScore float64 `pedantigo:"gte=0,gtefield=MinScore"`
+					MinScore float64 `validate:"gte=0"`
+					MaxScore float64 `validate:"gte=0,gtefield=MinScore"`
 				}
 
 				validator := New[ScoreComparison]()
@@ -420,8 +420,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "gtefield: string greater or equal valid equal",
 			testFunc: func(t *testing.T) {
 				type StringComparison struct {
-					StartStr string `pedantigo:"required"`
-					EndStr   string `pedantigo:"required,gtefield=StartStr"`
+					StartStr string `validate:"required"`
+					EndStr   string `validate:"required,gtefield=StartStr"`
 				}
 
 				validator := New[StringComparison]()
@@ -439,7 +439,7 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "gtefield: zero values greater or equal valid",
 			testFunc: func(t *testing.T) {
 				type ZeroGreaterOrEqualCheck struct {
-					Field1 int `pedantigo:"gtefield=Field2"`
+					Field1 int `validate:"gtefield=Field2"`
 					Field2 int
 				}
 
@@ -460,8 +460,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "ltfield: int less than valid",
 			testFunc: func(t *testing.T) {
 				type AgeRange struct {
-					MinAge int `pedantigo:"gt=0,ltfield=MaxAge"`
-					MaxAge int `pedantigo:"gt=0"`
+					MinAge int `validate:"gt=0,ltfield=MaxAge"`
+					MaxAge int `validate:"gt=0"`
 				}
 
 				validator := New[AgeRange]()
@@ -479,8 +479,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "ltfield: int less than invalid equal",
 			testFunc: func(t *testing.T) {
 				type AgeRangeWithLt struct {
-					MinAge int `pedantigo:"gt=0,ltfield=MaxAge"`
-					MaxAge int `pedantigo:"gt=0"`
+					MinAge int `validate:"gt=0,ltfield=MaxAge"`
+					MaxAge int `validate:"gt=0"`
 				}
 
 				validator := New[AgeRangeWithLt]()
@@ -498,7 +498,7 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "ltfield: float less than valid",
 			testFunc: func(t *testing.T) {
 				type TemperatureRange struct {
-					MinTemp float64 `pedantigo:"ltfield=MaxTemp"`
+					MinTemp float64 `validate:"ltfield=MaxTemp"`
 					MaxTemp float64
 				}
 
@@ -517,8 +517,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "ltfield: string less than valid",
 			testFunc: func(t *testing.T) {
 				type StringOrder struct {
-					First  string `pedantigo:"required,ltfield=Second"`
-					Second string `pedantigo:"required"`
+					First  string `validate:"required,ltfield=Second"`
+					Second string `validate:"required"`
 				}
 
 				validator := New[StringOrder]()
@@ -536,7 +536,7 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "ltfield: negative numbers less than valid",
 			testFunc: func(t *testing.T) {
 				type NegativeComparison struct {
-					Lower int `pedantigo:"ltfield=Upper"`
+					Lower int `validate:"ltfield=Upper"`
 					Upper int
 				}
 
@@ -557,8 +557,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "ltefield: int less or equal valid less",
 			testFunc: func(t *testing.T) {
 				type RankRange struct {
-					StartRank int `pedantigo:"gt=0,ltefield=EndRank"`
-					EndRank   int `pedantigo:"gt=0"`
+					StartRank int `validate:"gt=0,ltefield=EndRank"`
+					EndRank   int `validate:"gt=0"`
 				}
 
 				validator := New[RankRange]()
@@ -576,8 +576,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "ltefield: int less or equal valid equal",
 			testFunc: func(t *testing.T) {
 				type RankRange struct {
-					StartRank int `pedantigo:"gt=0,ltefield=EndRank"`
-					EndRank   int `pedantigo:"gt=0"`
+					StartRank int `validate:"gt=0,ltefield=EndRank"`
+					EndRank   int `validate:"gt=0"`
 				}
 
 				validator := New[RankRange]()
@@ -595,8 +595,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "ltefield: float less or equal valid equal",
 			testFunc: func(t *testing.T) {
 				type PriceRange struct {
-					MinPrice float64 `pedantigo:"gt=0,ltefield=MaxPrice"`
-					MaxPrice float64 `pedantigo:"gt=0"`
+					MinPrice float64 `validate:"gt=0,ltefield=MaxPrice"`
+					MaxPrice float64 `validate:"gt=0"`
 				}
 
 				validator := New[PriceRange]()
@@ -614,8 +614,8 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "ltefield: string less or equal valid equal",
 			testFunc: func(t *testing.T) {
 				type StringBoundary struct {
-					Start string `pedantigo:"required,ltefield=End"`
-					End   string `pedantigo:"required"`
+					Start string `validate:"required,ltefield=End"`
+					End   string `validate:"required"`
 				}
 
 				validator := New[StringBoundary]()
@@ -633,7 +633,7 @@ func TestCrossFieldComparison_BasicOperators(t *testing.T) {
 			name: "ltefield: zero values less or equal valid",
 			testFunc: func(t *testing.T) {
 				type ZeroLessOrEqualCheck struct {
-					Field1 int `pedantigo:"ltefield=Field2"`
+					Field1 int `validate:"ltefield=Field2"`
 					Field2 int
 				}
 
@@ -672,9 +672,9 @@ func TestCrossFieldComparison(t *testing.T) {
 			name: "multiple constraints valid",
 			testFunc: func(t *testing.T) {
 				type TransactionBounds struct {
-					MinAmount    float64 `pedantigo:"gt=0"`
-					MaxAmount    float64 `pedantigo:"gt=0,gtfield=MinAmount"`
-					ActualAmount float64 `pedantigo:"gt=0,gtefield=MinAmount,ltefield=MaxAmount"`
+					MinAmount    float64 `validate:"gt=0"`
+					MaxAmount    float64 `validate:"gt=0,gtfield=MinAmount"`
+					ActualAmount float64 `validate:"gt=0,gtefield=MinAmount,ltefield=MaxAmount"`
 				}
 
 				validator := New[TransactionBounds]()
@@ -693,9 +693,9 @@ func TestCrossFieldComparison(t *testing.T) {
 			name: "multiple constraints invalid",
 			testFunc: func(t *testing.T) {
 				type TransactionBounds struct {
-					MinAmount    float64 `pedantigo:"gt=0"`
-					MaxAmount    float64 `pedantigo:"gt=0,gtfield=MinAmount"`
-					ActualAmount float64 `pedantigo:"gt=0,gtefield=MinAmount,ltefield=MaxAmount"`
+					MinAmount    float64 `validate:"gt=0"`
+					MaxAmount    float64 `validate:"gt=0,gtfield=MinAmount"`
+					ActualAmount float64 `validate:"gt=0,gtefield=MinAmount,ltefield=MaxAmount"`
 				}
 
 				validator := New[TransactionBounds]()
@@ -714,9 +714,9 @@ func TestCrossFieldComparison(t *testing.T) {
 			name: "three way dependency valid",
 			testFunc: func(t *testing.T) {
 				type OrderValidation struct {
-					OrderTotal     float64 `pedantigo:"gt=0"`
-					DiscountAmount float64 `pedantigo:"gte=0,ltefield=OrderTotal"`
-					FinalAmount    float64 `pedantigo:"gt=0,ltfield=OrderTotal,gtfield=DiscountAmount"`
+					OrderTotal     float64 `validate:"gt=0"`
+					DiscountAmount float64 `validate:"gte=0,ltefield=OrderTotal"`
+					FinalAmount    float64 `validate:"gt=0,ltfield=OrderTotal,gtfield=DiscountAmount"`
 				}
 
 				validator := New[OrderValidation]()
@@ -758,8 +758,8 @@ func TestCrossFieldComparison(t *testing.T) {
 			name: "uint comparison valid",
 			testFunc: func(t *testing.T) {
 				type PortRange struct {
-					MinPort uint `pedantigo:"gt=0,ltfield=MaxPort"`
-					MaxPort uint `pedantigo:"gt=0"`
+					MinPort uint `validate:"gt=0,ltfield=MaxPort"`
+					MaxPort uint `validate:"gt=0"`
 				}
 
 				validator := New[PortRange]()
@@ -777,8 +777,8 @@ func TestCrossFieldComparison(t *testing.T) {
 			name: "uint comparison invalid",
 			testFunc: func(t *testing.T) {
 				type PortRange struct {
-					MinPort uint `pedantigo:"gt=0,ltfield=MaxPort"`
-					MaxPort uint `pedantigo:"gt=0"`
+					MinPort uint `validate:"gt=0,ltfield=MaxPort"`
+					MaxPort uint `validate:"gt=0"`
 				}
 
 				validator := New[PortRange]()
@@ -796,7 +796,7 @@ func TestCrossFieldComparison(t *testing.T) {
 			name: "int32 comparison valid",
 			testFunc: func(t *testing.T) {
 				type Int32Range struct {
-					Start int32 `pedantigo:"ltfield=End"`
+					Start int32 `validate:"ltfield=End"`
 					End   int32
 				}
 
@@ -815,7 +815,7 @@ func TestCrossFieldComparison(t *testing.T) {
 			name: "float32 comparison valid",
 			testFunc: func(t *testing.T) {
 				type Float32Range struct {
-					MinVal float32 `pedantigo:"ltfield=MaxVal"`
+					MinVal float32 `validate:"ltfield=MaxVal"`
 					MaxVal float32
 				}
 

--- a/internal/constraints/crossfield_csfield_test.go
+++ b/internal/constraints/crossfield_csfield_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	pedantigo "github.com/SmrutAI/pedantigo"
+	pedantigo "github.com/SmrutAI/pedantigo/v2"
 )
 
 func TestCsFieldConstraints(t *testing.T) {

--- a/internal/constraints/crossfield_csfield_test.go
+++ b/internal/constraints/crossfield_csfield_test.go
@@ -16,7 +16,7 @@ func TestCsFieldConstraints(t *testing.T) {
 		}
 		type Form struct {
 			Inner Inner  `json:"inner"`
-			Match string `json:"match" pedantigo:"eqcsfield=Inner.Value"`
+			Match string `json:"match" validate:"eqcsfield=Inner.Value"`
 		}
 		validator := pedantigo.New[Form]()
 
@@ -42,7 +42,7 @@ func TestCsFieldConstraints(t *testing.T) {
 		}
 		type Form struct {
 			Inner    Inner  `json:"inner"`
-			NotMatch string `json:"not_match" pedantigo:"necsfield=Inner.Value"`
+			NotMatch string `json:"not_match" validate:"necsfield=Inner.Value"`
 		}
 		validator := pedantigo.New[Form]()
 
@@ -68,7 +68,7 @@ func TestCsFieldConstraints(t *testing.T) {
 		}
 		type Form struct {
 			Inner   Inner `json:"inner"`
-			Greater int   `json:"greater" pedantigo:"gtcsfield=Inner.Value"`
+			Greater int   `json:"greater" validate:"gtcsfield=Inner.Value"`
 		}
 		validator := pedantigo.New[Form]()
 
@@ -94,7 +94,7 @@ func TestCsFieldConstraints(t *testing.T) {
 		}
 		type Form struct {
 			Inner       Inner `json:"inner"`
-			GreaterOrEq int   `json:"greater_or_eq" pedantigo:"gtecsfield=Inner.Value"`
+			GreaterOrEq int   `json:"greater_or_eq" validate:"gtecsfield=Inner.Value"`
 		}
 		validator := pedantigo.New[Form]()
 
@@ -127,7 +127,7 @@ func TestCsFieldConstraints(t *testing.T) {
 		}
 		type Form struct {
 			Inner Inner `json:"inner"`
-			Less  int   `json:"less" pedantigo:"ltcsfield=Inner.Value"`
+			Less  int   `json:"less" validate:"ltcsfield=Inner.Value"`
 		}
 		validator := pedantigo.New[Form]()
 
@@ -153,7 +153,7 @@ func TestCsFieldConstraints(t *testing.T) {
 		}
 		type Form struct {
 			Inner    Inner `json:"inner"`
-			LessOrEq int   `json:"less_or_eq" pedantigo:"ltecsfield=Inner.Value"`
+			LessOrEq int   `json:"less_or_eq" validate:"ltecsfield=Inner.Value"`
 		}
 		validator := pedantigo.New[Form]()
 

--- a/internal/constraints/crossfield_edge_cases_test.go
+++ b/internal/constraints/crossfield_edge_cases_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	. "github.com/SmrutAI/pedantigo"
+	. "github.com/SmrutAI/pedantigo/v2"
 )
 
 // runPanicTest runs a test function and checks for expected panic.

--- a/internal/constraints/crossfield_edge_cases_test.go
+++ b/internal/constraints/crossfield_edge_cases_test.go
@@ -67,8 +67,8 @@ func TestCrossField_NonexistentField(t *testing.T) {
 			name: "eqfield with nonexistent target field",
 			testFunc: func() interface{} {
 				type User struct {
-					Password        string `pedantigo:"required"`
-					ConfirmPassword string `pedantigo:"eqfield=NonExistentField"`
+					Password        string `validate:"required"`
+					ConfirmPassword string `validate:"eqfield=NonExistentField"`
 				}
 				return New[User]()
 			},
@@ -78,8 +78,8 @@ func TestCrossField_NonexistentField(t *testing.T) {
 			name: "gtfield with nonexistent target field",
 			testFunc: func() interface{} {
 				type Range struct {
-					Min int `pedantigo:"required"`
-					Val int `pedantigo:"gtfield=NoSuchField"`
+					Min int `validate:"required"`
+					Val int `validate:"gtfield=NoSuchField"`
 				}
 				return New[Range]()
 			},
@@ -89,8 +89,8 @@ func TestCrossField_NonexistentField(t *testing.T) {
 			name: "ltfield with nonexistent target field",
 			testFunc: func() interface{} {
 				type Range struct {
-					Max int `pedantigo:"required"`
-					Val int `pedantigo:"ltfield=InvalidTarget"`
+					Max int `validate:"required"`
+					Val int `validate:"ltfield=InvalidTarget"`
 				}
 				return New[Range]()
 			},
@@ -114,8 +114,8 @@ func TestCrossField_TypeIncompatibility(t *testing.T) {
 			name: "string compared with int (gtfield)",
 			setup: func() (interface{}, interface{}) {
 				type Mixed struct {
-					Age  int    `pedantigo:"required"`
-					Name string `pedantigo:"gtfield=Age"`
+					Age  int    `validate:"required"`
+					Name string `validate:"gtfield=Age"`
 				}
 				v := New[Mixed]()
 				return v, &Mixed{Age: 25, Name: "Alice"}
@@ -126,8 +126,8 @@ func TestCrossField_TypeIncompatibility(t *testing.T) {
 			name: "string compared with float64 (ltfield)",
 			setup: func() (interface{}, interface{}) {
 				type Mixed struct {
-					Price float64 `pedantigo:"required"`
-					Label string  `pedantigo:"ltfield=Price"`
+					Price float64 `validate:"required"`
+					Label string  `validate:"ltfield=Price"`
 				}
 				v := New[Mixed]()
 				return v, &Mixed{Price: 99.99, Label: "expensive"}
@@ -141,8 +141,8 @@ func TestCrossField_TypeIncompatibility(t *testing.T) {
 					Value int
 				}
 				type Mixed struct {
-					Count  int    `pedantigo:"required"`
-					Config Nested `pedantigo:"eqfield=Count"`
+					Count  int    `validate:"required"`
+					Config Nested `validate:"eqfield=Count"`
 				}
 				v := New[Mixed]()
 				return v, &Mixed{Count: 5, Config: Nested{Value: 5}}
@@ -180,8 +180,8 @@ func TestCrossField_NilPointer(t *testing.T) {
 			name: "target field is nil pointer",
 			setup: func() (interface{}, interface{}) {
 				type Optional struct {
-					Value  *int `pedantigo:"required"`
-					MinVal int  `pedantigo:"ltfield=Value"`
+					Value  *int `validate:"required"`
+					MinVal int  `validate:"ltfield=Value"`
 				}
 				v := New[Optional]()
 				return v, &Optional{Value: nil, MinVal: 10}
@@ -192,8 +192,8 @@ func TestCrossField_NilPointer(t *testing.T) {
 			name: "source field is nil pointer",
 			setup: func() (interface{}, interface{}) {
 				type Optional struct {
-					Value  *int `pedantigo:"required"`
-					MinVal *int `pedantigo:"gtfield=Value"`
+					Value  *int `validate:"required"`
+					MinVal *int `validate:"gtfield=Value"`
 				}
 				v := New[Optional]()
 				val := 10
@@ -205,8 +205,8 @@ func TestCrossField_NilPointer(t *testing.T) {
 			name: "both fields are nil pointers (should be equal)",
 			setup: func() (interface{}, interface{}) {
 				type Optional struct {
-					Field1 *int `pedantigo:"required"`
-					Field2 *int `pedantigo:"eqfield=Field1"`
+					Field1 *int `validate:"required"`
+					Field2 *int `validate:"eqfield=Field1"`
 				}
 				v := New[Optional]()
 				return v, &Optional{Field1: nil, Field2: nil}
@@ -241,8 +241,8 @@ func TestCrossField_CaseSensitivity(t *testing.T) {
 			name: "lowercase field reference (case mismatch)",
 			testFunc: func() interface{} {
 				type CaseTest struct {
-					Value    int `pedantigo:"required"`
-					MinValue int `pedantigo:"gtfield=value"`
+					Value    int `validate:"required"`
+					MinValue int `validate:"gtfield=value"`
 				}
 				return New[CaseTest]()
 			},
@@ -252,8 +252,8 @@ func TestCrossField_CaseSensitivity(t *testing.T) {
 			name: "incorrect mixed case field reference",
 			testFunc: func() interface{} {
 				type CaseTest struct {
-					UserID   int `pedantigo:"required"`
-					MinLimit int `pedantigo:"ltfield=userid"`
+					UserID   int `validate:"required"`
+					MinLimit int `validate:"ltfield=userid"`
 				}
 				return New[CaseTest]()
 			},
@@ -263,8 +263,8 @@ func TestCrossField_CaseSensitivity(t *testing.T) {
 			name: "correct case field reference (should work)",
 			testFunc: func() interface{} {
 				type CaseTest struct {
-					Value    int `pedantigo:"required"`
-					MinValue int `pedantigo:"gtfield=Value"`
+					Value    int `validate:"required"`
+					MinValue int `validate:"gtfield=Value"`
 				}
 				return New[CaseTest]()
 			},
@@ -286,7 +286,7 @@ func TestCrossField_NestedStruct(t *testing.T) {
 	}
 	type Outer struct {
 		Inner Inner
-		Check int `pedantigo:"eqfield=Inner.Value"`
+		Check int `validate:"eqfield=Inner.Value"`
 	}
 
 	t.Run("nested field reference - valid", func(t *testing.T) {
@@ -319,9 +319,9 @@ func TestCrossField_MultipleConstraints(t *testing.T) {
 			name: "both constraints valid",
 			setup: func() (interface{}, interface{}) {
 				type Range struct {
-					Min int `pedantigo:"required"`
-					Max int `pedantigo:"required"`
-					Val int `pedantigo:"gtfield=Min,ltfield=Max"`
+					Min int `validate:"required"`
+					Max int `validate:"required"`
+					Val int `validate:"gtfield=Min,ltfield=Max"`
 				}
 				v := New[Range]()
 				return v, &Range{Min: 0, Max: 100, Val: 50}
@@ -332,9 +332,9 @@ func TestCrossField_MultipleConstraints(t *testing.T) {
 			name: "first constraint fails",
 			setup: func() (interface{}, interface{}) {
 				type Range struct {
-					Min int `pedantigo:"required"`
-					Max int `pedantigo:"required"`
-					Val int `pedantigo:"gtfield=Min,ltfield=Max"`
+					Min int `validate:"required"`
+					Max int `validate:"required"`
+					Val int `validate:"gtfield=Min,ltfield=Max"`
 				}
 				v := New[Range]()
 				return v, &Range{Min: 50, Max: 100, Val: 40}
@@ -345,9 +345,9 @@ func TestCrossField_MultipleConstraints(t *testing.T) {
 			name: "second constraint fails",
 			setup: func() (interface{}, interface{}) {
 				type Range struct {
-					Min int `pedantigo:"required"`
-					Max int `pedantigo:"required"`
-					Val int `pedantigo:"gtfield=Min,ltfield=Max"`
+					Min int `validate:"required"`
+					Max int `validate:"required"`
+					Val int `validate:"gtfield=Min,ltfield=Max"`
 				}
 				v := New[Range]()
 				return v, &Range{Min: 0, Max: 50, Val: 60}
@@ -358,9 +358,9 @@ func TestCrossField_MultipleConstraints(t *testing.T) {
 			name: "both constraints fail",
 			setup: func() (interface{}, interface{}) {
 				type Range struct {
-					Min int `pedantigo:"required"`
-					Max int `pedantigo:"required"`
-					Val int `pedantigo:"gtfield=Min,ltfield=Max"`
+					Min int `validate:"required"`
+					Max int `validate:"required"`
+					Val int `validate:"gtfield=Min,ltfield=Max"`
 				}
 				v := New[Range]()
 				return v, &Range{Min: 50, Max: 40, Val: 30}
@@ -397,7 +397,7 @@ func TestCrossField_SelfReference(t *testing.T) {
 			name: "eqfield self-reference",
 			testFunc: func() interface{} {
 				type Recursive struct {
-					Value int `pedantigo:"eqfield=Value"`
+					Value int `validate:"eqfield=Value"`
 				}
 				return New[Recursive]()
 			},
@@ -407,7 +407,7 @@ func TestCrossField_SelfReference(t *testing.T) {
 			name: "gtfield self-reference",
 			testFunc: func() interface{} {
 				type Recursive struct {
-					Value int `pedantigo:"gtfield=Value"`
+					Value int `validate:"gtfield=Value"`
 				}
 				return New[Recursive]()
 			},
@@ -442,8 +442,8 @@ func TestCrossField_CircularDependency(t *testing.T) {
 			name: "two-field circular dependency",
 			setup: func() (interface{}, interface{}) {
 				type Circular struct {
-					Field1 int `pedantigo:"gtfield=Field2"`
-					Field2 int `pedantigo:"gtfield=Field1"`
+					Field1 int `validate:"gtfield=Field2"`
+					Field2 int `validate:"gtfield=Field1"`
 				}
 				v := New[Circular]()
 				return v, &Circular{Field1: 10, Field2: 5}
@@ -477,9 +477,9 @@ func TestCrossField_ZeroValue(t *testing.T) {
 			name: "both fields are zero (should be equal)",
 			setup: func() (interface{}, interface{}) {
 				type Range struct {
-					Min int `pedantigo:"required"`
-					Max int `pedantigo:"required"`
-					Val int `pedantigo:"eqfield=Min"`
+					Min int `validate:"required"`
+					Max int `validate:"required"`
+					Val int `validate:"eqfield=Min"`
 				}
 				v := New[Range]()
 				return v, &Range{Min: 0, Max: 100, Val: 0}
@@ -490,8 +490,8 @@ func TestCrossField_ZeroValue(t *testing.T) {
 			name: "zero vs non-zero (should fail equality)",
 			setup: func() (interface{}, interface{}) {
 				type Range struct {
-					Min int `pedantigo:"required"`
-					Val int `pedantigo:"eqfield=Min"`
+					Min int `validate:"required"`
+					Val int `validate:"eqfield=Min"`
 				}
 				v := New[Range]()
 				return v, &Range{Min: 10, Val: 0}
@@ -502,8 +502,8 @@ func TestCrossField_ZeroValue(t *testing.T) {
 			name: "both empty strings (should be equal)",
 			setup: func() (interface{}, interface{}) {
 				type Strings struct {
-					Field1 string `pedantigo:"required"`
-					Field2 string `pedantigo:"eqfield=Field1"`
+					Field1 string `validate:"required"`
+					Field2 string `validate:"eqfield=Field1"`
 				}
 				v := New[Strings]()
 				return v, &Strings{Field1: "", Field2: ""}
@@ -542,8 +542,8 @@ func TestCrossField_NumericTypeCompatibility(t *testing.T) {
 			name: "int vs int64 comparison",
 			setup: func() (interface{}, interface{}) {
 				type Mixed struct {
-					Value1 int   `pedantigo:"required"`
-					Value2 int64 `pedantigo:"gtfield=Value1"`
+					Value1 int   `validate:"required"`
+					Value2 int64 `validate:"gtfield=Value1"`
 				}
 				v := New[Mixed]()
 				return v, &Mixed{Value1: 10, Value2: 20}
@@ -554,8 +554,8 @@ func TestCrossField_NumericTypeCompatibility(t *testing.T) {
 			name: "float64 vs int comparison",
 			setup: func() (interface{}, interface{}) {
 				type Mixed struct {
-					IntVal   int     `pedantigo:"required"`
-					FloatVal float64 `pedantigo:"ltfield=IntVal"`
+					IntVal   int     `validate:"required"`
+					FloatVal float64 `validate:"ltfield=IntVal"`
 				}
 				v := New[Mixed]()
 				return v, &Mixed{IntVal: 100, FloatVal: 50.5}
@@ -566,8 +566,8 @@ func TestCrossField_NumericTypeCompatibility(t *testing.T) {
 			name: "uint vs int comparison",
 			setup: func() (interface{}, interface{}) {
 				type Mixed struct {
-					Signed   int  `pedantigo:"required"`
-					Unsigned uint `pedantigo:"eqfield=Signed"`
+					Signed   int  `validate:"required"`
+					Unsigned uint `validate:"eqfield=Signed"`
 				}
 				v := New[Mixed]()
 				return v, &Mixed{Signed: 10, Unsigned: 10}
@@ -601,8 +601,8 @@ func TestCrossField_EmptyString(t *testing.T) {
 			name: "empty string equality",
 			setup: func() (interface{}, interface{}) {
 				type Strings struct {
-					Field1 string `pedantigo:"required"`
-					Field2 string `pedantigo:"eqfield=Field1"`
+					Field1 string `validate:"required"`
+					Field2 string `validate:"eqfield=Field1"`
 				}
 				v := New[Strings]()
 				return v, &Strings{Field1: "", Field2: ""}
@@ -613,8 +613,8 @@ func TestCrossField_EmptyString(t *testing.T) {
 			name: "empty string inequality (should fail)",
 			setup: func() (interface{}, interface{}) {
 				type Strings struct {
-					Field1 string `pedantigo:"required"`
-					Field2 string `pedantigo:"nefield=Field1"`
+					Field1 string `validate:"required"`
+					Field2 string `validate:"nefield=Field1"`
 				}
 				v := New[Strings]()
 				return v, &Strings{Field1: "", Field2: ""}
@@ -654,8 +654,8 @@ func TestCrossField_TimeComparison(t *testing.T) {
 			name: "equal times",
 			setup: func() (interface{}, interface{}) {
 				type TimeRange struct {
-					StartTime time.Time `pedantigo:"required"`
-					EndTime   time.Time `pedantigo:"eqfield=StartTime"`
+					StartTime time.Time `validate:"required"`
+					EndTime   time.Time `validate:"eqfield=StartTime"`
 				}
 				v := New[TimeRange]()
 				return v, &TimeRange{StartTime: now, EndTime: now}
@@ -666,8 +666,8 @@ func TestCrossField_TimeComparison(t *testing.T) {
 			name: "end time after start time",
 			setup: func() (interface{}, interface{}) {
 				type TimeRange struct {
-					StartTime time.Time `pedantigo:"required"`
-					EndTime   time.Time `pedantigo:"gtfield=StartTime"`
+					StartTime time.Time `validate:"required"`
+					EndTime   time.Time `validate:"gtfield=StartTime"`
 				}
 				v := New[TimeRange]()
 				return v, &TimeRange{StartTime: now, EndTime: now.Add(1 * time.Hour)}
@@ -678,8 +678,8 @@ func TestCrossField_TimeComparison(t *testing.T) {
 			name: "end time before start time (should fail)",
 			setup: func() (interface{}, interface{}) {
 				type TimeRange struct {
-					StartTime time.Time `pedantigo:"required"`
-					EndTime   time.Time `pedantigo:"ltfield=StartTime"`
+					StartTime time.Time `validate:"required"`
+					EndTime   time.Time `validate:"ltfield=StartTime"`
 				}
 				v := New[TimeRange]()
 				return v, &TimeRange{StartTime: now, EndTime: now.Add(-1 * time.Hour)}
@@ -716,8 +716,8 @@ func TestCrossField_AllOperators(t *testing.T) {
 			name: "eqfield (equal) - valid",
 			setup: func() (interface{}, interface{}) {
 				type Pair struct {
-					Field1 int `pedantigo:"required"`
-					Field2 int `pedantigo:"eqfield=Field1"`
+					Field1 int `validate:"required"`
+					Field2 int `validate:"eqfield=Field1"`
 				}
 				v := New[Pair]()
 				return v, &Pair{Field1: 42, Field2: 42}
@@ -728,8 +728,8 @@ func TestCrossField_AllOperators(t *testing.T) {
 			name: "nefield (not equal) - valid",
 			setup: func() (interface{}, interface{}) {
 				type Pair struct {
-					Field1 int `pedantigo:"required"`
-					Field2 int `pedantigo:"nefield=Field1"`
+					Field1 int `validate:"required"`
+					Field2 int `validate:"nefield=Field1"`
 				}
 				v := New[Pair]()
 				return v, &Pair{Field1: 42, Field2: 43}
@@ -740,8 +740,8 @@ func TestCrossField_AllOperators(t *testing.T) {
 			name: "gtfield (greater than) - valid",
 			setup: func() (interface{}, interface{}) {
 				type Pair struct {
-					Field1 int `pedantigo:"required"`
-					Field2 int `pedantigo:"gtfield=Field1"`
+					Field1 int `validate:"required"`
+					Field2 int `validate:"gtfield=Field1"`
 				}
 				v := New[Pair]()
 				return v, &Pair{Field1: 10, Field2: 20}
@@ -752,8 +752,8 @@ func TestCrossField_AllOperators(t *testing.T) {
 			name: "gtefield (greater than or equal) - valid",
 			setup: func() (interface{}, interface{}) {
 				type Pair struct {
-					Field1 int `pedantigo:"required"`
-					Field2 int `pedantigo:"gtefield=Field1"`
+					Field1 int `validate:"required"`
+					Field2 int `validate:"gtefield=Field1"`
 				}
 				v := New[Pair]()
 				return v, &Pair{Field1: 10, Field2: 10}
@@ -764,8 +764,8 @@ func TestCrossField_AllOperators(t *testing.T) {
 			name: "ltfield (less than) - valid",
 			setup: func() (interface{}, interface{}) {
 				type Pair struct {
-					Field1 int `pedantigo:"required"`
-					Field2 int `pedantigo:"ltfield=Field1"`
+					Field1 int `validate:"required"`
+					Field2 int `validate:"ltfield=Field1"`
 				}
 				v := New[Pair]()
 				return v, &Pair{Field1: 100, Field2: 50}
@@ -776,8 +776,8 @@ func TestCrossField_AllOperators(t *testing.T) {
 			name: "ltefield (less than or equal) - valid",
 			setup: func() (interface{}, interface{}) {
 				type Pair struct {
-					Field1 int `pedantigo:"required"`
-					Field2 int `pedantigo:"ltefield=Field1"`
+					Field1 int `validate:"required"`
+					Field2 int `validate:"ltefield=Field1"`
 				}
 				v := New[Pair]()
 				return v, &Pair{Field1: 100, Field2: 100}
@@ -811,8 +811,8 @@ func TestCrossField_BoundaryValues(t *testing.T) {
 			name: "zero and one (boundary)",
 			setup: func() (interface{}, interface{}) {
 				type Boundary struct {
-					Field1 int `pedantigo:"required"`
-					Field2 int `pedantigo:"gtfield=Field1"`
+					Field1 int `validate:"required"`
+					Field2 int `validate:"gtfield=Field1"`
 				}
 				v := New[Boundary]()
 				return v, &Boundary{Field1: 0, Field2: 1}
@@ -823,8 +823,8 @@ func TestCrossField_BoundaryValues(t *testing.T) {
 			name: "negative number comparison",
 			setup: func() (interface{}, interface{}) {
 				type Boundary struct {
-					Field1 int `pedantigo:"required"`
-					Field2 int `pedantigo:"ltfield=Field1"`
+					Field1 int `validate:"required"`
+					Field2 int `validate:"ltfield=Field1"`
 				}
 				v := New[Boundary]()
 				return v, &Boundary{Field1: -10, Field2: -100}
@@ -835,8 +835,8 @@ func TestCrossField_BoundaryValues(t *testing.T) {
 			name: "max int64 comparison",
 			setup: func() (interface{}, interface{}) {
 				type Boundary struct {
-					Field1 int64 `pedantigo:"required"`
-					Field2 int64 `pedantigo:"eqfield=Field1"`
+					Field1 int64 `validate:"required"`
+					Field2 int64 `validate:"eqfield=Field1"`
 				}
 				v := New[Boundary]()
 				return v, &Boundary{Field1: 9223372036854775807, Field2: 9223372036854775807}
@@ -870,8 +870,8 @@ func TestCrossField_BooleanAndComplexTypes(t *testing.T) {
 			name: "boolean comparison",
 			setup: func() (interface{}, interface{}) {
 				type BooleanTest struct {
-					Flag1 bool `pedantigo:"required"`
-					Flag2 bool `pedantigo:"eqfield=Flag1"`
+					Flag1 bool `validate:"required"`
+					Flag2 bool `validate:"eqfield=Flag1"`
 				}
 				v := New[BooleanTest]()
 				return v, &BooleanTest{Flag1: true, Flag2: true}
@@ -882,8 +882,8 @@ func TestCrossField_BooleanAndComplexTypes(t *testing.T) {
 			name: "slice comparison",
 			setup: func() (interface{}, interface{}) {
 				type SliceTest struct {
-					Items []int `pedantigo:"required"`
-					Ref   []int `pedantigo:"eqfield=Items"`
+					Items []int `validate:"required"`
+					Ref   []int `validate:"eqfield=Items"`
 				}
 				v := New[SliceTest]()
 				return v, &SliceTest{Items: []int{1, 2, 3}, Ref: []int{1, 2, 3}}
@@ -917,7 +917,7 @@ func TestCrossField_UnexportedField(t *testing.T) {
 			name: "reference to unexported field",
 			testFunc: func() interface{} {
 				type Unexported struct {
-					Field int `pedantigo:"gtfield=value"`
+					Field int `validate:"gtfield=value"`
 				}
 				return New[Unexported]()
 			},
@@ -952,8 +952,8 @@ func TestCrossField_PointerTypes(t *testing.T) {
 			name: "pointer vs value comparison",
 			setup: func() (interface{}, interface{}) {
 				type PointerTest struct {
-					Value1 *int `pedantigo:"required"`
-					Value2 int  `pedantigo:"gtfield=Value1"`
+					Value1 *int `validate:"required"`
+					Value2 int  `validate:"gtfield=Value1"`
 				}
 				v := New[PointerTest]()
 				val := 10
@@ -965,8 +965,8 @@ func TestCrossField_PointerTypes(t *testing.T) {
 			name: "different pointer types comparison",
 			setup: func() (interface{}, interface{}) {
 				type PointerTest struct {
-					Value1 *int   `pedantigo:"required"`
-					Value2 *int64 `pedantigo:"eqfield=Value1"`
+					Value1 *int   `validate:"required"`
+					Value2 *int64 `validate:"eqfield=Value1"`
 				}
 				v := New[PointerTest]()
 				val1 := 10
@@ -1002,8 +1002,8 @@ func TestCrossField_FieldOrder(t *testing.T) {
 			name: "forward reference to later-defined field",
 			setup: func() (interface{}, interface{}) {
 				type Order struct {
-					Field2 int `pedantigo:"gtfield=Field1"`
-					Field1 int `pedantigo:"required"`
+					Field2 int `validate:"gtfield=Field1"`
+					Field1 int `validate:"required"`
 				}
 				v := New[Order]()
 				return v, &Order{Field1: 10, Field2: 20}
@@ -1037,9 +1037,9 @@ func TestCrossField_ChainedConstraints(t *testing.T) {
 			name: "chain of cross-field constraints (Min < Mid < Max)",
 			setup: func() (interface{}, interface{}) {
 				type MultiConstraint struct {
-					Min int `pedantigo:"required"`
-					Mid int `pedantigo:"gtfield=Min"`
-					Max int `pedantigo:"gtfield=Mid"`
+					Min int `validate:"required"`
+					Mid int `validate:"gtfield=Min"`
+					Max int `validate:"gtfield=Mid"`
 				}
 				v := New[MultiConstraint]()
 				return v, &MultiConstraint{Min: 10, Mid: 20, Max: 30}
@@ -1073,8 +1073,8 @@ func TestCrossField_FloatSpecialValues(t *testing.T) {
 			name: "positive infinity comparison",
 			setup: func() (interface{}, interface{}) {
 				type FloatSpecial struct {
-					Field1 float64 `pedantigo:"required"`
-					Field2 float64 `pedantigo:"gtfield=Field1"`
+					Field1 float64 `validate:"required"`
+					Field2 float64 `validate:"gtfield=Field1"`
 				}
 				v := New[FloatSpecial]()
 				inf := math.Inf(1)

--- a/internal/constraints/crossfield_excluded_test.go
+++ b/internal/constraints/crossfield_excluded_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	pedantigo "github.com/SmrutAI/pedantigo"
+	pedantigo "github.com/SmrutAI/pedantigo/v2"
 )
 
 // checkValidationError verifies that a validation error contains the expected field error.

--- a/internal/constraints/crossfield_excluded_test.go
+++ b/internal/constraints/crossfield_excluded_test.go
@@ -37,19 +37,19 @@ func checkValidationError(t *testing.T, err error, expectErr bool, errField stri
 // TestExcludedIf tests ExcludedIf validation.
 func TestExcludedIf(t *testing.T) {
 	type Payment struct {
-		Method     string `json:"method" pedantigo:"required"`
-		CashAmount int    `json:"cash_amount" pedantigo:"excluded_if=Method card"`
+		Method     string `json:"method" validate:"required"`
+		CashAmount int    `json:"cash_amount" validate:"excluded_if=Method card"`
 	}
 
 	type UserPreferences struct {
-		OptIn       bool   `json:"opt_in" pedantigo:"required"`
-		PhoneNumber string `json:"phone_number" pedantigo:"excluded_if=OptIn false"`
+		OptIn       bool   `json:"opt_in" validate:"required"`
+		PhoneNumber string `json:"phone_number" validate:"excluded_if=OptIn false"`
 	}
 
 	type Vehicle struct {
-		Type         string `json:"type" pedantigo:"required"`
-		LicensePlate string `json:"license_plate" pedantigo:"excluded_if=Type bicycle"`
-		ParkingSpot  int    `json:"parking_spot" pedantigo:"excluded_if=Type bicycle"`
+		Type         string `json:"type" validate:"required"`
+		LicensePlate string `json:"license_plate" validate:"excluded_if=Type bicycle"`
+		ParkingSpot  int    `json:"parking_spot" validate:"excluded_if=Type bicycle"`
 	}
 
 	tests := []struct {
@@ -172,8 +172,8 @@ func TestExcludedIf(t *testing.T) {
 // TestExcludedUnless tests ExcludedUnless validation.
 func TestExcludedUnless(t *testing.T) {
 	type Document struct {
-		Status        string `json:"status" pedantigo:"required"`
-		ApprovalNotes string `json:"approval_notes" pedantigo:"excluded_unless=Status approved"`
+		Status        string `json:"status" validate:"required"`
+		ApprovalNotes string `json:"approval_notes" validate:"excluded_unless=Status approved"`
 	}
 
 	tests := []struct {
@@ -240,18 +240,18 @@ func TestExcludedUnless(t *testing.T) {
 // TestExcludedWith tests ExcludedWith validation.
 func TestExcludedWith(t *testing.T) {
 	type User struct {
-		HomePhone string `json:"home_phone" pedantigo:"required"`
-		WorkPhone string `json:"work_phone" pedantigo:"excluded_with=HomePhone"`
+		HomePhone string `json:"home_phone" validate:"required"`
+		WorkPhone string `json:"work_phone" validate:"excluded_with=HomePhone"`
 	}
 
 	type Account struct {
-		BankBalance    int `json:"bank_balance" pedantigo:"min=0"`
-		CreditLineUsed int `json:"credit_line_used" pedantigo:"excluded_with=BankBalance"`
+		BankBalance    int `json:"bank_balance" validate:"min=0"`
+		CreditLineUsed int `json:"credit_line_used" validate:"excluded_with=BankBalance"`
 	}
 
 	type Feature struct {
-		EnabledGlobally bool   `json:"enabled_globally" pedantigo:"required"`
-		OverrideReason  string `json:"override_reason" pedantigo:"excluded_with=EnabledGlobally"`
+		EnabledGlobally bool   `json:"enabled_globally" validate:"required"`
+		OverrideReason  string `json:"override_reason" validate:"excluded_with=EnabledGlobally"`
 	}
 
 	tests := []struct {
@@ -381,13 +381,13 @@ func TestExcludedWith(t *testing.T) {
 // TestExcludedWithout tests ExcludedWithout validation.
 func TestExcludedWithout(t *testing.T) {
 	type Address struct {
-		Country string `json:"country" pedantigo:"required"`
-		ZipCode string `json:"zip_code" pedantigo:"excluded_without=Country"`
+		Country string `json:"country" validate:"required"`
+		ZipCode string `json:"zip_code" validate:"excluded_without=Country"`
 	}
 
 	type Notification struct {
-		IsEnabled   bool   `json:"is_enabled" pedantigo:"required"`
-		RetryPolicy string `json:"retry_policy" pedantigo:"excluded_without=IsEnabled"`
+		IsEnabled   bool   `json:"is_enabled" validate:"required"`
+		RetryPolicy string `json:"retry_policy" validate:"excluded_without=IsEnabled"`
 	}
 
 	tests := []struct {
@@ -486,7 +486,7 @@ func TestExcludedWithout(t *testing.T) {
 func TestExcludedWithoutUnmarshal(t *testing.T) {
 	type Shipping struct {
 		Weight      int `json:"weight"`
-		TrackingNum int `json:"tracking_num" pedantigo:"excluded_without=Weight"`
+		TrackingNum int `json:"tracking_num" validate:"excluded_without=Weight"`
 	}
 
 	tests := []struct {
@@ -550,10 +550,10 @@ func TestExcludedWithoutUnmarshal(t *testing.T) {
 // TestMultipleExclusionConstraints_Complex tests MultipleExclusionConstraints complex.
 func TestMultipleExclusionConstraints_Complex(t *testing.T) {
 	type Subscription struct {
-		Status             string `json:"status" pedantigo:"required"`
-		CancellationReason string `json:"cancellation_reason" pedantigo:"excluded_unless=Status cancelled"`
-		DowngradeReason    string `json:"downgrade_reason" pedantigo:"excluded_unless=Status downgraded"`
-		SuspendedUntilDate string `json:"suspended_until_date" pedantigo:"excluded_without=Status"`
+		Status             string `json:"status" validate:"required"`
+		CancellationReason string `json:"cancellation_reason" validate:"excluded_unless=Status cancelled"`
+		DowngradeReason    string `json:"downgrade_reason" validate:"excluded_unless=Status downgraded"`
+		SuspendedUntilDate string `json:"suspended_until_date" validate:"excluded_without=Status"`
 	}
 
 	validator := pedantigo.New[Subscription]()
@@ -609,12 +609,12 @@ func TestMultipleExclusionConstraints_Complex(t *testing.T) {
 
 func TestConditionalExclusion_RealWorldPaymentExample(t *testing.T) {
 	type PaymentMethod struct {
-		Type           string `json:"type" pedantigo:"required"`
-		CardNumber     string `json:"card_number" pedantigo:"excluded_unless=Type card"`
-		BankAccount    string `json:"bank_account" pedantigo:"excluded_unless=Type bank_transfer"`
-		CryptoCurrency string `json:"crypto_currency" pedantigo:"excluded_unless=Type crypto"`
-		CardExpiryDate string `json:"card_expiry_date" pedantigo:"excluded_with=BankAccount,excluded_with=CryptoCurrency"`
-		RoutingNumber  string `json:"routing_number" pedantigo:"excluded_without=Type"`
+		Type           string `json:"type" validate:"required"`
+		CardNumber     string `json:"card_number" validate:"excluded_unless=Type card"`
+		BankAccount    string `json:"bank_account" validate:"excluded_unless=Type bank_transfer"`
+		CryptoCurrency string `json:"crypto_currency" validate:"excluded_unless=Type crypto"`
+		CardExpiryDate string `json:"card_expiry_date" validate:"excluded_with=BankAccount,excluded_with=CryptoCurrency"`
+		RoutingNumber  string `json:"routing_number" validate:"excluded_without=Type"`
 	}
 
 	validator := pedantigo.New[PaymentMethod]()

--- a/internal/constraints/crossfield_nested_test.go
+++ b/internal/constraints/crossfield_nested_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	. "github.com/SmrutAI/pedantigo"
+	. "github.com/SmrutAI/pedantigo/v2"
 )
 
 // ============================================================================

--- a/internal/constraints/crossfield_nested_test.go
+++ b/internal/constraints/crossfield_nested_test.go
@@ -23,8 +23,8 @@ type InnerValues struct {
 // OuterStruct tests single-level nested field references.
 type OuterStruct struct {
 	Inner InnerValues
-	Value int    `pedantigo:"gtfield=Inner.MinValue,ltfield=Inner.MaxValue"`
-	Name  string `pedantigo:"eqfield=Inner.Name"`
+	Value int    `validate:"gtfield=Inner.MinValue,ltfield=Inner.MaxValue"`
+	Name  string `validate:"eqfield=Inner.Name"`
 }
 
 // DeepNestedStruct tests multi-level nested paths (Level1.Level2.RefValue).
@@ -34,13 +34,13 @@ type DeepNestedStruct struct {
 			RefValue int
 		}
 	}
-	Value int `pedantigo:"eqfield=Level1.Level2.RefValue"`
+	Value int `validate:"eqfield=Level1.Level2.RefValue"`
 }
 
 // WithPointerInner tests cross-field with pointer to nested struct.
 type WithPointerInner struct {
 	Inner *InnerValues
-	Value int `pedantigo:"gtfield=Inner.MinValue"`
+	Value int `validate:"gtfield=Inner.MinValue"`
 }
 
 // MultiNestedStruct tests multiple nested field references in one struct.
@@ -53,8 +53,8 @@ type MultiNestedStruct struct {
 		DefaultMin int
 		DefaultMax int
 	}
-	CurrentMin int `pedantigo:"gtefield=Bounds.Min,ltefield=Bounds.Max"`
-	CurrentMax int `pedantigo:"gtefield=Bounds.Min,ltefield=Bounds.Max,gtfield=CurrentMin"`
+	CurrentMin int `validate:"gtefield=Bounds.Min,ltefield=Bounds.Max"`
+	CurrentMax int `validate:"gtefield=Bounds.Min,ltefield=Bounds.Max,gtfield=CurrentMin"`
 }
 
 // ============================================================================
@@ -289,7 +289,7 @@ func TestCrossField_NestedPointer_NilInMiddle(t *testing.T) {
 	}
 	type Container struct {
 		Root  Level1
-		Value int `pedantigo:"gtfield=Root.Level2.Level3.Value"`
+		Value int `validate:"gtfield=Root.Level2.Level3.Value"`
 	}
 
 	data := Container{
@@ -485,8 +485,8 @@ func TestCrossField_NestedString(t *testing.T) {
 			Locale   string
 			Timezone string
 		}
-		UserLocale   string `pedantigo:"eqfield=Defaults.Locale"`
-		UserTimezone string `pedantigo:"nefield=Defaults.Timezone"`
+		UserLocale   string `validate:"eqfield=Defaults.Locale"`
+		UserTimezone string `validate:"nefield=Defaults.Timezone"`
 	}
 
 	tests := []struct {
@@ -561,7 +561,7 @@ func TestCrossField_NestedFloat(t *testing.T) {
 			MinPrice float64
 			MaxPrice float64
 		}
-		CurrentPrice float64 `pedantigo:"gtfield=Limits.MinPrice,ltfield=Limits.MaxPrice"`
+		CurrentPrice float64 `validate:"gtfield=Limits.MinPrice,ltfield=Limits.MaxPrice"`
 	}
 
 	tests := []struct {
@@ -648,8 +648,8 @@ func TestCrossField_NestedMixedTypes(t *testing.T) {
 			MaxInt   int
 			MaxFloat float64
 		}
-		IntValue   int     `pedantigo:"ltfield=Config.MaxInt"`
-		FloatValue float64 `pedantigo:"ltfield=Config.MaxFloat"`
+		IntValue   int     `validate:"ltfield=Config.MaxInt"`
+		FloatValue float64 `validate:"ltfield=Config.MaxFloat"`
 	}
 
 	data := MixedTypes{
@@ -694,7 +694,7 @@ func TestCrossField_NestedNonExistentField(t *testing.T) {
 			Value int
 		}
 		// This references a field that doesn't exist
-		Data int `pedantigo:"gtfield=Inner.NonExistent"`
+		Data int `validate:"gtfield=Inner.NonExistent"`
 	}
 
 	// This should panic during construction

--- a/internal/constraints/crossfield_required_test.go
+++ b/internal/constraints/crossfield_required_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	pedantigo "github.com/SmrutAI/pedantigo"
+	pedantigo "github.com/SmrutAI/pedantigo/v2"
 )
 
 // checkValidationErrorWithField verifies validation errors and optionally checks the first error's field.

--- a/internal/constraints/crossfield_required_test.go
+++ b/internal/constraints/crossfield_required_test.go
@@ -34,24 +34,24 @@ func checkValidationErrorWithField(t *testing.T, err error, wantErr bool, wantFi
 func TestRequiredIf(t *testing.T) {
 	type FormStringCondition struct {
 		Country string `json:"country"`
-		State   string `json:"state" pedantigo:"required_if=Country US"`
+		State   string `json:"state" validate:"required_if=Country US"`
 	}
 
 	type FormBoolCondition struct {
 		IsPremium      bool   `json:"is_premium"`
-		PremiumFeature string `json:"premium_feature" pedantigo:"required_if=IsPremium true"`
+		PremiumFeature string `json:"premium_feature" validate:"required_if=IsPremium true"`
 	}
 
 	type FormIntCondition struct {
 		Status       int    `json:"status"`
-		TrackingCode string `json:"tracking_code" pedantigo:"required_if=Status 2"`
+		TrackingCode string `json:"tracking_code" validate:"required_if=Status 2"`
 	}
 
 	type FormMultiple struct {
 		Country  string `json:"country"`
 		Domestic bool   `json:"domestic"`
-		State    string `json:"state" pedantigo:"required_if=Country US"`
-		TaxID    string `json:"tax_id" pedantigo:"required_if=Domestic true"`
+		State    string `json:"state" validate:"required_if=Country US"`
+		TaxID    string `json:"tax_id" validate:"required_if=Domestic true"`
 	}
 
 	tests := []struct {
@@ -189,19 +189,19 @@ func TestRequiredIf(t *testing.T) {
 func TestRequiredUnless(t *testing.T) {
 	type FormStringCondition struct {
 		Status   string `json:"status"`
-		Password string `json:"password" pedantigo:"required_unless=Status guest"`
+		Password string `json:"password" validate:"required_unless=Status guest"`
 	}
 
 	type FormBoolCondition struct {
 		Automated   bool   `json:"automated"`
-		CaptchaCode string `json:"captcha_code" pedantigo:"required_unless=Automated true"`
+		CaptchaCode string `json:"captcha_code" validate:"required_unless=Automated true"`
 	}
 
 	type FormMultiple struct {
 		UserType     string `json:"user_type"`
 		IsBot        bool   `json:"is_bot"`
-		Email        string `json:"email" pedantigo:"required_unless=UserType anonymous"`
-		Verification string `json:"verification" pedantigo:"required_unless=IsBot true"`
+		Email        string `json:"email" validate:"required_unless=UserType anonymous"`
+		Verification string `json:"verification" validate:"required_unless=IsBot true"`
 	}
 
 	tests := []struct {
@@ -307,24 +307,24 @@ func TestRequiredUnless(t *testing.T) {
 func TestRequiredWith(t *testing.T) {
 	type FormStringCondition struct {
 		Method string `json:"method"`
-		Token  string `json:"token" pedantigo:"required_with=Method"`
+		Token  string `json:"token" validate:"required_with=Method"`
 	}
 
 	type FormIntCondition struct {
 		Quantity  int    `json:"quantity"`
-		Warehouse string `json:"warehouse" pedantigo:"required_with=Quantity"`
+		Warehouse string `json:"warehouse" validate:"required_with=Quantity"`
 	}
 
 	type FormBoolCondition struct {
 		Enabled bool   `json:"enabled"`
-		Config  string `json:"config" pedantigo:"required_with=Enabled"`
+		Config  string `json:"config" validate:"required_with=Enabled"`
 	}
 
 	type FormMultiple struct {
 		GuestName     string `json:"guest_name"`
 		Phone         string `json:"phone"`
-		Address       string `json:"address" pedantigo:"required_with=GuestName"`
-		EmergencyName string `json:"emergency_name" pedantigo:"required_with=Phone"`
+		Address       string `json:"address" validate:"required_with=GuestName"`
+		EmergencyName string `json:"emergency_name" validate:"required_with=Phone"`
 	}
 
 	tests := []struct {
@@ -440,24 +440,24 @@ func TestRequiredWith(t *testing.T) {
 func TestRequiredWithout(t *testing.T) {
 	type FormStringCondition struct {
 		DefaultAddress string `json:"default_address"`
-		CustomAddress  string `json:"custom_address" pedantigo:"required_without=DefaultAddress"`
+		CustomAddress  string `json:"custom_address" validate:"required_without=DefaultAddress"`
 	}
 
 	type FormIntCondition struct {
 		FixedAmount    int    `json:"fixed_amount"`
-		PercentageCode string `json:"percentage_code" pedantigo:"required_without=FixedAmount"`
+		PercentageCode string `json:"percentage_code" validate:"required_without=FixedAmount"`
 	}
 
 	type FormBoolCondition struct {
 		UseDefault bool   `json:"use_default"`
-		CustomRule string `json:"custom_rule" pedantigo:"required_without=UseDefault"`
+		CustomRule string `json:"custom_rule" validate:"required_without=UseDefault"`
 	}
 
 	type FormMultiple struct {
 		WarehouseLocation string `json:"warehouse_location"`
 		ShippingLabel     string `json:"shipping_label"`
-		StorageBox        string `json:"storage_box" pedantigo:"required_without=WarehouseLocation"`
-		ShippingTracking  string `json:"shipping_tracking" pedantigo:"required_without=ShippingLabel"`
+		StorageBox        string `json:"storage_box" validate:"required_without=WarehouseLocation"`
+		ShippingTracking  string `json:"shipping_tracking" validate:"required_without=ShippingLabel"`
 	}
 
 	tests := []struct {
@@ -584,11 +584,11 @@ func TestCrossFieldConstraints(t *testing.T) {
 		type UserProfile struct {
 			AccountType      string `json:"account_type"`
 			IsVerified       bool   `json:"is_verified"`
-			BusinessName     string `json:"business_name" pedantigo:"required_if=AccountType business"`
-			TaxID            string `json:"tax_id" pedantigo:"required_if=AccountType business"`
-			VerificationDoc  string `json:"verification_doc" pedantigo:"required_if=IsVerified true"`
-			BackupEmail      string `json:"backup_email" pedantigo:"required_unless=AccountType government"`
-			NotificationPref string `json:"notification_pref" pedantigo:"required_with=BackupEmail"`
+			BusinessName     string `json:"business_name" validate:"required_if=AccountType business"`
+			TaxID            string `json:"tax_id" validate:"required_if=AccountType business"`
+			VerificationDoc  string `json:"verification_doc" validate:"required_if=IsVerified true"`
+			BackupEmail      string `json:"backup_email" validate:"required_unless=AccountType government"`
+			NotificationPref string `json:"notification_pref" validate:"required_with=BackupEmail"`
 		}
 		validator := pedantigo.New[UserProfile]()
 		err := validator.Validate(&UserProfile{
@@ -607,11 +607,11 @@ func TestCrossFieldConstraints(t *testing.T) {
 		type UserProfile struct {
 			AccountType      string `json:"account_type"`
 			IsVerified       bool   `json:"is_verified"`
-			BusinessName     string `json:"business_name" pedantigo:"required_if=AccountType business"`
-			TaxID            string `json:"tax_id" pedantigo:"required_if=AccountType business"`
-			VerificationDoc  string `json:"verification_doc" pedantigo:"required_if=IsVerified true"`
-			BackupEmail      string `json:"backup_email" pedantigo:"required_unless=AccountType government"`
-			NotificationPref string `json:"notification_pref" pedantigo:"required_with=BackupEmail"`
+			BusinessName     string `json:"business_name" validate:"required_if=AccountType business"`
+			TaxID            string `json:"tax_id" validate:"required_if=AccountType business"`
+			VerificationDoc  string `json:"verification_doc" validate:"required_if=IsVerified true"`
+			BackupEmail      string `json:"backup_email" validate:"required_unless=AccountType government"`
+			NotificationPref string `json:"notification_pref" validate:"required_with=BackupEmail"`
 		}
 		validator := pedantigo.New[UserProfile]()
 		err := validator.Validate(&UserProfile{
@@ -630,11 +630,11 @@ func TestCrossFieldConstraints(t *testing.T) {
 		type UserProfile struct {
 			AccountType      string `json:"account_type"`
 			IsVerified       bool   `json:"is_verified"`
-			BusinessName     string `json:"business_name" pedantigo:"required_if=AccountType business"`
-			TaxID            string `json:"tax_id" pedantigo:"required_if=AccountType business"`
-			VerificationDoc  string `json:"verification_doc" pedantigo:"required_if=IsVerified true"`
-			BackupEmail      string `json:"backup_email" pedantigo:"required_unless=AccountType government"`
-			NotificationPref string `json:"notification_pref" pedantigo:"required_with=BackupEmail"`
+			BusinessName     string `json:"business_name" validate:"required_if=AccountType business"`
+			TaxID            string `json:"tax_id" validate:"required_if=AccountType business"`
+			VerificationDoc  string `json:"verification_doc" validate:"required_if=IsVerified true"`
+			BackupEmail      string `json:"backup_email" validate:"required_unless=AccountType government"`
+			NotificationPref string `json:"notification_pref" validate:"required_with=BackupEmail"`
 		}
 		validator := pedantigo.New[UserProfile]()
 		err := validator.Validate(&UserProfile{
@@ -653,11 +653,11 @@ func TestCrossFieldConstraints(t *testing.T) {
 		type UserProfile struct {
 			AccountType      string `json:"account_type"`
 			IsVerified       bool   `json:"is_verified"`
-			BusinessName     string `json:"business_name" pedantigo:"required_if=AccountType business"`
-			TaxID            string `json:"tax_id" pedantigo:"required_if=AccountType business"`
-			VerificationDoc  string `json:"verification_doc" pedantigo:"required_if=IsVerified true"`
-			BackupEmail      string `json:"backup_email" pedantigo:"required_unless=AccountType government"`
-			NotificationPref string `json:"notification_pref" pedantigo:"required_with=BackupEmail"`
+			BusinessName     string `json:"business_name" validate:"required_if=AccountType business"`
+			TaxID            string `json:"tax_id" validate:"required_if=AccountType business"`
+			VerificationDoc  string `json:"verification_doc" validate:"required_if=IsVerified true"`
+			BackupEmail      string `json:"backup_email" validate:"required_unless=AccountType government"`
+			NotificationPref string `json:"notification_pref" validate:"required_with=BackupEmail"`
 		}
 		validator := pedantigo.New[UserProfile]()
 		err := validator.Validate(&UserProfile{
@@ -676,8 +676,8 @@ func TestCrossFieldConstraints(t *testing.T) {
 		type Form struct {
 			Field1 string `json:"field1"`
 			Field2 string `json:"field2"`
-			Field3 string `json:"field3" pedantigo:"required_if=Field1 trigger"`
-			Field4 string `json:"field4" pedantigo:"required_unless=Field2 skip"`
+			Field3 string `json:"field3" validate:"required_if=Field1 trigger"`
+			Field4 string `json:"field4" validate:"required_unless=Field2 skip"`
 		}
 		validator := pedantigo.New[Form]()
 		require.NotNil(t, validator, "validator creation failed")
@@ -692,7 +692,7 @@ func TestCrossFieldConstraints(t *testing.T) {
 	t.Run("zero value distinction", func(t *testing.T) {
 		type Form struct {
 			TriggerField string `json:"trigger_field"`
-			TargetField  string `json:"target_field" pedantigo:"required_with=TriggerField"`
+			TargetField  string `json:"target_field" validate:"required_with=TriggerField"`
 		}
 		validator := pedantigo.New[Form]()
 		err := validator.Validate(&Form{
@@ -706,7 +706,7 @@ func TestCrossFieldConstraints(t *testing.T) {
 		type Form struct {
 			privateField string
 			PublicField  string `json:"public_field"`
-			Conditional  string `json:"conditional" pedantigo:"required_if=PublicField trigger"`
+			Conditional  string `json:"conditional" validate:"required_if=PublicField trigger"`
 		}
 		validator := pedantigo.New[Form]()
 		err := validator.Validate(&Form{
@@ -721,7 +721,7 @@ func TestCrossFieldConstraints(t *testing.T) {
 		type Form struct {
 			privateField string
 			PublicField  string `json:"public_field"`
-			Conditional  string `json:"conditional" pedantigo:"required_if=PublicField trigger"`
+			Conditional  string `json:"conditional" validate:"required_if=PublicField trigger"`
 		}
 		validator := pedantigo.New[Form]()
 		err := validator.Validate(&Form{
@@ -735,7 +735,7 @@ func TestCrossFieldConstraints(t *testing.T) {
 	t.Run("reflect value handling", func(t *testing.T) {
 		type Form struct {
 			Status string `json:"status"`
-			Detail string `json:"detail" pedantigo:"required_if=Status complete"`
+			Detail string `json:"detail" validate:"required_if=Status complete"`
 		}
 		validator := pedantigo.New[Form]()
 		form := Form{

--- a/internal/constraints/crossfield_skipunless_test.go
+++ b/internal/constraints/crossfield_skipunless_test.go
@@ -16,7 +16,7 @@ func TestSkipUnless(t *testing.T) {
 	t.Run("condition met - validation proceeds", func(t *testing.T) {
 		type Form struct {
 			Status string `json:"status"`
-			Data   string `json:"data" pedantigo:"skip_unless=Status active"`
+			Data   string `json:"data" validate:"skip_unless=Status active"`
 		}
 
 		validator := New[Form]()
@@ -34,7 +34,7 @@ func TestSkipUnless(t *testing.T) {
 	t.Run("condition not met - validation skipped", func(t *testing.T) {
 		type Form struct {
 			Status string `json:"status"`
-			Data   string `json:"data" pedantigo:"skip_unless=Status active"`
+			Data   string `json:"data" validate:"skip_unless=Status active"`
 		}
 
 		validator := New[Form]()
@@ -52,7 +52,7 @@ func TestSkipUnless(t *testing.T) {
 	t.Run("boolean condition - true", func(t *testing.T) {
 		type Form struct {
 			Enabled bool   `json:"enabled"`
-			APIKey  string `json:"api_key" pedantigo:"skip_unless=Enabled true"`
+			APIKey  string `json:"api_key" validate:"skip_unless=Enabled true"`
 		}
 
 		validator := New[Form]()
@@ -70,7 +70,7 @@ func TestSkipUnless(t *testing.T) {
 	t.Run("boolean condition - false skips", func(t *testing.T) {
 		type Form struct {
 			Enabled bool   `json:"enabled"`
-			APIKey  string `json:"api_key" pedantigo:"skip_unless=Enabled true"`
+			APIKey  string `json:"api_key" validate:"skip_unless=Enabled true"`
 		}
 
 		validator := New[Form]()
@@ -88,7 +88,7 @@ func TestSkipUnless(t *testing.T) {
 	t.Run("integer condition", func(t *testing.T) {
 		type Form struct {
 			Level  int    `json:"level"`
-			Reward string `json:"reward" pedantigo:"skip_unless=Level 5"`
+			Reward string `json:"reward" validate:"skip_unless=Level 5"`
 		}
 
 		validator := New[Form]()
@@ -106,7 +106,7 @@ func TestSkipUnless(t *testing.T) {
 	t.Run("integer condition not met", func(t *testing.T) {
 		type Form struct {
 			Level  int    `json:"level"`
-			Reward string `json:"reward" pedantigo:"skip_unless=Level 5"`
+			Reward string `json:"reward" validate:"skip_unless=Level 5"`
 		}
 
 		validator := New[Form]()
@@ -124,7 +124,7 @@ func TestSkipUnless(t *testing.T) {
 	t.Run("case sensitive match", func(t *testing.T) {
 		type Form struct {
 			Type string `json:"type"`
-			Data string `json:"data" pedantigo:"skip_unless=Type Active"`
+			Data string `json:"data" validate:"skip_unless=Type Active"`
 		}
 
 		validator := New[Form]()
@@ -143,7 +143,7 @@ func TestSkipUnless(t *testing.T) {
 func TestSkipUnlessErrorCases(t *testing.T) {
 	t.Run("target field missing - panics at validator creation", func(t *testing.T) {
 		type Form struct {
-			Data string `json:"data" pedantigo:"skip_unless=NonExistentField value"`
+			Data string `json:"data" validate:"skip_unless=NonExistentField value"`
 		}
 
 		// ParseFieldPath panics when field doesn't exist
@@ -160,7 +160,7 @@ func TestSkipUnless_SkipsAllConstraints(t *testing.T) {
 	t.Run("skip_unless skips required when condition not met", func(t *testing.T) {
 		type Form struct {
 			Status string `json:"status"`
-			Data   string `json:"data" pedantigo:"skip_unless=Status active,required,min=5"`
+			Data   string `json:"data" validate:"skip_unless=Status active,required,min=5"`
 		}
 
 		validator := New[Form]()
@@ -180,7 +180,7 @@ func TestSkipUnless_SkipsAllConstraints(t *testing.T) {
 	t.Run("skip_unless validates when condition is met", func(t *testing.T) {
 		type Form struct {
 			Status string `json:"status"`
-			Data   string `json:"data" pedantigo:"skip_unless=Status active,required,min=5"`
+			Data   string `json:"data" validate:"skip_unless=Status active,required,min=5"`
 		}
 
 		validator := New[Form]()
@@ -199,7 +199,7 @@ func TestSkipUnless_SkipsAllConstraints(t *testing.T) {
 	t.Run("skip_unless skips email validation when condition not met", func(t *testing.T) {
 		type Form struct {
 			ContactMethod string `json:"contact_method"`
-			Email         string `json:"email" pedantigo:"skip_unless=ContactMethod email,required,email"`
+			Email         string `json:"email" validate:"skip_unless=ContactMethod email,required,email"`
 		}
 
 		validator := New[Form]()
@@ -217,7 +217,7 @@ func TestSkipUnless_SkipsAllConstraints(t *testing.T) {
 	t.Run("skip_unless validates email when condition is met", func(t *testing.T) {
 		type Form struct {
 			ContactMethod string `json:"contact_method"`
-			Email         string `json:"email" pedantigo:"skip_unless=ContactMethod email,required,email"`
+			Email         string `json:"email" validate:"skip_unless=ContactMethod email,required,email"`
 		}
 
 		validator := New[Form]()
@@ -237,15 +237,15 @@ func TestSkipUnless_SkipsAllConstraints(t *testing.T) {
 // This is the primary use case for skip_unless.
 func TestSkipUnless_DiscriminatedUnion(t *testing.T) {
 	type TV struct {
-		Channel int `json:"channel" pedantigo:"required,min=1,max=999"`
+		Channel int `json:"channel" validate:"required,min=1,max=999"`
 	}
 	type Fan struct {
-		Speed int `json:"speed" pedantigo:"required,min=1,max=5"`
+		Speed int `json:"speed" validate:"required,min=1,max=5"`
 	}
 	type Suite struct {
-		SuiteType string `json:"suite_type" pedantigo:"required,oneof=tv fan"`
-		TV        TV     `json:"tv" pedantigo:"skip_unless=SuiteType tv"`
-		Fan       Fan    `json:"fan" pedantigo:"skip_unless=SuiteType fan"`
+		SuiteType string `json:"suite_type" validate:"required,oneof=tv fan"`
+		TV        TV     `json:"tv" validate:"skip_unless=SuiteType tv"`
+		Fan       Fan    `json:"fan" validate:"skip_unless=SuiteType fan"`
 	}
 
 	validator := New[Suite]()
@@ -299,7 +299,7 @@ func TestSkipUnless_DiscriminatedUnion(t *testing.T) {
 func TestSkipUnless_MultipleConstraints(t *testing.T) {
 	type Form struct {
 		Type     string `json:"type"`
-		Username string `json:"username" pedantigo:"skip_unless=Type user,required,min=3,max=20,alphanum"`
+		Username string `json:"username" validate:"skip_unless=Type user,required,min=3,max=20,alphanum"`
 	}
 
 	validator := New[Form]()
@@ -330,7 +330,7 @@ func TestSkipUnless_TypeComparisons(t *testing.T) {
 	t.Run("uint comparison", func(t *testing.T) {
 		type Form struct {
 			Level uint   `json:"level"`
-			Badge string `json:"badge" pedantigo:"skip_unless=Level 10,required,min=1"`
+			Badge string `json:"badge" validate:"skip_unless=Level 10,required,min=1"`
 		}
 
 		validator := New[Form]()
@@ -349,7 +349,7 @@ func TestSkipUnless_TypeComparisons(t *testing.T) {
 	t.Run("bool comparison false", func(t *testing.T) {
 		type Form struct {
 			Disabled bool   `json:"disabled"`
-			Reason   string `json:"reason" pedantigo:"skip_unless=Disabled true,required,min=5"`
+			Reason   string `json:"reason" validate:"skip_unless=Disabled true,required,min=5"`
 		}
 
 		validator := New[Form]()

--- a/internal/constraints/crossfield_skipunless_test.go
+++ b/internal/constraints/crossfield_skipunless_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	. "github.com/SmrutAI/pedantigo"
+	. "github.com/SmrutAI/pedantigo/v2"
 )
 
 // TestSkipUnless tests the skip_unless constraint for conditional validation.

--- a/internal/constraints/iso.go
+++ b/internal/constraints/iso.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/SmrutAI/pedantigo/internal/isocodes"
+	"github.com/SmrutAI/pedantigo/v2/internal/isocodes"
 )
 
 // ISO code constraint name constants.

--- a/internal/constraints/or_test.go
+++ b/internal/constraints/or_test.go
@@ -11,7 +11,7 @@ import (
 // TestOrConstraint_FirstMatches tests OR constraint when first option matches.
 func TestOrConstraint_FirstMatches(t *testing.T) {
 	type Form struct {
-		Color string `json:"color" pedantigo:"hexcolor|rgb"`
+		Color string `json:"color" validate:"hexcolor|rgb"`
 	}
 	validator := pedantigo.New[Form]()
 	err := validator.Validate(&Form{Color: "#FF0000"})
@@ -21,7 +21,7 @@ func TestOrConstraint_FirstMatches(t *testing.T) {
 // TestOrConstraint_SecondMatches tests OR constraint when second option matches.
 func TestOrConstraint_SecondMatches(t *testing.T) {
 	type Form struct {
-		Color string `json:"color" pedantigo:"hexcolor|rgb"`
+		Color string `json:"color" validate:"hexcolor|rgb"`
 	}
 	validator := pedantigo.New[Form]()
 	err := validator.Validate(&Form{Color: "rgb(255,0,0)"})
@@ -31,7 +31,7 @@ func TestOrConstraint_SecondMatches(t *testing.T) {
 // TestOrConstraint_NoMatch tests OR constraint when all options fail.
 func TestOrConstraint_NoMatch(t *testing.T) {
 	type Form struct {
-		Color string `json:"color" pedantigo:"hexcolor|rgb"`
+		Color string `json:"color" validate:"hexcolor|rgb"`
 	}
 	validator := pedantigo.New[Form]()
 	err := validator.Validate(&Form{Color: "invalid"})
@@ -41,7 +41,7 @@ func TestOrConstraint_NoMatch(t *testing.T) {
 // TestOrConstraint_TripleOR tests OR constraint with three options (third matches).
 func TestOrConstraint_TripleOR_ThirdMatches(t *testing.T) {
 	type Form struct {
-		Color string `json:"color" pedantigo:"hexcolor|rgb|rgba"`
+		Color string `json:"color" validate:"hexcolor|rgb|rgba"`
 	}
 	validator := pedantigo.New[Form]()
 	err := validator.Validate(&Form{Color: "rgba(255,0,0,0.5)"})
@@ -51,7 +51,7 @@ func TestOrConstraint_TripleOR_ThirdMatches(t *testing.T) {
 // TestOrConstraint_TripleOR_FirstMatches tests OR constraint with three options (first matches).
 func TestOrConstraint_TripleOR_FirstMatches(t *testing.T) {
 	type Form struct {
-		Color string `json:"color" pedantigo:"hexcolor|rgb|rgba"`
+		Color string `json:"color" validate:"hexcolor|rgb|rgba"`
 	}
 	validator := pedantigo.New[Form]()
 	err := validator.Validate(&Form{Color: "#ABC123"})
@@ -61,7 +61,7 @@ func TestOrConstraint_TripleOR_FirstMatches(t *testing.T) {
 // TestOrConstraint_TripleOR_NoMatch tests OR constraint with three options (all fail).
 func TestOrConstraint_TripleOR_NoMatch(t *testing.T) {
 	type Form struct {
-		Color string `json:"color" pedantigo:"hexcolor|rgb|rgba"`
+		Color string `json:"color" validate:"hexcolor|rgb|rgba"`
 	}
 	validator := pedantigo.New[Form]()
 	err := validator.Validate(&Form{Color: "not-a-color"})
@@ -71,7 +71,7 @@ func TestOrConstraint_TripleOR_NoMatch(t *testing.T) {
 // TestOrConstraint_EmptyString tests OR constraint with empty string (should pass, not required).
 func TestOrConstraint_EmptyString(t *testing.T) {
 	type Form struct {
-		Color string `json:"color" pedantigo:"hexcolor|rgb"`
+		Color string `json:"color" validate:"hexcolor|rgb"`
 	}
 	validator := pedantigo.New[Form]()
 	err := validator.Validate(&Form{Color: ""})
@@ -81,7 +81,7 @@ func TestOrConstraint_EmptyString(t *testing.T) {
 // TestOrConstraint_MixedTypes_EmailMatches tests OR with different constraint types (email matches).
 func TestOrConstraint_MixedTypes_EmailMatches(t *testing.T) {
 	type Form struct {
-		Contact string `json:"contact" pedantigo:"email|url"`
+		Contact string `json:"contact" validate:"email|url"`
 	}
 	validator := pedantigo.New[Form]()
 	err := validator.Validate(&Form{Contact: "test@example.com"})
@@ -91,7 +91,7 @@ func TestOrConstraint_MixedTypes_EmailMatches(t *testing.T) {
 // TestOrConstraint_MixedTypes_URLMatches tests OR with different constraint types (url matches).
 func TestOrConstraint_MixedTypes_URLMatches(t *testing.T) {
 	type Form struct {
-		Contact string `json:"contact" pedantigo:"email|url"`
+		Contact string `json:"contact" validate:"email|url"`
 	}
 	validator := pedantigo.New[Form]()
 	err := validator.Validate(&Form{Contact: "https://example.com"})
@@ -101,7 +101,7 @@ func TestOrConstraint_MixedTypes_URLMatches(t *testing.T) {
 // TestOrConstraint_MixedTypes_NoMatch tests OR with different constraint types (both fail).
 func TestOrConstraint_MixedTypes_NoMatch(t *testing.T) {
 	type Form struct {
-		Contact string `json:"contact" pedantigo:"email|url"`
+		Contact string `json:"contact" validate:"email|url"`
 	}
 	validator := pedantigo.New[Form]()
 	err := validator.Validate(&Form{Contact: "not-an-email-or-url"})
@@ -111,7 +111,7 @@ func TestOrConstraint_MixedTypes_NoMatch(t *testing.T) {
 // TestOrConstraint_WithRequired_Valid tests OR combined with required constraint (valid input).
 func TestOrConstraint_WithRequired_Valid(t *testing.T) {
 	type Form struct {
-		Color string `json:"color" pedantigo:"required,hexcolor|rgb"`
+		Color string `json:"color" validate:"required,hexcolor|rgb"`
 	}
 	validator := pedantigo.New[Form]()
 	err := validator.Validate(&Form{Color: "#FF0000"})
@@ -122,7 +122,7 @@ func TestOrConstraint_WithRequired_Valid(t *testing.T) {
 // Note: In pedantigo, 'required' only checks for missing JSON fields, not empty strings.
 func TestOrConstraint_WithRequired_MissingFails(t *testing.T) {
 	type Form struct {
-		Color string `json:"color" pedantigo:"required,hexcolor|rgb"`
+		Color string `json:"color" validate:"required,hexcolor|rgb"`
 	}
 	validator := pedantigo.New[Form]()
 	// Test via Unmarshal - missing field should fail required
@@ -133,7 +133,7 @@ func TestOrConstraint_WithRequired_MissingFails(t *testing.T) {
 // TestOrConstraint_WithRequired_EmptyPasses tests that empty string passes (required only checks for missing).
 func TestOrConstraint_WithRequired_EmptyPasses(t *testing.T) {
 	type Form struct {
-		Color string `json:"color" pedantigo:"required,hexcolor|rgb"`
+		Color string `json:"color" validate:"required,hexcolor|rgb"`
 	}
 	validator := pedantigo.New[Form]()
 	// Empty string passes - 'required' only checks for missing fields, not empty values
@@ -144,7 +144,7 @@ func TestOrConstraint_WithRequired_EmptyPasses(t *testing.T) {
 // TestOrConstraint_WithRequired_InvalidFails tests OR combined with required (invalid value fails OR).
 func TestOrConstraint_WithRequired_InvalidFails(t *testing.T) {
 	type Form struct {
-		Color string `json:"color" pedantigo:"required,hexcolor|rgb"`
+		Color string `json:"color" validate:"required,hexcolor|rgb"`
 	}
 	validator := pedantigo.New[Form]()
 	err := validator.Validate(&Form{Color: "invalid"})
@@ -154,7 +154,7 @@ func TestOrConstraint_WithRequired_InvalidFails(t *testing.T) {
 // TestOrConstraint_NilPointer tests OR constraint with nil pointer (should pass).
 func TestOrConstraint_NilPointer(t *testing.T) {
 	type Form struct {
-		Color *string `json:"color" pedantigo:"hexcolor|rgb"`
+		Color *string `json:"color" validate:"hexcolor|rgb"`
 	}
 	validator := pedantigo.New[Form]()
 	err := validator.Validate(&Form{Color: nil})
@@ -164,7 +164,7 @@ func TestOrConstraint_NilPointer(t *testing.T) {
 // TestOrConstraint_PointerToValidValue tests OR constraint with pointer to valid value.
 func TestOrConstraint_PointerToValidValue(t *testing.T) {
 	type Form struct {
-		Color *string `json:"color" pedantigo:"hexcolor|rgb"`
+		Color *string `json:"color" validate:"hexcolor|rgb"`
 	}
 	validator := pedantigo.New[Form]()
 	validColor := "#FF0000"
@@ -175,7 +175,7 @@ func TestOrConstraint_PointerToValidValue(t *testing.T) {
 // TestOrConstraint_PointerToInvalidValue tests OR constraint with pointer to invalid value.
 func TestOrConstraint_PointerToInvalidValue(t *testing.T) {
 	type Form struct {
-		Color *string `json:"color" pedantigo:"hexcolor|rgb"`
+		Color *string `json:"color" validate:"hexcolor|rgb"`
 	}
 	validator := pedantigo.New[Form]()
 	invalidColor := "not-valid"
@@ -186,9 +186,9 @@ func TestOrConstraint_PointerToInvalidValue(t *testing.T) {
 // TestOrConstraint_MultipleFields tests OR constraint across multiple struct fields.
 func TestOrConstraint_MultipleFields(t *testing.T) {
 	type Form struct {
-		PrimaryColor   string `json:"primary_color" pedantigo:"hexcolor|rgb"`
-		SecondaryColor string `json:"secondary_color" pedantigo:"hexcolor|rgba"`
-		Contact        string `json:"contact" pedantigo:"email|url"`
+		PrimaryColor   string `json:"primary_color" validate:"hexcolor|rgb"`
+		SecondaryColor string `json:"secondary_color" validate:"hexcolor|rgba"`
+		Contact        string `json:"contact" validate:"email|url"`
 	}
 	validator := pedantigo.New[Form]()
 	err := validator.Validate(&Form{
@@ -202,8 +202,8 @@ func TestOrConstraint_MultipleFields(t *testing.T) {
 // TestOrConstraint_MultipleFields_OneFails tests OR constraint with one field failing.
 func TestOrConstraint_MultipleFields_OneFails(t *testing.T) {
 	type Form struct {
-		PrimaryColor   string `json:"primary_color" pedantigo:"hexcolor|rgb"`
-		SecondaryColor string `json:"secondary_color" pedantigo:"hexcolor|rgba"`
+		PrimaryColor   string `json:"primary_color" validate:"hexcolor|rgb"`
+		SecondaryColor string `json:"secondary_color" validate:"hexcolor|rgba"`
 	}
 	validator := pedantigo.New[Form]()
 	err := validator.Validate(&Form{
@@ -216,7 +216,7 @@ func TestOrConstraint_MultipleFields_OneFails(t *testing.T) {
 // TestOrConstraint_WithUnmarshal tests OR constraint via Unmarshal (integration test).
 func TestOrConstraint_WithUnmarshal(t *testing.T) {
 	type Form struct {
-		Color string `json:"color" pedantigo:"hexcolor|rgb|rgba"`
+		Color string `json:"color" validate:"hexcolor|rgb|rgba"`
 	}
 
 	tests := []struct {
@@ -267,7 +267,7 @@ func TestOrConstraint_WithUnmarshal(t *testing.T) {
 // TestOrConstraint_ComplexCombination tests OR with other string constraints.
 func TestOrConstraint_ComplexCombination(t *testing.T) {
 	type Form struct {
-		Identifier string `json:"identifier" pedantigo:"uuid|email"`
+		Identifier string `json:"identifier" validate:"uuid|email"`
 	}
 
 	tests := []struct {
@@ -308,7 +308,7 @@ func TestOrConstraint_ComplexCombination(t *testing.T) {
 // TestOrConstraint_AlphaOrNumeric tests OR with character class constraints.
 func TestOrConstraint_AlphaOrNumeric(t *testing.T) {
 	type Form struct {
-		Code string `json:"code" pedantigo:"alpha|numeric"`
+		Code string `json:"code" validate:"alpha|numeric"`
 	}
 
 	tests := []struct {

--- a/internal/constraints/or_test.go
+++ b/internal/constraints/or_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	pedantigo "github.com/SmrutAI/pedantigo"
+	pedantigo "github.com/SmrutAI/pedantigo/v2"
 )
 
 // TestOrConstraint_FirstMatches tests OR constraint when first option matches.

--- a/internal/constraints/postcode_alias_test.go
+++ b/internal/constraints/postcode_alias_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	pedantigo "github.com/SmrutAI/pedantigo"
+	pedantigo "github.com/SmrutAI/pedantigo/v2"
 )
 
 // TestPostcodeISO3166Alpha2Alias tests the postcode_iso3166_alpha2 alias.

--- a/internal/constraints/postcode_alias_test.go
+++ b/internal/constraints/postcode_alias_test.go
@@ -13,7 +13,7 @@ func TestPostcodeISO3166Alpha2Alias(t *testing.T) {
 	// Test 1: US postcode via alias - valid
 	t.Run("US postcode via alias valid", func(t *testing.T) {
 		type Form struct {
-			Zip string `json:"zip" pedantigo:"postcode_iso3166_alpha2=US"`
+			Zip string `json:"zip" validate:"postcode_iso3166_alpha2=US"`
 		}
 		validator := pedantigo.New[Form]()
 		err := validator.Validate(&Form{Zip: "90210"})
@@ -23,7 +23,7 @@ func TestPostcodeISO3166Alpha2Alias(t *testing.T) {
 	// Test 2: US postcode via alias - invalid
 	t.Run("US postcode via alias invalid", func(t *testing.T) {
 		type Form struct {
-			Zip string `json:"zip" pedantigo:"postcode_iso3166_alpha2=US"`
+			Zip string `json:"zip" validate:"postcode_iso3166_alpha2=US"`
 		}
 		validator := pedantigo.New[Form]()
 		err := validator.Validate(&Form{Zip: "invalid"})
@@ -33,7 +33,7 @@ func TestPostcodeISO3166Alpha2Alias(t *testing.T) {
 	// Test 3: UK postcode via alias
 	t.Run("UK postcode via alias", func(t *testing.T) {
 		type Form struct {
-			Postcode string `json:"postcode" pedantigo:"postcode_iso3166_alpha2=GB"`
+			Postcode string `json:"postcode" validate:"postcode_iso3166_alpha2=GB"`
 		}
 		validator := pedantigo.New[Form]()
 		err := validator.Validate(&Form{Postcode: "SW1A 1AA"})
@@ -43,10 +43,10 @@ func TestPostcodeISO3166Alpha2Alias(t *testing.T) {
 	// Test 4: Both syntaxes produce same result
 	t.Run("alias identical to original", func(t *testing.T) {
 		type FormOriginal struct {
-			Zip string `json:"zip" pedantigo:"postcode=US"`
+			Zip string `json:"zip" validate:"postcode=US"`
 		}
 		type FormAlias struct {
-			Zip string `json:"zip" pedantigo:"postcode_iso3166_alpha2=US"`
+			Zip string `json:"zip" validate:"postcode_iso3166_alpha2=US"`
 		}
 
 		validatorOrig := pedantigo.New[FormOriginal]()
@@ -68,7 +68,7 @@ func TestPostcodeISO3166Alpha2Alias(t *testing.T) {
 	// Test 5: Empty string passes (not required)
 	t.Run("empty string passes", func(t *testing.T) {
 		type Form struct {
-			Zip string `json:"zip" pedantigo:"postcode_iso3166_alpha2=US"`
+			Zip string `json:"zip" validate:"postcode_iso3166_alpha2=US"`
 		}
 		validator := pedantigo.New[Form]()
 		err := validator.Validate(&Form{Zip: ""})

--- a/internal/deserialize/builder.go
+++ b/internal/deserialize/builder.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/SmrutAI/pedantigo/internal/tags"
+	"github.com/SmrutAI/pedantigo/v2/internal/tags"
 )
 
 // StringTransformations holds flags for string transformations to apply during deserialization.

--- a/internal/deserialize/builder.go
+++ b/internal/deserialize/builder.go
@@ -30,7 +30,7 @@ type FieldDeserializer func(outPtr *reflect.Value, inValue any) error
 // BuilderOptions configures the deserializer builder.
 type BuilderOptions struct {
 	StrictMissingFields bool
-	TagName             string // Custom struct tag name (default: "pedantigo")
+	TagName             string // Custom struct tag name (default: "validate")
 }
 
 // BuildFieldDeserializers creates field deserializer closures for each struct field.

--- a/internal/deserialize/builder_test.go
+++ b/internal/deserialize/builder_test.go
@@ -246,7 +246,7 @@ func TestBuildFieldDeserializers_Defaults(t *testing.T) {
 		{
 			name: "string default in strict mode",
 			structType: struct {
-				Name string `pedantigo:"default=guest"`
+				Name string `validate:"default=guest"`
 			}{},
 			strictMissingFields: true,
 			shouldPanic:         false,
@@ -254,7 +254,7 @@ func TestBuildFieldDeserializers_Defaults(t *testing.T) {
 		{
 			name: "int default in strict mode",
 			structType: struct {
-				Port int `pedantigo:"default=8080"`
+				Port int `validate:"default=8080"`
 			}{},
 			strictMissingFields: true,
 			shouldPanic:         false,
@@ -262,7 +262,7 @@ func TestBuildFieldDeserializers_Defaults(t *testing.T) {
 		{
 			name: "bool default in strict mode",
 			structType: struct {
-				Enabled bool `pedantigo:"default=true"`
+				Enabled bool `validate:"default=true"`
 			}{},
 			strictMissingFields: true,
 			shouldPanic:         false,
@@ -270,7 +270,7 @@ func TestBuildFieldDeserializers_Defaults(t *testing.T) {
 		{
 			name: "float64 default in strict mode",
 			structType: struct {
-				Timeout float64 `pedantigo:"default=30.5"`
+				Timeout float64 `validate:"default=30.5"`
 			}{},
 			strictMissingFields: true,
 			shouldPanic:         false,
@@ -278,7 +278,7 @@ func TestBuildFieldDeserializers_Defaults(t *testing.T) {
 		{
 			name: "empty string default",
 			structType: struct {
-				Name string `pedantigo:"default="`
+				Name string `validate:"default="`
 			}{},
 			strictMissingFields: true,
 			shouldPanic:         false,
@@ -286,7 +286,7 @@ func TestBuildFieldDeserializers_Defaults(t *testing.T) {
 		{
 			name: "default tag in non-strict mode panics",
 			structType: struct {
-				Name string `pedantigo:"default=guest"`
+				Name string `validate:"default=guest"`
 			}{},
 			strictMissingFields:  false,
 			shouldPanic:          true,
@@ -295,9 +295,9 @@ func TestBuildFieldDeserializers_Defaults(t *testing.T) {
 		{
 			name: "multiple defaults",
 			structType: struct {
-				Name    string `pedantigo:"default=guest"`
-				Port    int    `pedantigo:"default=8080"`
-				Enabled bool   `pedantigo:"default=true"`
+				Name    string `validate:"default=guest"`
+				Port    int    `validate:"default=8080"`
+				Enabled bool   `validate:"default=true"`
 			}{},
 			strictMissingFields: true,
 			shouldPanic:         false,
@@ -334,7 +334,7 @@ func TestBuildFieldDeserializers_DefaultUsingMethod(t *testing.T) {
 		{
 			name: "defaultUsingMethod with non-strict mode panics",
 			structType: struct {
-				Port int `pedantigo:"defaultUsingMethod=GetPort"`
+				Port int `validate:"defaultUsingMethod=GetPort"`
 			}{},
 			strictMissingFields:  false,
 			shouldPanic:          true,
@@ -343,7 +343,7 @@ func TestBuildFieldDeserializers_DefaultUsingMethod(t *testing.T) {
 		{
 			name: "defaultUsingMethod with missing method panics",
 			structType: struct {
-				Age int `pedantigo:"defaultUsingMethod=NonExistentMethod"`
+				Age int `validate:"defaultUsingMethod=NonExistentMethod"`
 			}{},
 			strictMissingFields:  true,
 			shouldPanic:          true,
@@ -540,7 +540,7 @@ func TestBuildFieldDeserializers_FieldDeserializerCallable(t *testing.T) {
 // TestBuildFieldDeserializers_RequiredFieldValidation tests required field tag validation.
 func TestBuildFieldDeserializers_RequiredFieldValidation(t *testing.T) {
 	type TestStruct struct {
-		Name string `pedantigo:"required"`
+		Name string `validate:"required"`
 		Age  int
 	}
 
@@ -606,21 +606,21 @@ func TestBuildFieldDeserializers_ConstraintsParsed(t *testing.T) {
 		{
 			name: "field with email constraint",
 			structType: struct {
-				Email string `pedantigo:"email"`
+				Email string `validate:"email"`
 			}{},
 			expectedFields: []string{"Email"},
 		},
 		{
 			name: "field with min constraint",
 			structType: struct {
-				Age int `pedantigo:"min=18"`
+				Age int `validate:"min=18"`
 			}{},
 			expectedFields: []string{"Age"},
 		},
 		{
 			name: "field with multiple constraints",
 			structType: struct {
-				Email string `pedantigo:"required,email,min=5,max=100"`
+				Email string `validate:"required,email,min=5,max=100"`
 			}{},
 			expectedFields: []string{"Email"},
 		},
@@ -998,11 +998,11 @@ func getMapKeys(m map[string]FieldDeserializer) []string {
 // TestBuildFieldDeserializers_ExtraFieldsTagSkip tests that fields with extra_fields tag are skipped.
 func TestBuildFieldDeserializers_ExtraFieldsTagSkip(t *testing.T) {
 	type ExtraCapture struct {
-		Name   string         `json:"name" pedantigo:"required"`
-		Extras map[string]any `json:"extras" pedantigo:"extra_fields"`
+		Name   string         `json:"name" validate:"required"`
+		Extras map[string]any `json:"extras" validate:"extra_fields"`
 	}
 
-	opts := BuilderOptions{TagName: "pedantigo", StrictMissingFields: true}
+	opts := BuilderOptions{TagName: "validate", StrictMissingFields: true}
 	deserializers := BuildFieldDeserializers(
 		reflect.TypeOf(ExtraCapture{}),
 		opts,
@@ -1020,10 +1020,10 @@ func TestBuildFieldDeserializers_ExtraFieldsTagSkip(t *testing.T) {
 // TestBuildFieldDeserializers_StaticDefaultApplied tests that static defaults are applied for missing fields.
 func TestBuildFieldDeserializers_StaticDefaultApplied(t *testing.T) {
 	type WithDefault struct {
-		Name string `json:"name" pedantigo:"default=DefaultName"`
+		Name string `json:"name" validate:"default=DefaultName"`
 	}
 
-	opts := BuilderOptions{TagName: "pedantigo", StrictMissingFields: true}
+	opts := BuilderOptions{TagName: "validate", StrictMissingFields: true}
 
 	var setDefaultCalled bool
 	var setDefaultValue string
@@ -1056,10 +1056,10 @@ func TestBuildFieldDeserializers_StaticDefaultApplied(t *testing.T) {
 // TestBuildFieldDeserializers_StaticDefaultWithTransform tests default with string transformation.
 func TestBuildFieldDeserializers_StaticDefaultWithTransform(t *testing.T) {
 	type WithDefaultAndTransform struct {
-		Name string `json:"name" pedantigo:"default=  hello  ,strip_whitespace,to_upper"`
+		Name string `json:"name" validate:"default=  hello  ,strip_whitespace,to_upper"`
 	}
 
-	opts := BuilderOptions{TagName: "pedantigo", StrictMissingFields: true}
+	opts := BuilderOptions{TagName: "validate", StrictMissingFields: true}
 
 	deserializers := BuildFieldDeserializers(
 		reflect.TypeOf(WithDefaultAndTransform{}),
@@ -1091,7 +1091,7 @@ func TestBuildFieldDeserializers_SetFieldValueError(t *testing.T) {
 		Name string `json:"name"`
 	}
 
-	opts := BuilderOptions{TagName: "pedantigo", StrictMissingFields: true}
+	opts := BuilderOptions{TagName: "validate", StrictMissingFields: true}
 
 	deserializers := BuildFieldDeserializers(
 		reflect.TypeOf(Simple{}),
@@ -1116,7 +1116,7 @@ func TestBuildFieldDeserializers_SetFieldValueError(t *testing.T) {
 
 // MethodDefaultStruct is a struct with defaultUsingMethod.
 type MethodDefaultStruct struct {
-	Port int `json:"port" pedantigo:"defaultUsingMethod=GetDefaultPort"`
+	Port int `json:"port" validate:"defaultUsingMethod=GetDefaultPort"`
 }
 
 // GetDefaultPort returns the default port.
@@ -1126,7 +1126,7 @@ func (m *MethodDefaultStruct) GetDefaultPort() (int, error) {
 
 // TestBuildFieldDeserializers_MethodDefaultApplied tests defaultUsingMethod execution.
 func TestBuildFieldDeserializers_MethodDefaultApplied(t *testing.T) {
-	opts := BuilderOptions{TagName: "pedantigo", StrictMissingFields: true}
+	opts := BuilderOptions{TagName: "validate", StrictMissingFields: true}
 
 	deserializers := BuildFieldDeserializers(
 		reflect.TypeOf(MethodDefaultStruct{}),
@@ -1151,7 +1151,7 @@ func TestBuildFieldDeserializers_MethodDefaultApplied(t *testing.T) {
 
 // MethodDefaultErrorStruct is a struct with defaultUsingMethod that returns an error.
 type MethodDefaultErrorStruct struct {
-	Port int `json:"port" pedantigo:"defaultUsingMethod=GetDefaultPortWithError"`
+	Port int `json:"port" validate:"defaultUsingMethod=GetDefaultPortWithError"`
 }
 
 // GetDefaultPortWithError returns an error.
@@ -1161,7 +1161,7 @@ func (m *MethodDefaultErrorStruct) GetDefaultPortWithError() (int, error) {
 
 // TestBuildFieldDeserializers_MethodDefaultError tests error from defaultUsingMethod.
 func TestBuildFieldDeserializers_MethodDefaultError(t *testing.T) {
-	opts := BuilderOptions{TagName: "pedantigo", StrictMissingFields: true}
+	opts := BuilderOptions{TagName: "validate", StrictMissingFields: true}
 
 	deserializers := BuildFieldDeserializers(
 		reflect.TypeOf(MethodDefaultErrorStruct{}),
@@ -1186,7 +1186,7 @@ func TestBuildFieldDeserializers_MethodDefaultError(t *testing.T) {
 
 // MethodDefaultStringStruct has a method default for string field with transformations.
 type MethodDefaultStringStruct struct {
-	Name string `json:"name" pedantigo:"defaultUsingMethod=GetDefaultName,to_upper"`
+	Name string `json:"name" validate:"defaultUsingMethod=GetDefaultName,to_upper"`
 }
 
 // GetDefaultName returns default name.
@@ -1196,7 +1196,7 @@ func (m *MethodDefaultStringStruct) GetDefaultName() (string, error) {
 
 // TestBuildFieldDeserializers_MethodDefaultWithTransform tests method default with transformations.
 func TestBuildFieldDeserializers_MethodDefaultWithTransform(t *testing.T) {
-	opts := BuilderOptions{TagName: "pedantigo", StrictMissingFields: true}
+	opts := BuilderOptions{TagName: "validate", StrictMissingFields: true}
 
 	deserializers := BuildFieldDeserializers(
 		reflect.TypeOf(MethodDefaultStringStruct{}),

--- a/internal/deserialize/extras.go
+++ b/internal/deserialize/extras.go
@@ -13,7 +13,7 @@ type ExtraFieldInfo struct {
 	FieldName  string // Go field name (for error messages)
 }
 
-// DetectExtraField finds the field tagged with `pedantigo:"extra_fields"`.
+// DetectExtraField finds the field tagged with `validate:"extra_fields"`.
 // Returns nil if no such field exists.
 // Panics if:
 //   - Multiple fields have extra_fields tag

--- a/internal/deserialize/extras.go
+++ b/internal/deserialize/extras.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/SmrutAI/pedantigo/internal/tags"
+	"github.com/SmrutAI/pedantigo/v2/internal/tags"
 )
 
 // ExtraFieldInfo holds metadata about a struct's extra_fields field.

--- a/internal/deserialize/extras_test.go
+++ b/internal/deserialize/extras_test.go
@@ -12,7 +12,7 @@ import (
 
 type ValidExtraField struct {
 	Name   string         `json:"name"`
-	Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+	Extras map[string]any `json:"-" validate:"extra_fields"`
 }
 
 type NoExtraField struct {
@@ -22,45 +22,45 @@ type NoExtraField struct {
 
 type WrongType struct {
 	Name   string `json:"name"`
-	Extras string `json:"-" pedantigo:"extra_fields"` // Wrong type!
+	Extras string `json:"-" validate:"extra_fields"` // Wrong type!
 }
 
 type MultipleExtraFields struct {
 	Name    string         `json:"name"`
-	Extras1 map[string]any `json:"-" pedantigo:"extra_fields"`
-	Extras2 map[string]any `json:"-" pedantigo:"extra_fields"` // Duplicate!
+	Extras1 map[string]any `json:"-" validate:"extra_fields"`
+	Extras2 map[string]any `json:"-" validate:"extra_fields"` // Duplicate!
 }
 
 type PointerMapField struct {
 	Name   string          `json:"name"`
-	Extras *map[string]any `json:"-" pedantigo:"extra_fields"` // Pointer to map - should fail
+	Extras *map[string]any `json:"-" validate:"extra_fields"` // Pointer to map - should fail
 }
 
 type privateExtraField struct {
 	Name   string
-	extras map[string]any `json:"-" pedantigo:"extra_fields"` //nolint:unused // private field - ignored
+	extras map[string]any `json:"-" validate:"extra_fields"` //nolint:unused // private field - ignored
 }
 
 type MapStringInterface struct {
 	Name   string                 `json:"name"`
-	Extras map[string]interface{} `json:"-" pedantigo:"extra_fields"` // interface{} is alias for any
+	Extras map[string]interface{} `json:"-" validate:"extra_fields"` // interface{} is alias for any
 }
 
 type WrongMapKeyType struct {
 	Name   string      `json:"name"`
-	Extras map[int]any `json:"-" pedantigo:"extra_fields"` // Wrong key type!
+	Extras map[int]any `json:"-" validate:"extra_fields"` // Wrong key type!
 }
 
 type WrongMapValueType struct {
 	Name   string            `json:"name"`
-	Extras map[string]string `json:"-" pedantigo:"extra_fields"` // Wrong value type!
+	Extras map[string]string `json:"-" validate:"extra_fields"` // Wrong value type!
 }
 
 // Tests
 
 func TestDetectExtraField_ValidField_ReturnsInfo(t *testing.T) {
 	typ := reflect.TypeOf(ValidExtraField{})
-	result := DetectExtraField(typ, "pedantigo")
+	result := DetectExtraField(typ, "validate")
 
 	require.NotNil(t, result, "Should detect extra_fields field")
 	assert.Equal(t, 1, result.FieldIndex, "Extra field should be at index 1")
@@ -70,7 +70,7 @@ func TestDetectExtraField_ValidField_ReturnsInfo(t *testing.T) {
 func TestDetectExtraField_MapStringInterface_ReturnsInfo(t *testing.T) {
 	// interface{} is an alias for any, should be accepted
 	typ := reflect.TypeOf(MapStringInterface{})
-	result := DetectExtraField(typ, "pedantigo")
+	result := DetectExtraField(typ, "validate")
 
 	require.NotNil(t, result, "Should detect extra_fields field with map[string]interface{}")
 	assert.Equal(t, 1, result.FieldIndex, "Extra field should be at index 1")
@@ -79,7 +79,7 @@ func TestDetectExtraField_MapStringInterface_ReturnsInfo(t *testing.T) {
 
 func TestDetectExtraField_NoExtraField_ReturnsNil(t *testing.T) {
 	typ := reflect.TypeOf(NoExtraField{})
-	result := DetectExtraField(typ, "pedantigo")
+	result := DetectExtraField(typ, "validate")
 
 	assert.Nil(t, result, "Should return nil when no extra_fields field exists")
 }
@@ -90,7 +90,7 @@ func TestDetectExtraField_WrongType_Panics(t *testing.T) {
 	require.PanicsWithValue(t,
 		"field 'Extras' tagged with pedantigo:\"extra_fields\" must be of type map[string]any",
 		func() {
-			DetectExtraField(typ, "pedantigo")
+			DetectExtraField(typ, "validate")
 		},
 		"Should panic when field type is not map[string]any",
 	)
@@ -102,7 +102,7 @@ func TestDetectExtraField_WrongMapKeyType_Panics(t *testing.T) {
 	require.PanicsWithValue(t,
 		"field 'Extras' tagged with pedantigo:\"extra_fields\" must be of type map[string]any",
 		func() {
-			DetectExtraField(typ, "pedantigo")
+			DetectExtraField(typ, "validate")
 		},
 		"Should panic when map key type is not string",
 	)
@@ -114,7 +114,7 @@ func TestDetectExtraField_WrongMapValueType_Panics(t *testing.T) {
 	require.PanicsWithValue(t,
 		"field 'Extras' tagged with pedantigo:\"extra_fields\" must be of type map[string]any",
 		func() {
-			DetectExtraField(typ, "pedantigo")
+			DetectExtraField(typ, "validate")
 		},
 		"Should panic when map value type is not any/interface{}",
 	)
@@ -126,7 +126,7 @@ func TestDetectExtraField_MultipleExtraFields_Panics(t *testing.T) {
 	require.PanicsWithValue(t,
 		"multiple fields tagged with pedantigo:\"extra_fields\" found: only one is allowed",
 		func() {
-			DetectExtraField(typ, "pedantigo")
+			DetectExtraField(typ, "validate")
 		},
 		"Should panic when multiple extra_fields tags exist",
 	)
@@ -138,7 +138,7 @@ func TestDetectExtraField_PointerToMapStringAny_Panics(t *testing.T) {
 	require.PanicsWithValue(t,
 		"field 'Extras' tagged with pedantigo:\"extra_fields\" must be of type map[string]any",
 		func() {
-			DetectExtraField(typ, "pedantigo")
+			DetectExtraField(typ, "validate")
 		},
 		"Should panic when field is pointer to map[string]any",
 	)
@@ -147,15 +147,19 @@ func TestDetectExtraField_PointerToMapStringAny_Panics(t *testing.T) {
 func TestDetectExtraField_PrivateField_Ignored(t *testing.T) {
 	// Private fields should be ignored even if they have the tag
 	typ := reflect.TypeOf(privateExtraField{})
-	result := DetectExtraField(typ, "pedantigo")
+	result := DetectExtraField(typ, "validate")
 
 	assert.Nil(t, result, "Should ignore private fields with extra_fields tag")
 }
 
 func TestDetectExtraField_DifferentTagName_ReturnsNil(t *testing.T) {
-	// When using a different tag name, should not detect the field
-	typ := reflect.TypeOf(ValidExtraField{})
-	result := DetectExtraField(typ, "validate") // Different tag name
+	// Field is tagged with "binding", but we look up using "validate" - should not match.
+	type BindingTaggedField struct {
+		Name   string         `json:"name"`
+		Extras map[string]any `json:"-" binding:"extra_fields"`
+	}
+	typ := reflect.TypeOf(BindingTaggedField{})
+	result := DetectExtraField(typ, "validate") // Different tag name than the struct uses
 
 	assert.Nil(t, result, "Should return nil when using different tag name")
 }
@@ -163,11 +167,11 @@ func TestDetectExtraField_DifferentTagName_ReturnsNil(t *testing.T) {
 func TestDetectExtraField_EmptyTagValue_ReturnsNil(t *testing.T) {
 	type EmptyTag struct {
 		Name   string         `json:"name"`
-		Extras map[string]any `json:"-" pedantigo:""` // Empty tag value
+		Extras map[string]any `json:"-" validate:""` // Empty tag value
 	}
 
 	typ := reflect.TypeOf(EmptyTag{})
-	result := DetectExtraField(typ, "pedantigo")
+	result := DetectExtraField(typ, "validate")
 
 	assert.Nil(t, result, "Should return nil when tag value is empty")
 }
@@ -175,11 +179,11 @@ func TestDetectExtraField_EmptyTagValue_ReturnsNil(t *testing.T) {
 func TestDetectExtraField_WrongTagValue_ReturnsNil(t *testing.T) {
 	type WrongTagValue struct {
 		Name   string         `json:"name"`
-		Extras map[string]any `json:"-" pedantigo:"something_else"` // Wrong tag value
+		Extras map[string]any `json:"-" validate:"something_else"` // Wrong tag value
 	}
 
 	typ := reflect.TypeOf(WrongTagValue{})
-	result := DetectExtraField(typ, "pedantigo")
+	result := DetectExtraField(typ, "validate")
 
 	assert.Nil(t, result, "Should return nil when tag value is not 'extra_fields'")
 }
@@ -188,12 +192,12 @@ func TestDetectExtraField_WrongTagValue_ReturnsNil(t *testing.T) {
 func TestDetectExtraField_PointerType(t *testing.T) {
 	type HasExtra struct {
 		Name   string         `json:"name"`
-		Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any `json:"-" validate:"extra_fields"`
 	}
 
 	// Pass pointer to struct type
 	typ := reflect.TypeOf(&HasExtra{})
-	result := DetectExtraField(typ, "pedantigo")
+	result := DetectExtraField(typ, "validate")
 
 	assert.NotNil(t, result, "Should handle pointer types by dereferencing")
 	assert.Equal(t, 1, result.FieldIndex)
@@ -202,14 +206,14 @@ func TestDetectExtraField_PointerType(t *testing.T) {
 // TestDetectExtraField_NonStructType tests DetectExtraField returns nil for non-struct types.
 func TestDetectExtraField_NonStructType(t *testing.T) {
 	// Test with string type
-	result := DetectExtraField(reflect.TypeOf(""), "pedantigo")
+	result := DetectExtraField(reflect.TypeOf(""), "validate")
 	assert.Nil(t, result, "Should return nil for string type")
 
 	// Test with int type
-	result = DetectExtraField(reflect.TypeOf(0), "pedantigo")
+	result = DetectExtraField(reflect.TypeOf(0), "validate")
 	assert.Nil(t, result, "Should return nil for int type")
 
 	// Test with slice type
-	result = DetectExtraField(reflect.TypeOf([]string{}), "pedantigo")
+	result = DetectExtraField(reflect.TypeOf([]string{}), "validate")
 	assert.Nil(t, result, "Should return nil for slice type")
 }

--- a/internal/deserialize/setter.go
+++ b/internal/deserialize/setter.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/SmrutAI/pedantigo/internal/tags"
+	"github.com/SmrutAI/pedantigo/v2/internal/tags"
 )
 
 // FieldOptions contains options for field deserialization and required checking.

--- a/internal/deserialize/setter.go
+++ b/internal/deserialize/setter.go
@@ -16,7 +16,7 @@ import (
 type FieldOptions struct {
 	// StrictMissingFields controls whether missing required fields cause errors.
 	StrictMissingFields bool
-	// TagName is the struct tag name to parse (e.g., "pedantigo" or "validate").
+	// TagName is the struct tag name to parse (default "validate"; e.g., "binding" for Gin).
 	TagName string
 	// Path is the current field path for error reporting (e.g., "Items[0]").
 	Path string

--- a/internal/deserialize/setter_test.go
+++ b/internal/deserialize/setter_test.go
@@ -1235,8 +1235,8 @@ func TestMultiRequiredFieldError_Error(t *testing.T) {
 
 func TestSetFieldValueWithOptions_RequiredFields(t *testing.T) {
 	type Address struct {
-		Street string `json:"street" pedantigo:"required"`
-		City   string `json:"city" pedantigo:"required"`
+		Street string `json:"street" validate:"required"`
+		City   string `json:"city" validate:"required"`
 	}
 
 	type TestStruct struct {
@@ -1255,7 +1255,7 @@ func TestSetFieldValueWithOptions_RequiredFields(t *testing.T) {
 			value: map[string]any{"street": "123 Main St", "city": "NYC"},
 			opts: FieldOptions{
 				StrictMissingFields: true,
-				TagName:             "pedantigo",
+				TagName:             "validate",
 			},
 			wantErr: false,
 		},
@@ -1264,7 +1264,7 @@ func TestSetFieldValueWithOptions_RequiredFields(t *testing.T) {
 			value: map[string]any{"street": "123 Main St"},
 			opts: FieldOptions{
 				StrictMissingFields: true,
-				TagName:             "pedantigo",
+				TagName:             "validate",
 			},
 			wantErr: true,
 		},
@@ -1273,7 +1273,7 @@ func TestSetFieldValueWithOptions_RequiredFields(t *testing.T) {
 			value: map[string]any{"street": "123 Main St"},
 			opts: FieldOptions{
 				StrictMissingFields: false,
-				TagName:             "pedantigo",
+				TagName:             "validate",
 			},
 			wantErr: false,
 		},
@@ -1282,7 +1282,7 @@ func TestSetFieldValueWithOptions_RequiredFields(t *testing.T) {
 			value: map[string]any{"street": "123 Main St"},
 			opts: FieldOptions{
 				StrictMissingFields: true,
-				TagName:             "pedantigo",
+				TagName:             "validate",
 				Path:                "Parent",
 			},
 			wantErr: true,
@@ -1292,7 +1292,7 @@ func TestSetFieldValueWithOptions_RequiredFields(t *testing.T) {
 			value: map[string]any{"street": "123 Main St"},
 			opts: FieldOptions{
 				StrictMissingFields: true,
-				TagName:             "pedantigo",
+				TagName:             "validate",
 				FieldName:           "Address",
 			},
 			wantErr: true,
@@ -1324,8 +1324,8 @@ func TestSetFieldValueWithOptions_RequiredFields(t *testing.T) {
 
 func TestSetFieldValueWithOptions_SliceWithRequiredFields(t *testing.T) {
 	type Item struct {
-		Name  string `json:"name" pedantigo:"required"`
-		Count int    `json:"count" pedantigo:"required"`
+		Name  string `json:"name" validate:"required"`
+		Count int    `json:"count" validate:"required"`
 	}
 
 	type TestStruct struct {
@@ -1346,7 +1346,7 @@ func TestSetFieldValueWithOptions_SliceWithRequiredFields(t *testing.T) {
 			},
 			opts: FieldOptions{
 				StrictMissingFields: true,
-				TagName:             "pedantigo",
+				TagName:             "validate",
 				FieldName:           "Items",
 			},
 			wantErr: false,
@@ -1359,7 +1359,7 @@ func TestSetFieldValueWithOptions_SliceWithRequiredFields(t *testing.T) {
 			},
 			opts: FieldOptions{
 				StrictMissingFields: true,
-				TagName:             "pedantigo",
+				TagName:             "validate",
 				FieldName:           "Items",
 			},
 			wantErr: true,
@@ -1371,7 +1371,7 @@ func TestSetFieldValueWithOptions_SliceWithRequiredFields(t *testing.T) {
 			},
 			opts: FieldOptions{
 				StrictMissingFields: true,
-				TagName:             "pedantigo",
+				TagName:             "validate",
 				FieldName:           "Items",
 			},
 			wantErr: false,
@@ -1401,8 +1401,8 @@ func TestSetFieldValueWithOptions_SliceWithRequiredFields(t *testing.T) {
 
 func TestSetFieldValueWithOptions_MapWithRequiredFields(t *testing.T) {
 	type Data struct {
-		Value int    `json:"value" pedantigo:"required"`
-		Label string `json:"label" pedantigo:"required"`
+		Value int    `json:"value" validate:"required"`
+		Label string `json:"label" validate:"required"`
 	}
 
 	type TestStruct struct {
@@ -1423,7 +1423,7 @@ func TestSetFieldValueWithOptions_MapWithRequiredFields(t *testing.T) {
 			},
 			opts: FieldOptions{
 				StrictMissingFields: true,
-				TagName:             "pedantigo",
+				TagName:             "validate",
 				FieldName:           "Records",
 			},
 			wantErr: false,
@@ -1436,7 +1436,7 @@ func TestSetFieldValueWithOptions_MapWithRequiredFields(t *testing.T) {
 			},
 			opts: FieldOptions{
 				StrictMissingFields: true,
-				TagName:             "pedantigo",
+				TagName:             "validate",
 				FieldName:           "Records",
 			},
 			wantErr: true,
@@ -1448,7 +1448,7 @@ func TestSetFieldValueWithOptions_MapWithRequiredFields(t *testing.T) {
 			},
 			opts: FieldOptions{
 				StrictMissingFields: true,
-				TagName:             "pedantigo",
+				TagName:             "validate",
 				FieldName:           "Records",
 			},
 			wantErr: false,
@@ -1689,7 +1689,7 @@ func TestDeserializeStructFields_RecursiveError(t *testing.T) {
 // TestDeserializeStructFields_MultiRequiredErrorPropagation tests MultiRequiredFieldError propagation.
 func TestDeserializeStructFields_MultiRequiredErrorPropagation(t *testing.T) {
 	type Nested struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 	type Parent struct {
 		Nested Nested `json:"nested"`
@@ -1704,13 +1704,13 @@ func TestDeserializeStructFields_MultiRequiredErrorPropagation(t *testing.T) {
 	recursiveSet = func(fv reflect.Value, iv any, ft reflect.Type) error {
 		return SetFieldValueWithOptions(fv, iv, ft, recursiveSet, FieldOptions{
 			StrictMissingFields: true,
-			TagName:             "pedantigo",
+			TagName:             "validate",
 		})
 	}
 
 	err := deserializeStructFields(reflect.ValueOf(&out).Elem(), reflect.TypeOf(out), inputMap, recursiveSet, FieldOptions{
 		StrictMissingFields: true,
-		TagName:             "pedantigo",
+		TagName:             "validate",
 	})
 	require.Error(t, err)
 	var multiErr *MultiRequiredFieldError

--- a/internal/schemagen/schemagen.go
+++ b/internal/schemagen/schemagen.go
@@ -133,7 +133,7 @@ func GenerateBaseSchema[T any]() *jsonschema.Schema {
 	}
 
 	// Clear the required fields set by jsonschema library
-	// We'll add our own based on pedantigo:"required" tags
+	// We'll add our own based on validate:"required" tags
 	actualSchema.Required = nil
 
 	return actualSchema

--- a/internal/schemagen/schemagen_test.go
+++ b/internal/schemagen/schemagen_test.go
@@ -16,19 +16,19 @@ import (
 // Test structs
 // SimpleStruct represents the data structure.
 type SimpleStruct struct {
-	Name  string `json:"name" pedantigo:"required,min=3,max=50"`
-	Age   int    `json:"age" pedantigo:"min=18,max=100"`
-	Email string `json:"email" pedantigo:"email"`
+	Name  string `json:"name" validate:"required,min=3,max=50"`
+	Age   int    `json:"age" validate:"min=18,max=100"`
+	Email string `json:"email" validate:"email"`
 }
 
 type NestedStruct struct {
-	User    SimpleStruct `json:"user" pedantigo:"required"`
+	User    SimpleStruct `json:"user" validate:"required"`
 	Created time.Time    `json:"created"`
 }
 
 type SliceStruct struct {
-	Tags []string `json:"tags" pedantigo:"min=1,max=10"`
-	IDs  []int    `json:"ids" pedantigo:"min=1"`
+	Tags []string `json:"tags" validate:"min=1,max=10"`
+	IDs  []int    `json:"ids" validate:"min=1"`
 }
 
 type MapStruct struct {
@@ -36,16 +36,16 @@ type MapStruct struct {
 }
 
 type ConstraintsStruct struct {
-	URL        string  `json:"url" pedantigo:"url"`
-	UUID       string  `json:"uuid" pedantigo:"uuid"`
-	IPv4       string  `json:"ipv4" pedantigo:"ipv4"`
-	IPv6       string  `json:"ipv6" pedantigo:"ipv6"`
-	Pattern    string  `json:"pattern" pedantigo:"regexp=^[A-Z]+$"`
-	Status     string  `json:"status" pedantigo:"oneof=active inactive pending"`
-	Score      float64 `json:"score" pedantigo:"gte=0,lte=100"`
-	Count      int     `json:"count" pedantigo:"gt=0,lt=1000"`
-	Enabled    bool    `json:"enabled" pedantigo:"default=true"`
-	MaxRetries int     `json:"max_retries" pedantigo:"default=3"`
+	URL        string  `json:"url" validate:"url"`
+	UUID       string  `json:"uuid" validate:"uuid"`
+	IPv4       string  `json:"ipv4" validate:"ipv4"`
+	IPv6       string  `json:"ipv6" validate:"ipv6"`
+	Pattern    string  `json:"pattern" validate:"regexp=^[A-Z]+$"`
+	Status     string  `json:"status" validate:"oneof=active inactive pending"`
+	Score      float64 `json:"score" validate:"gte=0,lte=100"`
+	Count      int     `json:"count" validate:"gt=0,lt=1000"`
+	Enabled    bool    `json:"enabled" validate:"default=true"`
+	MaxRetries int     `json:"max_retries" validate:"default=3"`
 }
 
 // Test containers for nested types
@@ -134,7 +134,7 @@ func TestGenerateOpenAPIBaseSchema(t *testing.T) {
 
 func TestEnhanceSchema(t *testing.T) {
 	mockParseTagFunc := func(tag reflect.StructTag) map[string]string {
-		pedantigoTag := tag.Get("pedantigo")
+		pedantigoTag := tag.Get("validate")
 		if pedantigoTag == "" {
 			return nil
 		}
@@ -1420,7 +1420,7 @@ func TestParseDefaultValue(t *testing.T) {
 
 func TestEnhanceNestedTypes(t *testing.T) {
 	mockParseTagFunc := func(tag reflect.StructTag) map[string]string {
-		pedantigoTag := tag.Get("pedantigo")
+		pedantigoTag := tag.Get("validate")
 		if pedantigoTag == "" {
 			return nil
 		}
@@ -1659,7 +1659,7 @@ func TestApplyConstraintsToItems(t *testing.T) {
 
 func TestFullIntegration(t *testing.T) {
 	mockParseTagFunc := func(tag reflect.StructTag) map[string]string {
-		pedantigoTag := tag.Get("pedantigo")
+		pedantigoTag := tag.Get("validate")
 		if pedantigoTag == "" {
 			return nil
 		}
@@ -1752,33 +1752,33 @@ func splitKeyValue(part string) (key, value string, found bool) {
 
 // CatUnion represents a cat variant with validation constraints.
 type CatUnion struct {
-	Name  string `json:"name" pedantigo:"required"`
-	Lives int    `json:"lives" pedantigo:"min=1,max=9"`
+	Name  string `json:"name" validate:"required"`
+	Lives int    `json:"lives" validate:"min=1,max=9"`
 }
 
 // DogUnion represents a dog variant with validation constraints.
 type DogUnion struct {
-	Name  string `json:"name" pedantigo:"required"`
+	Name  string `json:"name" validate:"required"`
 	Breed string `json:"breed"`
 }
 
 // BirdUnion represents a bird variant with validation constraints.
 type BirdUnion struct {
-	Name string `json:"name" pedantigo:"required"`
-	Eggs int    `json:"eggs" pedantigo:"min=0"`
+	Name string `json:"name" validate:"required"`
+	Eggs int    `json:"eggs" validate:"min=0"`
 }
 
 // NestedVariant represents a variant with nested struct fields.
 type NestedVariant struct {
-	ID    string       `json:"id" pedantigo:"required"`
-	Owner SimpleStruct `json:"owner" pedantigo:"required"`
+	ID    string       `json:"id" validate:"required"`
+	Owner SimpleStruct `json:"owner" validate:"required"`
 }
 
 // TestGenerateVariantSchema_BasicVariant tests GenerateVariantSchema
 // generates schema for variant type with properties.
 func TestGenerateVariantSchema_BasicVariant(t *testing.T) {
 	mockParseTagFunc := func(tag reflect.StructTag) map[string]string {
-		validateTag := tag.Get("pedantigo")
+		validateTag := tag.Get("validate")
 		if validateTag == "" {
 			return nil
 		}
@@ -1847,7 +1847,7 @@ func TestGenerateVariantSchema_DiscriminatorConstConstraint(t *testing.T) {
 	}
 
 	mockParseTagFunc := func(tag reflect.StructTag) map[string]string {
-		validateTag := tag.Get("pedantigo")
+		validateTag := tag.Get("validate")
 		if validateTag == "" {
 			return nil
 		}
@@ -1889,7 +1889,7 @@ func TestGenerateVariantSchema_DiscriminatorConstConstraint(t *testing.T) {
 // GenerateVariantSchema includes validation constraints from pedantigo tags.
 func TestGenerateVariantSchema_IncludesValidationConstraints(t *testing.T) {
 	mockParseTagFunc := func(tag reflect.StructTag) map[string]string {
-		validateTag := tag.Get("pedantigo")
+		validateTag := tag.Get("validate")
 		if validateTag == "" {
 			return nil
 		}
@@ -1935,7 +1935,7 @@ func TestGenerateVariantSchema_IncludesValidationConstraints(t *testing.T) {
 // GenerateVariantSchema handles nested struct fields.
 func TestGenerateVariantSchema_HandlesNestedStructs(t *testing.T) {
 	mockParseTagFunc := func(tag reflect.StructTag) map[string]string {
-		validateTag := tag.Get("pedantigo")
+		validateTag := tag.Get("validate")
 		if validateTag == "" {
 			return nil
 		}
@@ -2011,7 +2011,7 @@ func TestGenerateUnionSchema_ReturnsOneOfSchema(t *testing.T) {
 	}
 
 	mockParseTagFunc := func(tag reflect.StructTag) map[string]string {
-		validateTag := tag.Get("pedantigo")
+		validateTag := tag.Get("validate")
 		if validateTag == "" {
 			return nil
 		}
@@ -2073,7 +2073,7 @@ func TestGenerateUnionSchema_OneOfArrayLength(t *testing.T) {
 	}
 
 	mockParseTagFunc := func(tag reflect.StructTag) map[string]string {
-		validateTag := tag.Get("pedantigo")
+		validateTag := tag.Get("validate")
 		if validateTag == "" {
 			return nil
 		}
@@ -2115,7 +2115,7 @@ func TestGenerateUnionSchema_EachVariantProperlyGenerated(t *testing.T) {
 	}
 
 	mockParseTagFunc := func(tag reflect.StructTag) map[string]string {
-		validateTag := tag.Get("pedantigo")
+		validateTag := tag.Get("validate")
 		if validateTag == "" {
 			return nil
 		}
@@ -2159,7 +2159,7 @@ func TestGenerateUnionSchema_DiscriminatorConstInEachVariant(t *testing.T) {
 	}
 
 	mockParseTagFunc := func(tag reflect.StructTag) map[string]string {
-		validateTag := tag.Get("pedantigo")
+		validateTag := tag.Get("validate")
 		if validateTag == "" {
 			return nil
 		}
@@ -2209,7 +2209,7 @@ func TestGenerateUnionSchema_VariantPropertiesIncluded(t *testing.T) {
 	}
 
 	mockParseTagFunc := func(tag reflect.StructTag) map[string]string {
-		validateTag := tag.Get("pedantigo")
+		validateTag := tag.Get("validate")
 		if validateTag == "" {
 			return nil
 		}
@@ -2310,7 +2310,7 @@ func TestGenerateUnionSchema_WithValidationConstraints(t *testing.T) {
 	}
 
 	mockParseTagFunc := func(tag reflect.StructTag) map[string]string {
-		validateTag := tag.Get("pedantigo")
+		validateTag := tag.Get("validate")
 		if validateTag == "" {
 			return nil
 		}
@@ -2351,13 +2351,13 @@ func TestGenerateUnionSchema_WithValidationConstraints(t *testing.T) {
 // TestEnhanceSchema_UnexportedFields tests that unexported fields are skipped.
 func TestEnhanceSchema_UnexportedFields(t *testing.T) {
 	type StructWithUnexported struct {
-		Public     string `json:"public" pedantigo:"required"`
+		Public     string `json:"public" validate:"required"`
 		private    string //nolint:unused // intentionally unexported for testing
-		AlsoPublic int    `json:"also_public" pedantigo:"min=0"`
+		AlsoPublic int    `json:"also_public" validate:"min=0"`
 	}
 
 	mockParseTagFunc := func(tag reflect.StructTag) map[string]string {
-		pedantigoTag := tag.Get("pedantigo")
+		pedantigoTag := tag.Get("validate")
 		if pedantigoTag == "" {
 			return nil
 		}
@@ -2388,11 +2388,11 @@ func TestEnhanceSchema_UnexportedFields(t *testing.T) {
 // TestEnhanceSchema_PointerType tests enhancing a pointer type.
 func TestEnhanceSchema_PointerType(t *testing.T) {
 	type Target struct {
-		Name string `json:"name" pedantigo:"required,min=1"`
+		Name string `json:"name" validate:"required,min=1"`
 	}
 
 	mockParseTagFunc := func(tag reflect.StructTag) map[string]string {
-		pedantigoTag := tag.Get("pedantigo")
+		pedantigoTag := tag.Get("validate")
 		if pedantigoTag == "" {
 			return nil
 		}
@@ -2439,13 +2439,13 @@ func TestEnhanceSchema_NonStructType(t *testing.T) {
 // TestEnhanceSchema_JSONTagWithOptions tests JSON tag with comma-separated options.
 func TestEnhanceSchema_JSONTagWithOptions(t *testing.T) {
 	type StructWithJSONOptions struct {
-		Name     string `json:"name,omitempty" pedantigo:"required"`
-		Age      int    `json:"age,string" pedantigo:"min=0"`
+		Name     string `json:"name,omitempty" validate:"required"`
+		Age      int    `json:"age,string" validate:"min=0"`
 		Disabled string `json:"-"`
 	}
 
 	mockParseTagFunc := func(tag reflect.StructTag) map[string]string {
-		pedantigoTag := tag.Get("pedantigo")
+		pedantigoTag := tag.Get("validate")
 		if pedantigoTag == "" {
 			return nil
 		}
@@ -2503,15 +2503,15 @@ func TestApplyConstraints_MapWithConstraints(t *testing.T) {
 
 // MetadataStruct is a test struct with schema metadata.
 type MetadataStruct struct {
-	Name  string `json:"name" pedantigo:"required,title=User Name,description=Full name of user,examples=[\"John\",\"Jane\"]"`
-	Age   int    `json:"age" pedantigo:"min=0,description=Age in years,examples=[18,25,30]"`
-	Email string `json:"email" pedantigo:"email,title=Email Address,description=Contact email,examples=[\"john@example.com\",\"jane@example.com\"]"`
+	Name  string `json:"name" validate:"required,title=User Name,description=Full name of user,examples=[\"John\",\"Jane\"]"`
+	Age   int    `json:"age" validate:"min=0,description=Age in years,examples=[18,25,30]"`
+	Email string `json:"email" validate:"email,title=Email Address,description=Contact email,examples=[\"john@example.com\",\"jane@example.com\"]"`
 }
 
 // TestEnhanceSchema_WithMetadata tests metadata propagation through EnhanceSchema.
 func TestEnhanceSchema_WithMetadata(t *testing.T) {
 	mockParseTagFunc := func(tag reflect.StructTag) map[string]string {
-		pedantigoTag := tag.Get("pedantigo")
+		pedantigoTag := tag.Get("validate")
 		if pedantigoTag == "" {
 			return nil
 		}
@@ -2568,15 +2568,15 @@ func TestEnhanceSchema_WithMetadata(t *testing.T) {
 
 // ComplexMetadataStruct tests metadata with special characters and edge cases.
 type ComplexMetadataStruct struct {
-	Description string `json:"description" pedantigo:"title=Item Description,examples=[\"This is a test\",\"Another example here\"]"`
-	Count       int    `json:"count" pedantigo:"title=Item Count,description=Number of items available"`
-	Status      string `json:"status" pedantigo:"oneof=active inactive,title=Status,description=Current status,examples=[\"active\",\"inactive\"]"`
+	Description string `json:"description" validate:"title=Item Description,examples=[\"This is a test\",\"Another example here\"]"`
+	Count       int    `json:"count" validate:"title=Item Count,description=Number of items available"`
+	Status      string `json:"status" validate:"oneof=active inactive,title=Status,description=Current status,examples=[\"active\",\"inactive\"]"`
 }
 
 // TestEnhanceSchema_WithComplexMetadata tests metadata with special characters.
 func TestEnhanceSchema_WithComplexMetadata(t *testing.T) {
 	mockParseTagFunc := func(tag reflect.StructTag) map[string]string {
-		pedantigoTag := tag.Get("pedantigo")
+		pedantigoTag := tag.Get("validate")
 		if pedantigoTag == "" {
 			return nil
 		}
@@ -2647,11 +2647,11 @@ func TestEnhanceSchema_NilProperties(t *testing.T) {
 // TestEnhanceSchema_FieldWithoutSchema tests when field schema doesn't exist.
 func TestEnhanceSchema_FieldWithoutSchema(t *testing.T) {
 	type Missing struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	parseTagFunc := func(tag reflect.StructTag) map[string]string {
-		pedantigoTag := tag.Get("pedantigo")
+		pedantigoTag := tag.Get("validate")
 		if pedantigoTag == "" {
 			return nil
 		}
@@ -2671,11 +2671,11 @@ func TestEnhanceSchema_FieldWithoutSchema(t *testing.T) {
 // TestEnhanceSchema_DuplicateRequired tests that required fields aren't duplicated.
 func TestEnhanceSchema_DuplicateRequired(t *testing.T) {
 	type User struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	parseTagFunc := func(tag reflect.StructTag) map[string]string {
-		pedantigoTag := tag.Get("pedantigo")
+		pedantigoTag := tag.Get("validate")
 		if pedantigoTag == "" {
 			return nil
 		}

--- a/internal/serialize/builder.go
+++ b/internal/serialize/builder.go
@@ -18,7 +18,7 @@ type FieldMetadata struct {
 }
 
 // BuildFieldMetadata creates serialization metadata for each struct field.
-// It uses the provided tagName to parse validation constraints (e.g., "pedantigo", "validate", "binding").
+// It uses the provided tagName to parse validation constraints (default "validate"; e.g., "binding" for Gin).
 func BuildFieldMetadata(typ reflect.Type, tagName string) map[string]FieldMetadata {
 	metadata := make(map[string]FieldMetadata)
 

--- a/internal/serialize/builder.go
+++ b/internal/serialize/builder.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/SmrutAI/pedantigo/internal/tags"
+	"github.com/SmrutAI/pedantigo/v2/internal/tags"
 )
 
 // FieldMetadata holds pre-parsed serialization metadata for a field.

--- a/internal/serialize/serializer.go
+++ b/internal/serialize/serializer.go
@@ -8,7 +8,7 @@ import (
 type Options struct {
 	Context  string
 	OmitZero bool
-	TagName  string // The struct tag name to use (e.g., "pedantigo", "validate", "binding")
+	TagName  string // The struct tag name to use (default "validate"; e.g., "binding" for Gin)
 }
 
 // ShouldIncludeField determines if a field should be included in output.

--- a/internal/serialize/serializer_test.go
+++ b/internal/serialize/serializer_test.go
@@ -12,18 +12,18 @@ import (
 type TestUser struct {
 	ID       int    `json:"id"`
 	Name     string `json:"name"`
-	Password string `json:"password" pedantigo:"exclude:response|log"`
-	Token    string `json:"token" pedantigo:"exclude:log"`
-	Port     int    `json:"port" pedantigo:"omitzero"`
+	Password string `json:"password" validate:"exclude:response|log"`
+	Token    string `json:"token" validate:"exclude:log"`
+	Port     int    `json:"port" validate:"omitzero"`
 	Debug    bool   `json:"debug,omitempty"`
 }
 
 type TestConfig struct {
 	Host     string `json:"host"`
-	Port     int    `json:"port" pedantigo:"omitzero"`
-	APIKey   string `json:"api_key" pedantigo:"exclude:response"`
-	Internal string `json:"internal" pedantigo:"exclude:log|response"`
-	Enabled  *bool  `json:"enabled" pedantigo:"omitzero"`
+	Port     int    `json:"port" validate:"omitzero"`
+	APIKey   string `json:"api_key" validate:"exclude:response"`
+	Internal string `json:"internal" validate:"exclude:log|response"`
+	Enabled  *bool  `json:"enabled" validate:"omitzero"`
 	Count    *int   `json:"count"`
 }
 
@@ -34,7 +34,7 @@ type TestNested struct {
 
 type TestProfile struct {
 	Email    string `json:"email"`
-	Password string `json:"password" pedantigo:"exclude:response"`
+	Password string `json:"password" validate:"exclude:response"`
 }
 
 type TestPrivateFields struct {
@@ -50,7 +50,7 @@ type TestJSONDash struct {
 // ==================== BuildFieldMetadata Tests ====================
 
 func TestBuildFieldMetadata_Basic(t *testing.T) {
-	metadata := BuildFieldMetadata(reflect.TypeOf(TestUser{}), "pedantigo")
+	metadata := BuildFieldMetadata(reflect.TypeOf(TestUser{}), "validate")
 
 	// Should have metadata for all exported fields
 	assert.Contains(t, metadata, "id")
@@ -66,7 +66,7 @@ func TestBuildFieldMetadata_Basic(t *testing.T) {
 }
 
 func TestBuildFieldMetadata_ExcludeContexts(t *testing.T) {
-	metadata := BuildFieldMetadata(reflect.TypeOf(TestUser{}), "pedantigo")
+	metadata := BuildFieldMetadata(reflect.TypeOf(TestUser{}), "validate")
 
 	// Password excluded from "response" and "log" contexts
 	passwordMeta := metadata["password"]
@@ -85,7 +85,7 @@ func TestBuildFieldMetadata_ExcludeContexts(t *testing.T) {
 }
 
 func TestBuildFieldMetadata_MultipleExcludeContexts(t *testing.T) {
-	metadata := BuildFieldMetadata(reflect.TypeOf(TestConfig{}), "pedantigo")
+	metadata := BuildFieldMetadata(reflect.TypeOf(TestConfig{}), "validate")
 
 	// Internal excluded from both "log" and "response"
 	internalMeta := metadata["internal"]
@@ -100,7 +100,7 @@ func TestBuildFieldMetadata_MultipleExcludeContexts(t *testing.T) {
 }
 
 func TestBuildFieldMetadata_OmitZero(t *testing.T) {
-	metadata := BuildFieldMetadata(reflect.TypeOf(TestUser{}), "pedantigo")
+	metadata := BuildFieldMetadata(reflect.TypeOf(TestUser{}), "validate")
 
 	// Port has omitzero tag
 	portMeta := metadata["port"]
@@ -112,7 +112,7 @@ func TestBuildFieldMetadata_OmitZero(t *testing.T) {
 }
 
 func TestBuildFieldMetadata_OmitEmpty(t *testing.T) {
-	metadata := BuildFieldMetadata(reflect.TypeOf(TestUser{}), "pedantigo")
+	metadata := BuildFieldMetadata(reflect.TypeOf(TestUser{}), "validate")
 
 	// Debug has json:",omitempty" tag
 	debugMeta := metadata["debug"]
@@ -124,7 +124,7 @@ func TestBuildFieldMetadata_OmitEmpty(t *testing.T) {
 }
 
 func TestBuildFieldMetadata_JSONDash(t *testing.T) {
-	metadata := BuildFieldMetadata(reflect.TypeOf(TestJSONDash{}), "pedantigo")
+	metadata := BuildFieldMetadata(reflect.TypeOf(TestJSONDash{}), "validate")
 
 	// Should have metadata for "name"
 	assert.Contains(t, metadata, "name")
@@ -135,7 +135,7 @@ func TestBuildFieldMetadata_JSONDash(t *testing.T) {
 }
 
 func TestBuildFieldMetadata_UnexportedFields(t *testing.T) {
-	metadata := BuildFieldMetadata(reflect.TypeOf(TestPrivateFields{}), "pedantigo")
+	metadata := BuildFieldMetadata(reflect.TypeOf(TestPrivateFields{}), "validate")
 
 	// Should have metadata for exported field
 	assert.Contains(t, metadata, "public")
@@ -146,7 +146,7 @@ func TestBuildFieldMetadata_UnexportedFields(t *testing.T) {
 
 func TestBuildFieldMetadata_PointerType(t *testing.T) {
 	// Should handle pointer to struct
-	metadata := BuildFieldMetadata(reflect.TypeOf(&TestUser{}), "pedantigo")
+	metadata := BuildFieldMetadata(reflect.TypeOf(&TestUser{}), "validate")
 
 	// Should still work and extract fields
 	assert.Contains(t, metadata, "id")
@@ -156,13 +156,13 @@ func TestBuildFieldMetadata_PointerType(t *testing.T) {
 
 func TestBuildFieldMetadata_NonStructType(t *testing.T) {
 	// Should return empty map for non-struct types
-	metadata := BuildFieldMetadata(reflect.TypeOf("string"), "pedantigo")
+	metadata := BuildFieldMetadata(reflect.TypeOf("string"), "validate")
 	assert.Empty(t, metadata)
 
-	metadata = BuildFieldMetadata(reflect.TypeOf(42), "pedantigo")
+	metadata = BuildFieldMetadata(reflect.TypeOf(42), "validate")
 	assert.Empty(t, metadata)
 
-	metadata = BuildFieldMetadata(reflect.TypeOf([]int{1, 2, 3}), "pedantigo")
+	metadata = BuildFieldMetadata(reflect.TypeOf([]int{1, 2, 3}), "validate")
 	assert.Empty(t, metadata)
 }
 
@@ -524,14 +524,14 @@ func TestHasWhitelistContext_EmptyContext(t *testing.T) {
 // ==================== BuildFieldMetadata Include Tests ====================
 
 type TestIncludeUser struct {
-	ID       int    `json:"id" pedantigo:"include:summary|public"`
-	Email    string `json:"email" pedantigo:"include:summary|contact"`
-	Phone    string `json:"phone" pedantigo:"include:contact"`
+	ID       int    `json:"id" validate:"include:summary|public"`
+	Email    string `json:"email" validate:"include:summary|contact"`
+	Phone    string `json:"phone" validate:"include:contact"`
 	Password string `json:"password"` // No include tags
 }
 
 func TestBuildFieldMetadata_IncludeContexts(t *testing.T) {
-	metadata := BuildFieldMetadata(reflect.TypeOf(TestIncludeUser{}), "pedantigo")
+	metadata := BuildFieldMetadata(reflect.TypeOf(TestIncludeUser{}), "validate")
 
 	// ID has include:summary and include:public
 	idMeta := metadata["id"]
@@ -564,13 +564,13 @@ func TestToFilteredMap_IncludeWhitelist(t *testing.T) {
 		Password: "secret",
 	}
 
-	metadata := BuildFieldMetadata(reflect.TypeOf(user), "pedantigo")
+	metadata := BuildFieldMetadata(reflect.TypeOf(user), "validate")
 
 	// Test "summary" context - should only include ID and Email
 	optsSummary := Options{
 		Context:  "summary",
 		OmitZero: false,
-		TagName:  "pedantigo",
+		TagName:  "validate",
 	}
 	resultSummary := ToFilteredMap(reflect.ValueOf(user), metadata, optsSummary)
 
@@ -583,7 +583,7 @@ func TestToFilteredMap_IncludeWhitelist(t *testing.T) {
 	optsContact := Options{
 		Context:  "contact",
 		OmitZero: false,
-		TagName:  "pedantigo",
+		TagName:  "validate",
 	}
 	resultContact := ToFilteredMap(reflect.ValueOf(user), metadata, optsContact)
 
@@ -596,7 +596,7 @@ func TestToFilteredMap_IncludeWhitelist(t *testing.T) {
 	optsNone := Options{
 		Context:  "",
 		OmitZero: false,
-		TagName:  "pedantigo",
+		TagName:  "validate",
 	}
 	resultNone := ToFilteredMap(reflect.ValueOf(user), metadata, optsNone)
 
@@ -621,11 +621,11 @@ func TestToFilteredMap_Basic(t *testing.T) {
 		Age:   25,
 	}
 
-	metadata := BuildFieldMetadata(reflect.TypeOf(obj), "pedantigo")
+	metadata := BuildFieldMetadata(reflect.TypeOf(obj), "validate")
 	opts := Options{
 		Context:  "",
 		OmitZero: false,
-		TagName:  "pedantigo",
+		TagName:  "validate",
 	}
 
 	result := ToFilteredMap(reflect.ValueOf(obj), metadata, opts)
@@ -645,11 +645,11 @@ func TestToFilteredMap_ExcludesPassword(t *testing.T) {
 		Debug:    true,
 	}
 
-	metadata := BuildFieldMetadata(reflect.TypeOf(user), "pedantigo")
+	metadata := BuildFieldMetadata(reflect.TypeOf(user), "validate")
 	opts := Options{
 		Context:  "response",
 		OmitZero: false,
-		TagName:  "pedantigo",
+		TagName:  "validate",
 	}
 
 	result := ToFilteredMap(reflect.ValueOf(user), metadata, opts)
@@ -675,11 +675,11 @@ func TestToFilteredMap_OmitsZeroPort(t *testing.T) {
 		Debug:    false,
 	}
 
-	metadata := BuildFieldMetadata(reflect.TypeOf(user), "pedantigo")
+	metadata := BuildFieldMetadata(reflect.TypeOf(user), "validate")
 	opts := Options{
 		Context:  "",
 		OmitZero: true, // OmitZero enabled
-		TagName:  "pedantigo",
+		TagName:  "validate",
 	}
 
 	result := ToFilteredMap(reflect.ValueOf(user), metadata, opts)
@@ -705,11 +705,11 @@ func TestToFilteredMap_NestedStruct(t *testing.T) {
 		},
 	}
 
-	metadata := BuildFieldMetadata(reflect.TypeOf(nested), "pedantigo")
+	metadata := BuildFieldMetadata(reflect.TypeOf(nested), "validate")
 	opts := Options{
 		Context:  "response",
 		OmitZero: false,
-		TagName:  "pedantigo",
+		TagName:  "validate",
 	}
 
 	result := ToFilteredMap(reflect.ValueOf(nested), metadata, opts)
@@ -745,11 +745,11 @@ func TestToFilteredMap_NestedStructPointer(t *testing.T) {
 		Profile: profile,
 	}
 
-	metadata := BuildFieldMetadata(reflect.TypeOf(nested), "pedantigo")
+	metadata := BuildFieldMetadata(reflect.TypeOf(nested), "validate")
 	opts := Options{
 		Context:  "response",
 		OmitZero: false,
-		TagName:  "pedantigo",
+		TagName:  "validate",
 	}
 
 	result := ToFilteredMap(reflect.ValueOf(nested), metadata, opts)
@@ -769,11 +769,11 @@ func TestToFilteredMap_NestedStructPointer(t *testing.T) {
 func TestToFilteredMap_NilPointer(t *testing.T) {
 	var user *TestUser
 
-	metadata := BuildFieldMetadata(reflect.TypeOf(TestUser{}), "pedantigo")
+	metadata := BuildFieldMetadata(reflect.TypeOf(TestUser{}), "validate")
 	opts := Options{
 		Context:  "",
 		OmitZero: false,
-		TagName:  "pedantigo",
+		TagName:  "validate",
 	}
 
 	result := ToFilteredMap(reflect.ValueOf(user), metadata, opts)
@@ -792,11 +792,11 @@ func TestToFilteredMap_PointerToStruct(t *testing.T) {
 		Debug:    true,
 	}
 
-	metadata := BuildFieldMetadata(reflect.TypeOf(*user), "pedantigo")
+	metadata := BuildFieldMetadata(reflect.TypeOf(*user), "validate")
 	opts := Options{
 		Context:  "",
 		OmitZero: false,
-		TagName:  "pedantigo",
+		TagName:  "validate",
 	}
 
 	result := ToFilteredMap(reflect.ValueOf(user), metadata, opts)
@@ -815,13 +815,13 @@ func TestToFilteredMap_MultipleContexts(t *testing.T) {
 		Count:    nil,
 	}
 
-	metadata := BuildFieldMetadata(reflect.TypeOf(config), "pedantigo")
+	metadata := BuildFieldMetadata(reflect.TypeOf(config), "validate")
 
 	// Test "response" context
 	optsResponse := Options{
 		Context:  "response",
 		OmitZero: false,
-		TagName:  "pedantigo",
+		TagName:  "validate",
 	}
 	resultResponse := ToFilteredMap(reflect.ValueOf(config), metadata, optsResponse)
 
@@ -833,7 +833,7 @@ func TestToFilteredMap_MultipleContexts(t *testing.T) {
 	optsLog := Options{
 		Context:  "log",
 		OmitZero: false,
-		TagName:  "pedantigo",
+		TagName:  "validate",
 	}
 	resultLog := ToFilteredMap(reflect.ValueOf(config), metadata, optsLog)
 
@@ -845,7 +845,7 @@ func TestToFilteredMap_MultipleContexts(t *testing.T) {
 	optsNone := Options{
 		Context:  "",
 		OmitZero: false,
-		TagName:  "pedantigo",
+		TagName:  "validate",
 	}
 	resultNone := ToFilteredMap(reflect.ValueOf(config), metadata, optsNone)
 
@@ -867,11 +867,11 @@ func TestToFilteredMap_PointerFields(t *testing.T) {
 		Count:    &count,
 	}
 
-	metadata := BuildFieldMetadata(reflect.TypeOf(config), "pedantigo")
+	metadata := BuildFieldMetadata(reflect.TypeOf(config), "validate")
 	opts := Options{
 		Context:  "",
 		OmitZero: true,
-		TagName:  "pedantigo",
+		TagName:  "validate",
 	}
 
 	result := ToFilteredMap(reflect.ValueOf(config), metadata, opts)
@@ -896,11 +896,11 @@ func TestToFilteredMap_NilPointerFieldWithOmitZero(t *testing.T) {
 		Count:    nil, // Nil pointer without omitzero tag
 	}
 
-	metadata := BuildFieldMetadata(reflect.TypeOf(config), "pedantigo")
+	metadata := BuildFieldMetadata(reflect.TypeOf(config), "validate")
 	opts := Options{
 		Context:  "",
 		OmitZero: true,
-		TagName:  "pedantigo",
+		TagName:  "validate",
 	}
 
 	result := ToFilteredMap(reflect.ValueOf(config), metadata, opts)
@@ -916,11 +916,11 @@ func TestToFilteredMap_EmptyStruct(t *testing.T) {
 	type EmptyStruct struct{}
 
 	obj := EmptyStruct{}
-	metadata := BuildFieldMetadata(reflect.TypeOf(obj), "pedantigo")
+	metadata := BuildFieldMetadata(reflect.TypeOf(obj), "validate")
 	opts := Options{
 		Context:  "",
 		OmitZero: false,
-		TagName:  "pedantigo",
+		TagName:  "validate",
 	}
 
 	result := ToFilteredMap(reflect.ValueOf(obj), metadata, opts)

--- a/internal/tags/parsed_tag.go
+++ b/internal/tags/parsed_tag.go
@@ -4,10 +4,10 @@ package tags
 // It separates constraints into collection-level, key-level, and element-level.
 //
 // Example tags:
-//   - pedantigo:"min=3"                    -> CollectionConstraints only
-//   - pedantigo:"dive,email"               -> ElementConstraints only (dive present)
-//   - pedantigo:"min=3,dive,min=5"         -> Both collection and element
-//   - pedantigo:"dive,keys,min=2,endkeys,email" -> Map: key + value constraints
+//   - validate:"min=3"                    -> CollectionConstraints only
+//   - validate:"dive,email"               -> ElementConstraints only (dive present)
+//   - validate:"min=3,dive,min=5"         -> Both collection and element
+//   - validate:"dive,keys,min=2,endkeys,email" -> Map: key + value constraints
 type ParsedTag struct {
 	// CollectionConstraints are constraints that apply to the collection itself
 	// (before any dive tag). For slices: min/max = element count.

--- a/internal/tags/parser.go
+++ b/internal/tags/parser.go
@@ -8,7 +8,7 @@ import (
 )
 
 // DefaultTagName is the default struct tag name used by Pedantigo.
-const DefaultTagName = "pedantigo"
+const DefaultTagName = "validate"
 
 // ExtraFieldsTag is the tag value for fields that store extra/unknown JSON fields.
 const ExtraFieldsTag = "extra_fields"
@@ -60,8 +60,8 @@ func splitTagConstraints(tag string) []string {
 	return parts
 }
 
-// ParseTag parses a struct tag using the default "pedantigo" tag name.
-// Example: pedantigo:"required,email,min=18" -> map{"required": "", "email": "", "min": "18"}
+// ParseTag parses a struct tag using the default "validate" tag name.
+// Example: validate:"required,email,min=18" -> map{"required": "", "email": "", "min": "18"}
 // Special handling for oneof which has space-separated values: oneof=admin user guest.
 func ParseTag(tag reflect.StructTag) map[string]string {
 	return ParseTagWithName(tag, DefaultTagName)
@@ -130,15 +130,15 @@ func ParseTagWithName(tag reflect.StructTag, tagName string) map[string]string {
 	return constraints
 }
 
-// ParseTagWithDive parses a struct tag using the default "pedantigo" tag name
+// ParseTagWithDive parses a struct tag using the default "validate" tag name
 // and returns a structured ParsedTag that separates collection-level, key-level,
 // and element-level constraints.
 //
 // Syntax:
-//   - pedantigo:"min=3"                    -> CollectionConstraints only
-//   - pedantigo:"dive,email"               -> ElementConstraints only (dive present)
-//   - pedantigo:"min=3,dive,min=5"         -> Both collection and element
-//   - pedantigo:"dive,keys,min=2,endkeys,email" -> Map: key + value constraints
+//   - validate:"min=3"                    -> CollectionConstraints only
+//   - validate:"dive,email"               -> ElementConstraints only (dive present)
+//   - validate:"min=3,dive,min=5"         -> Both collection and element
+//   - validate:"dive,keys,min=2,endkeys,email" -> Map: key + value constraints
 func ParseTagWithDive(tag reflect.StructTag) *ParsedTag {
 	return ParseTagWithDiveAndName(tag, DefaultTagName)
 }

--- a/internal/tags/parser_test.go
+++ b/internal/tags/parser_test.go
@@ -20,93 +20,93 @@ func TestParseTag_ValidConstraints(t *testing.T) {
 	}{
 		{
 			name:       "single_simple_constraint_required",
-			tag:        reflect.StructTag(`pedantigo:"required"`),
+			tag:        reflect.StructTag(`validate:"required"`),
 			wantKeys:   map[string]string{"required": ""},
 			wantLength: 1,
 		},
 		{
 			name:       "single_simple_constraint_email",
-			tag:        reflect.StructTag(`pedantigo:"email"`),
+			tag:        reflect.StructTag(`validate:"email"`),
 			wantKeys:   map[string]string{"email": ""},
 			wantLength: 1,
 		},
 		{
 			name:       "multiple_simple_constraints",
-			tag:        reflect.StructTag(`pedantigo:"required,email"`),
+			tag:        reflect.StructTag(`validate:"required,email"`),
 			wantKeys:   map[string]string{"required": "", "email": ""},
 			wantLength: 2,
 		},
 		{
 			name:       "single_constraint_with_value_min",
-			tag:        reflect.StructTag(`pedantigo:"min=18"`),
+			tag:        reflect.StructTag(`validate:"min=18"`),
 			wantKeys:   map[string]string{"min": "18"},
 			wantLength: 1,
 		},
 		{
 			name:       "single_constraint_with_value_default",
-			tag:        reflect.StructTag(`pedantigo:"default=active"`),
+			tag:        reflect.StructTag(`validate:"default=active"`),
 			wantKeys:   map[string]string{"default": "active"},
 			wantLength: 1,
 		},
 		{
 			name:       "multiple_constraints_with_values",
-			tag:        reflect.StructTag(`pedantigo:"min=18,max=120"`),
+			tag:        reflect.StructTag(`validate:"min=18,max=120"`),
 			wantKeys:   map[string]string{"min": "18", "max": "120"},
 			wantLength: 2,
 		},
 		{
 			name:       "mixed_simple_and_valued_constraints",
-			tag:        reflect.StructTag(`pedantigo:"required,email,min=18"`),
+			tag:        reflect.StructTag(`validate:"required,email,min=18"`),
 			wantKeys:   map[string]string{"required": "", "email": "", "min": "18"},
 			wantLength: 3,
 		},
 		{
 			name:       "constraint_value_with_alphanumeric",
-			tag:        reflect.StructTag(`pedantigo:"pattern=[a-z]+"`),
+			tag:        reflect.StructTag(`validate:"pattern=[a-z]+"`),
 			wantKeys:   map[string]string{"pattern": "[a-z]+"},
 			wantLength: 1,
 		},
 		{
 			name:       "constraint_with_whitespace_around_equals",
-			tag:        reflect.StructTag(`pedantigo:"min = 5 , max = 10"`),
+			tag:        reflect.StructTag(`validate:"min = 5 , max = 10"`),
 			wantKeys:   map[string]string{"min": "5", "max": "10"},
 			wantLength: 2,
 		},
 		{
 			name:       "constraints_with_trailing_comma",
-			tag:        reflect.StructTag(`pedantigo:"required,email,"`),
+			tag:        reflect.StructTag(`validate:"required,email,"`),
 			wantKeys:   map[string]string{"required": "", "email": ""},
 			wantLength: 2,
 		},
 		{
 			name:       "complex_combination_all_types",
-			tag:        reflect.StructTag(`pedantigo:"required,email,min=3,max=100,default=user@example.com"`),
+			tag:        reflect.StructTag(`validate:"required,email,min=3,max=100,default=user@example.com"`),
 			wantKeys:   map[string]string{"required": "", "email": "", "min": "3", "max": "100", "default": "user@example.com"},
 			wantLength: 5,
 		},
 		// Colon syntax tests (key:value)
 		{
 			name:       "colon_syntax_single",
-			tag:        reflect.StructTag(`pedantigo:"exclude:response"`),
+			tag:        reflect.StructTag(`validate:"exclude:response"`),
 			wantKeys:   map[string]string{"exclude": "response"},
 			wantLength: 1,
 		},
 		{
 			name:       "colon_syntax_with_pipe_value",
-			tag:        reflect.StructTag(`pedantigo:"exclude:response|log"`),
+			tag:        reflect.StructTag(`validate:"exclude:response|log"`),
 			wantKeys:   map[string]string{"exclude": "response|log"},
 			wantLength: 1,
 		},
 		{
 			name:       "colon_syntax_mixed_with_equals",
-			tag:        reflect.StructTag(`pedantigo:"min=5,exclude:internal,max=100"`),
+			tag:        reflect.StructTag(`validate:"min=5,exclude:internal,max=100"`),
 			wantKeys:   map[string]string{"min": "5", "exclude": "internal", "max": "100"},
 			wantLength: 3,
 		},
 		// JSON array examples tests
 		{
 			name: "examples_json_array_of_strings",
-			tag:  reflect.StructTag(`pedantigo:"required,examples=[\"a\",\"b\",\"c\"]"`),
+			tag:  reflect.StructTag(`validate:"required,examples=[\"a\",\"b\",\"c\"]"`),
 			wantKeys: map[string]string{
 				"required": "",
 				"examples": `["a","b","c"]`,
@@ -115,7 +115,7 @@ func TestParseTag_ValidConstraints(t *testing.T) {
 		},
 		{
 			name: "examples_json_array_of_ints",
-			tag:  reflect.StructTag(`pedantigo:"required,examples=[0,1,2,3]"`),
+			tag:  reflect.StructTag(`validate:"required,examples=[0,1,2,3]"`),
 			wantKeys: map[string]string{
 				"required": "",
 				"examples": "[0,1,2,3]",
@@ -124,7 +124,7 @@ func TestParseTag_ValidConstraints(t *testing.T) {
 		},
 		{
 			name: "examples_json_array_of_arrays",
-			tag:  reflect.StructTag(`pedantigo:"required,examples=[[0,2],[1,3,5],[]]"`),
+			tag:  reflect.StructTag(`validate:"required,examples=[[0,2],[1,3,5],[]]"`),
 			wantKeys: map[string]string{
 				"required": "",
 				"examples": "[[0,2],[1,3,5],[]]",
@@ -133,7 +133,7 @@ func TestParseTag_ValidConstraints(t *testing.T) {
 		},
 		{
 			name: "examples_json_with_constraints_before_and_after",
-			tag:  reflect.StructTag(`pedantigo:"gte=0,examples=[[0,2],[1,3,5]],description=test desc"`),
+			tag:  reflect.StructTag(`validate:"gte=0,examples=[[0,2],[1,3,5]],description=test desc"`),
 			wantKeys: map[string]string{
 				"gte":         "0",
 				"examples":    "[[0,2],[1,3,5]]",
@@ -144,19 +144,19 @@ func TestParseTag_ValidConstraints(t *testing.T) {
 		// OR operator tests
 		{
 			name:       "or_operator_simple",
-			tag:        reflect.StructTag(`pedantigo:"hexcolor|rgb"`),
+			tag:        reflect.StructTag(`validate:"hexcolor|rgb"`),
 			wantKeys:   map[string]string{"__or__hexcolor|rgb": ""},
 			wantLength: 1,
 		},
 		{
 			name:       "or_operator_multiple_options",
-			tag:        reflect.StructTag(`pedantigo:"hexcolor|rgb|rgba|hsl|hsla"`),
+			tag:        reflect.StructTag(`validate:"hexcolor|rgb|rgba|hsl|hsla"`),
 			wantKeys:   map[string]string{"__or__hexcolor|rgb|rgba|hsl|hsla": ""},
 			wantLength: 1,
 		},
 		{
 			name:       "or_operator_with_other_constraints",
-			tag:        reflect.StructTag(`pedantigo:"required,hexcolor|rgb,min=3"`),
+			tag:        reflect.StructTag(`validate:"required,hexcolor|rgb,min=3"`),
 			wantKeys:   map[string]string{"required": "", "__or__hexcolor|rgb": "", "min": "3"},
 			wantLength: 3,
 		},
@@ -192,21 +192,21 @@ func TestParseTagWithDive_CollectionConstraintsOnly(t *testing.T) {
 	}{
 		{
 			name:        "single_min_constraint",
-			tag:         reflect.StructTag(`pedantigo:"min=3"`),
+			tag:         reflect.StructTag(`validate:"min=3"`),
 			constraints: map[string]string{"min": "3"},
 		},
 		{
 			name:        "multiple_collection_constraints",
-			tag:         reflect.StructTag(`pedantigo:"min=3,max=10"`),
+			tag:         reflect.StructTag(`validate:"min=3,max=10"`),
 			constraints: map[string]string{"min": "3", "max": "10"},
 		},
 		{
 			name:    "empty_tag",
-			tag:     reflect.StructTag(`pedantigo:""`),
+			tag:     reflect.StructTag(`validate:""`),
 			wantNil: true,
 		},
 		{
-			name:    "no_pedantigo_tag",
+			name:    "no_validate_tag",
 			tag:     reflect.StructTag(`json:"field"`),
 			wantNil: true,
 		},
@@ -241,28 +241,28 @@ func TestParseTagWithDive_ElementConstraints(t *testing.T) {
 	}{
 		{
 			name:                  "dive_only_with_element_constraint",
-			tag:                   reflect.StructTag(`pedantigo:"dive,email"`),
+			tag:                   reflect.StructTag(`validate:"dive,email"`),
 			wantDivePresent:       true,
 			collectionConstraints: map[string]string{},
 			elementConstraints:    map[string]string{"email": ""},
 		},
 		{
 			name:                  "dive_with_multiple_element_constraints",
-			tag:                   reflect.StructTag(`pedantigo:"dive,email,min=5"`),
+			tag:                   reflect.StructTag(`validate:"dive,email,min=5"`),
 			wantDivePresent:       true,
 			collectionConstraints: map[string]string{},
 			elementConstraints:    map[string]string{"email": "", "min": "5"},
 		},
 		{
 			name:                  "collection_and_element_constraints",
-			tag:                   reflect.StructTag(`pedantigo:"min=3,dive,min=5"`),
+			tag:                   reflect.StructTag(`validate:"min=3,dive,min=5"`),
 			wantDivePresent:       true,
 			collectionConstraints: map[string]string{"min": "3"},
 			elementConstraints:    map[string]string{"min": "5"},
 		},
 		{
 			name:                  "collection_max_and_element_email",
-			tag:                   reflect.StructTag(`pedantigo:"max=100,dive,email,required"`),
+			tag:                   reflect.StructTag(`validate:"max=100,dive,email,required"`),
 			wantDivePresent:       true,
 			collectionConstraints: map[string]string{"max": "100"},
 			elementConstraints:    map[string]string{"email": "", "required": ""},
@@ -292,19 +292,19 @@ func TestParseTagWithDive_MapKeyConstraints(t *testing.T) {
 	}{
 		{
 			name:               "keys_with_min_constraint",
-			tag:                reflect.StructTag(`pedantigo:"dive,keys,min=2,endkeys,email"`),
+			tag:                reflect.StructTag(`validate:"dive,keys,min=2,endkeys,email"`),
 			keyConstraints:     map[string]string{"min": "2"},
 			elementConstraints: map[string]string{"email": ""},
 		},
 		{
 			name:               "keys_with_multiple_constraints",
-			tag:                reflect.StructTag(`pedantigo:"dive,keys,min=2,max=10,endkeys,required"`),
+			tag:                reflect.StructTag(`validate:"dive,keys,min=2,max=10,endkeys,required"`),
 			keyConstraints:     map[string]string{"min": "2", "max": "10"},
 			elementConstraints: map[string]string{"required": ""},
 		},
 		{
 			name:               "keys_with_pattern",
-			tag:                reflect.StructTag(`pedantigo:"dive,keys,pattern=^[a-z]+$,endkeys,min=1"`),
+			tag:                reflect.StructTag(`validate:"dive,keys,pattern=^[a-z]+$,endkeys,min=1"`),
 			keyConstraints:     map[string]string{"pattern": "^[a-z]+$"},
 			elementConstraints: map[string]string{"min": "1"},
 		},
@@ -331,17 +331,17 @@ func TestParseTagWithDive_Panics(t *testing.T) {
 	}{
 		{
 			name:          "keys_without_dive",
-			tag:           reflect.StructTag(`pedantigo:"keys,min=2,endkeys"`),
+			tag:           reflect.StructTag(`validate:"keys,min=2,endkeys"`),
 			expectedPanic: "'keys' can only appear after 'dive'",
 		},
 		{
 			name:          "endkeys_without_keys",
-			tag:           reflect.StructTag(`pedantigo:"dive,endkeys"`),
+			tag:           reflect.StructTag(`validate:"dive,endkeys"`),
 			expectedPanic: "'endkeys' without preceding 'keys'",
 		},
 		{
 			name:          "keys_without_endkeys",
-			tag:           reflect.StructTag(`pedantigo:"dive,keys,min=2"`),
+			tag:           reflect.StructTag(`validate:"dive,keys,min=2"`),
 			expectedPanic: "'keys' without closing 'endkeys'",
 		},
 	}
@@ -357,7 +357,7 @@ func TestParseTagWithDive_Panics(t *testing.T) {
 
 // TestParseTagWithDive_WhitespaceHandling tests that whitespace is properly trimmed.
 func TestParseTagWithDive_WhitespaceHandling(t *testing.T) {
-	parsed := ParseTagWithDive(reflect.StructTag(`pedantigo:"  min = 3 , dive , email  "`))
+	parsed := ParseTagWithDive(reflect.StructTag(`validate:"  min = 3 , dive , email  "`))
 
 	require.NotNil(t, parsed)
 	assert.True(t, parsed.DivePresent)
@@ -400,9 +400,9 @@ func TestParseTagWithName_CustomTag(t *testing.T) {
 			wantLength: 2,
 		},
 		{
-			name:       "pedantigo_tag_still_works",
-			tag:        reflect.StructTag(`pedantigo:"required,min=3"`),
-			tagName:    "pedantigo",
+			name:       "non_default_tag_name_still_works",
+			tag:        reflect.StructTag(`legacy_tag:"required,min=3"`),
+			tagName:    "legacy_tag",
 			wantKeys:   map[string]string{"required": "", "min": "3"},
 			wantLength: 2,
 		},
@@ -432,8 +432,8 @@ func TestParseTagWithName_WrongTag_ReturnsNil(t *testing.T) {
 		tagName string
 	}{
 		{
-			name:    "looking_for_validate_but_has_pedantigo",
-			tag:     reflect.StructTag(`pedantigo:"required"`),
+			name:    "looking_for_validate_but_has_legacy_tag",
+			tag:     reflect.StructTag(`legacy_tag:"required"`),
 			tagName: "validate",
 		},
 		{
@@ -517,8 +517,8 @@ func TestParseTagWithDiveAndName_WrongTag_ReturnsNil(t *testing.T) {
 		tagName string
 	}{
 		{
-			name:    "looking_for_validate_but_has_pedantigo",
-			tag:     reflect.StructTag(`pedantigo:"dive,email"`),
+			name:    "looking_for_validate_but_has_legacy_tag",
+			tag:     reflect.StructTag(`legacy_tag:"dive,email"`),
 			tagName: "validate",
 		},
 		{
@@ -536,24 +536,24 @@ func TestParseTagWithDiveAndName_WrongTag_ReturnsNil(t *testing.T) {
 	}
 }
 
-// TestParseTag_DelegatestoParseTagWithName verifies ParseTag uses default "pedantigo" tag.
+// TestParseTag_DelegatestoParseTagWithName verifies ParseTag uses DefaultTagName.
 func TestParseTag_DelegatesToParseTagWithName(t *testing.T) {
-	tag := reflect.StructTag(`pedantigo:"required,email"`)
+	tag := reflect.StructTag(`validate:"required,email"`)
 
 	// Both should return identical results
 	fromParseTag := ParseTag(tag)
-	fromParseTagWithName := ParseTagWithName(tag, "pedantigo")
+	fromParseTagWithName := ParseTagWithName(tag, DefaultTagName)
 
 	assert.Equal(t, fromParseTag, fromParseTagWithName)
 }
 
 // TestParseTagWithDive_DelegatesToParseTagWithDiveAndName verifies delegation.
 func TestParseTagWithDive_DelegatesToParseTagWithDiveAndName(t *testing.T) {
-	tag := reflect.StructTag(`pedantigo:"min=3,dive,email"`)
+	tag := reflect.StructTag(`validate:"min=3,dive,email"`)
 
 	// Both should return identical results
 	fromParseTagWithDive := ParseTagWithDive(tag)
-	fromParseTagWithDiveAndName := ParseTagWithDiveAndName(tag, "pedantigo")
+	fromParseTagWithDiveAndName := ParseTagWithDiveAndName(tag, DefaultTagName)
 
 	assert.Equal(t, fromParseTagWithDive.DivePresent, fromParseTagWithDiveAndName.DivePresent)
 	assert.Equal(t, fromParseTagWithDive.CollectionConstraints, fromParseTagWithDiveAndName.CollectionConstraints)
@@ -587,49 +587,49 @@ func TestParseTag_AliasExpansion(t *testing.T) {
 	}{
 		{
 			name:       "alias_expands_to_or_expression",
-			tag:        reflect.StructTag(`pedantigo:"iscolor"`),
+			tag:        reflect.StructTag(`validate:"iscolor"`),
 			wantKeys:   map[string]string{"__or__hexcolor|rgb|rgba|hsl|hsla": ""},
 			wantLength: 1,
 		},
 		{
 			name:       "alias_expands_to_simple_constraint",
-			tag:        reflect.StructTag(`pedantigo:"isuri"`),
+			tag:        reflect.StructTag(`validate:"isuri"`),
 			wantKeys:   map[string]string{"uri": ""},
 			wantLength: 1,
 		},
 		{
 			name:       "alias_with_other_constraints",
-			tag:        reflect.StructTag(`pedantigo:"required,iscolor,min=3"`),
+			tag:        reflect.StructTag(`validate:"required,iscolor,min=3"`),
 			wantKeys:   map[string]string{"required": "", "__or__hexcolor|rgb|rgba|hsl|hsla": "", "min": "3"},
 			wantLength: 3,
 		},
 		{
 			name:       "unknown_alias_not_expanded",
-			tag:        reflect.StructTag(`pedantigo:"unknown_alias"`),
+			tag:        reflect.StructTag(`validate:"unknown_alias"`),
 			wantKeys:   map[string]string{"unknown_alias": ""},
 			wantLength: 1,
 		},
 		{
 			name:       "postcode_alias",
-			tag:        reflect.StructTag(`pedantigo:"postcode_iso3166_alpha2"`),
+			tag:        reflect.StructTag(`validate:"postcode_iso3166_alpha2"`),
 			wantKeys:   map[string]string{"postcode": ""},
 			wantLength: 1,
 		},
 		{
 			name:       "alias_expands_to_key_value",
-			tag:        reflect.StructTag(`pedantigo:"shortstring"`),
+			tag:        reflect.StructTag(`validate:"shortstring"`),
 			wantKeys:   map[string]string{"min": "1", "max": "50"},
 			wantLength: 2,
 		},
 		{
 			name:       "alias_with_empty_part_skipped",
-			tag:        reflect.StructTag(`pedantigo:"complexalias"`),
+			tag:        reflect.StructTag(`validate:"complexalias"`),
 			wantKeys:   map[string]string{"required": "", "min": "5", "email": ""},
 			wantLength: 3,
 		},
 		{
 			name:       "alias_with_mixed_types",
-			tag:        reflect.StructTag(`pedantigo:"mixedalias"`),
+			tag:        reflect.StructTag(`validate:"mixedalias"`),
 			wantKeys:   map[string]string{"min": "10", "__or__hexcolor|rgb": "", "max": "100"},
 			wantLength: 3,
 		},
@@ -676,49 +676,49 @@ func TestParseTagWithDive_OrOperatorAndAlias(t *testing.T) {
 	}{
 		{
 			name:                  "or_in_collection",
-			tag:                   reflect.StructTag(`pedantigo:"hexcolor|rgb,dive,email"`),
+			tag:                   reflect.StructTag(`validate:"hexcolor|rgb,dive,email"`),
 			collectionConstraints: map[string]string{"__or__hexcolor|rgb": ""},
 			elementConstraints:    map[string]string{"email": ""},
 		},
 		{
 			name:                  "or_in_element",
-			tag:                   reflect.StructTag(`pedantigo:"min=3,dive,hexcolor|rgb"`),
+			tag:                   reflect.StructTag(`validate:"min=3,dive,hexcolor|rgb"`),
 			collectionConstraints: map[string]string{"min": "3"},
 			elementConstraints:    map[string]string{"__or__hexcolor|rgb": ""},
 		},
 		{
 			name:                  "alias_in_element",
-			tag:                   reflect.StructTag(`pedantigo:"dive,iscolor"`),
+			tag:                   reflect.StructTag(`validate:"dive,iscolor"`),
 			collectionConstraints: map[string]string{},
 			elementConstraints:    map[string]string{"__or__hexcolor|rgb|rgba|hsl|hsla": ""},
 		},
 		{
 			name:                  "colon_syntax_in_collection",
-			tag:                   reflect.StructTag(`pedantigo:"exclude:response,dive,email"`),
+			tag:                   reflect.StructTag(`validate:"exclude:response,dive,email"`),
 			collectionConstraints: map[string]string{"exclude": "response"},
 			elementConstraints:    map[string]string{"email": ""},
 		},
 		{
 			name:                  "colon_syntax_in_element",
-			tag:                   reflect.StructTag(`pedantigo:"dive,exclude:internal"`),
+			tag:                   reflect.StructTag(`validate:"dive,exclude:internal"`),
 			collectionConstraints: map[string]string{},
 			elementConstraints:    map[string]string{"exclude": "internal"},
 		},
 		{
 			name:                  "alias_with_key_value_in_element",
-			tag:                   reflect.StructTag(`pedantigo:"dive,shortstring"`),
+			tag:                   reflect.StructTag(`validate:"dive,shortstring"`),
 			collectionConstraints: map[string]string{},
 			elementConstraints:    map[string]string{"min": "1", "max": "50"},
 		},
 		{
 			name:                  "alias_with_empty_part_in_element",
-			tag:                   reflect.StructTag(`pedantigo:"dive,complexalias"`),
+			tag:                   reflect.StructTag(`validate:"dive,complexalias"`),
 			collectionConstraints: map[string]string{},
 			elementConstraints:    map[string]string{"required": "", "min": "5", "email": ""},
 		},
 		{
 			name:                  "alias_with_mixed_types_in_element",
-			tag:                   reflect.StructTag(`pedantigo:"dive,mixedalias"`),
+			tag:                   reflect.StructTag(`validate:"dive,mixedalias"`),
 			collectionConstraints: map[string]string{},
 			elementConstraints:    map[string]string{"min": "10", "__or__hexcolor|rgb": "", "max": "100"},
 		},
@@ -758,14 +758,14 @@ func TestParseTag_InvalidInputs(t *testing.T) {
 			wantEmpty: false,
 		},
 		{
-			name:      "pedantigo_with_empty_value",
-			tag:       reflect.StructTag(`pedantigo:""`),
+			name:      "validate_with_empty_value",
+			tag:       reflect.StructTag(`validate:""`),
 			wantNil:   true,
 			wantEmpty: false,
 		},
 		{
 			name:      "only_whitespace_in_tag",
-			tag:       reflect.StructTag(`pedantigo:"   "`),
+			tag:       reflect.StructTag(`validate:"   "`),
 			wantNil:   false,
 			wantEmpty: true,
 			wantKeys:  map[string]string{},

--- a/marshal_options.go
+++ b/marshal_options.go
@@ -3,7 +3,7 @@ package pedantigo
 // MarshalOptions configures Marshal behavior.
 type MarshalOptions struct {
 	// Context specifies which exclusion context to apply.
-	// Fields tagged with pedantigo:"exclude:context" will be omitted.
+	// Fields tagged with validate:"exclude:context" will be omitted.
 	// Empty string means no context-based exclusion.
 	Context string
 

--- a/minmax_dive_test.go
+++ b/minmax_dive_test.go
@@ -11,11 +11,11 @@ import (
 // on numeric fields inside nested structs accessed via dive.
 func TestMinMaxNumericInNestedDiveStruct(t *testing.T) {
 	type Fact struct {
-		Content    string  `json:"content" pedantigo:"required"`
-		Importance float32 `json:"importance" pedantigo:"required,min=0,max=1"`
+		Content    string  `json:"content" validate:"required"`
+		Importance float32 `json:"importance" validate:"required,min=0,max=1"`
 	}
 	type Schema struct {
-		Facts []Fact `json:"facts" pedantigo:"required,dive"`
+		Facts []Fact `json:"facts" validate:"required,dive"`
 	}
 
 	validator := New[Schema]()
@@ -106,11 +106,11 @@ func TestMinMaxNumericInNestedDiveStruct(t *testing.T) {
 // TestMinMaxIntInNestedDiveStruct tests min/max on int fields in nested structs.
 func TestMinMaxIntInNestedDiveStruct(t *testing.T) {
 	type Item struct {
-		Name     string `json:"name" pedantigo:"required"`
-		Quantity int    `json:"quantity" pedantigo:"required,min=0,max=100"`
+		Name     string `json:"name" validate:"required"`
+		Quantity int    `json:"quantity" validate:"required,min=0,max=100"`
 	}
 	type Order struct {
-		Items []Item `json:"items" pedantigo:"required,dive"`
+		Items []Item `json:"items" validate:"required,dive"`
 	}
 
 	validator := New[Order]()
@@ -153,10 +153,10 @@ func TestMinMaxIntInNestedDiveStruct(t *testing.T) {
 // TestMinMaxInNestedMapStruct tests min/max on fields in map value structs.
 func TestMinMaxInNestedMapStruct(t *testing.T) {
 	type Score struct {
-		Value float64 `json:"value" pedantigo:"required,min=0,max=100"`
+		Value float64 `json:"value" validate:"required,min=0,max=100"`
 	}
 	type Scores struct {
-		BySubject map[string]Score `json:"by_subject" pedantigo:"dive"`
+		BySubject map[string]Score `json:"by_subject" validate:"dive"`
 	}
 
 	validator := New[Scores]()

--- a/omitempty_crossfield_test.go
+++ b/omitempty_crossfield_test.go
@@ -20,8 +20,8 @@ func TestValidate_OmitEmpty_WithCrossFieldConstraints(t *testing.T) {
 	// -------------------------------------------------------------------------
 
 	type omitEmptyScopeStruct struct {
-		ActorID   string `pedantigo:"omitempty,max=64,required_with=ActorType"`
-		ActorType string `pedantigo:"omitempty,oneof=user agent system,required_with=ActorID"`
+		ActorID   string `validate:"omitempty,max=64,required_with=ActorType"`
+		ActorType string `validate:"omitempty,oneof=user agent system,required_with=ActorID"`
 	}
 
 	t.Run("required_with/both_zero_no_error", func(t *testing.T) {
@@ -137,8 +137,8 @@ func TestValidate_OmitEmpty_WithCrossFieldConstraints(t *testing.T) {
 	// -------------------------------------------------------------------------
 
 	type omitEmptyConditionalStruct struct {
-		Mode  string `pedantigo:"oneof=auto manual"`
-		Query string `pedantigo:"omitempty,required_if=Mode manual"`
+		Mode  string `validate:"oneof=auto manual"`
+		Query string `validate:"omitempty,required_if=Mode manual"`
 	}
 
 	t.Run("required_if/condition_not_met_no_error", func(t *testing.T) {
@@ -181,12 +181,12 @@ func TestValidate_OmitEmpty_WithCrossFieldConstraints(t *testing.T) {
 	// -------------------------------------------------------------------------
 
 	type omitEmptyInnerStruct struct {
-		Value string `pedantigo:"min=1"`
+		Value string `validate:"min=1"`
 	}
 
 	type omitEmptyOuterStruct struct {
-		Inner *omitEmptyInnerStruct `pedantigo:"omitempty"`
-		Name  string                `pedantigo:"omitempty,max=10"`
+		Inner *omitEmptyInnerStruct `validate:"omitempty"`
+		Name  string                `validate:"omitempty,max=10"`
 	}
 
 	t.Run("nested_struct/nil_pointer_omitempty_skips_recursion", func(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -24,7 +24,7 @@ type ValidatorOptions struct {
 	ExtraFields ExtraFieldsMode
 
 	// TagName overrides the global struct tag name for this validator instance.
-	// If empty, the global tag name (set via SetTagName or defaulting to "pedantigo") is used.
+	// If empty, the global tag name (set via SetTagName or defaulting to "validate") is used.
 	// This allows different validators to use different struct tag names.
 	//
 	// Example:

--- a/options_test.go
+++ b/options_test.go
@@ -15,8 +15,8 @@ func TestResolveTagName_InstanceOverridesGlobal(t *testing.T) {
 	resetTagNameForTesting()
 	resetValidatorCreatedForTesting()
 
-	// Set global to "validate"
-	SetTagName("validate")
+	// Set global to "custom_validate"
+	SetTagName("custom_validate")
 
 	// Instance with TagName should override global
 	opts := ValidatorOptions{TagName: "binding"}
@@ -33,29 +33,29 @@ func TestResolveTagName_EmptyInstanceUsesGlobal(t *testing.T) {
 	resetTagNameForTesting()
 	resetValidatorCreatedForTesting()
 
-	// Set global to "validate"
-	SetTagName("validate")
+	// Set global to "custom_validate"
+	SetTagName("custom_validate")
 
 	// Instance without TagName should use global
 	opts := ValidatorOptions{} // TagName is empty string
 	resolved := resolveTagName(opts)
 
-	assert.Equal(t, "validate", resolved, "empty instance TagName should use global")
+	assert.Equal(t, "custom_validate", resolved, "empty instance TagName should use global")
 
 	resetTagNameForTesting()
 	resetValidatorCreatedForTesting()
 }
 
-// TestResolveTagName_DefaultGlobal verifies default global is "pedantigo".
+// TestResolveTagName_DefaultGlobal verifies default global is "validate".
 func TestResolveTagName_DefaultGlobal(t *testing.T) {
 	resetTagNameForTesting()
 	resetValidatorCreatedForTesting()
 
-	// Global should be default "pedantigo"
+	// Global should be default "validate"
 	opts := ValidatorOptions{}
 	resolved := resolveTagName(opts)
 
-	assert.Equal(t, "pedantigo", resolved, "default global should be 'pedantigo'")
+	assert.Equal(t, "validate", resolved, "default global should be 'pedantigo'")
 }
 
 // TestDefaultValidatorOptions_TagNameEmpty verifies default options has empty TagName.

--- a/pedantigo.go
+++ b/pedantigo.go
@@ -8,8 +8,8 @@
 // Global functions with automatic caching - no setup needed:
 //
 //	type User struct {
-//	    Email string `json:"email" pedantigo:"required,email"`
-//	    Age   int    `json:"age" pedantigo:"min=18,max=120"`
+//	    Email string `json:"email" validate:"required,email"`
+//	    Age   int    `json:"age" validate:"min=18,max=120"`
 //	}
 //
 //	// Parse JSON and validate
@@ -50,8 +50,8 @@ package pedantigo
 // Example:
 //
 //	type DateRange struct {
-//	    Start time.Time `json:"start" pedantigo:"required"`
-//	    End   time.Time `json:"end" pedantigo:"required"`
+//	    Start time.Time `json:"start" validate:"required"`
+//	    End   time.Time `json:"end" validate:"required"`
 //	}
 //
 //	func (d *DateRange) Validate() error {

--- a/registry.go
+++ b/registry.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/SmrutAI/pedantigo/internal/constraints"
-	"github.com/SmrutAI/pedantigo/internal/tags"
+	"github.com/SmrutAI/pedantigo/v2/internal/constraints"
+	"github.com/SmrutAI/pedantigo/v2/internal/tags"
 )
 
 // ValidationFunc is the signature for custom field-level validation functions.

--- a/registry_ctx_test.go
+++ b/registry_ctx_test.go
@@ -111,7 +111,7 @@ func TestValidateCtx_BasicUsage(t *testing.T) {
 	}
 
 	type User struct {
-		Username string `json:"username" pedantigo:"required,ctx_required_db"`
+		Username string `json:"username" validate:"required,ctx_required_db"`
 	}
 
 	tests := []struct {
@@ -174,7 +174,7 @@ func TestValidateCtx_WithTimeout(t *testing.T) {
 	}
 
 	type SlowUser struct {
-		ID string `json:"id" pedantigo:"slow_check"`
+		ID string `json:"id" validate:"slow_check"`
 	}
 
 	t.Run("context timeout triggers", func(t *testing.T) {
@@ -215,7 +215,7 @@ func TestValidateCtx_WithCancellation(t *testing.T) {
 	}
 
 	type CancellableUser struct {
-		Name string `json:"name" pedantigo:"cancellable"`
+		Name string `json:"name" validate:"cancellable"`
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -255,8 +255,8 @@ func TestValidateCtx_MultipleFields(t *testing.T) {
 	}
 
 	type SecureResource struct {
-		TenantID string `json:"tenant_id" pedantigo:"required,check_tenant"`
-		Action   string `json:"action" pedantigo:"required,check_permission"`
+		TenantID string `json:"tenant_id" validate:"required,check_tenant"`
+		Action   string `json:"action" validate:"required,check_permission"`
 	}
 
 	ctx := context.Background()
@@ -292,7 +292,7 @@ func TestValidateCtx_WithParameter(t *testing.T) {
 	}
 
 	type ParamUser struct {
-		Score int `json:"score" pedantigo:"min_ctx=10"`
+		Score int `json:"score" validate:"min_ctx=10"`
 	}
 
 	ctx := context.WithValue(context.Background(), ctxKeyMultiplier, 2)
@@ -317,7 +317,7 @@ func TestValidator_ValidateCtx(t *testing.T) {
 	}
 
 	type TestStruct struct {
-		Field string `json:"field" pedantigo:"ctx_validator_test"`
+		Field string `json:"field" validate:"ctx_validator_test"`
 	}
 
 	v := New[TestStruct]()
@@ -343,7 +343,7 @@ func TestValidator_ValidateCtx(t *testing.T) {
 
 func TestValidateCtx_NilContext(t *testing.T) {
 	type User struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	user := &User{Name: "John"}
@@ -357,7 +357,7 @@ func TestValidateCtx_NilContext(t *testing.T) {
 func TestValidateCtx_NilStruct(t *testing.T) {
 	ctx := context.Background()
 	var user *struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	err := ValidateCtx(ctx, user)
@@ -400,7 +400,7 @@ func TestValidateCtx_ContextValues(t *testing.T) {
 	}
 
 	type EchoStruct struct {
-		Data string `json:"data" pedantigo:"echo_context"`
+		Data string `json:"data" validate:"echo_context"`
 	}
 
 	ctx := context.WithValue(context.Background(), ctxKeyEcho, "echo_value")

--- a/registry_tagname_test.go
+++ b/registry_tagname_test.go
@@ -19,7 +19,7 @@ func TestRegisterTagNameFunc(t *testing.T) {
 		})
 
 		type FormUser struct {
-			Email string `form:"user_email" pedantigo:"email"`
+			Email string `form:"user_email" validate:"email"`
 		}
 
 		user := &FormUser{Email: "invalid"}
@@ -48,7 +48,7 @@ func TestRegisterTagNameFunc(t *testing.T) {
 		})
 
 		type YamlConfig struct {
-			APIKey string `yaml:"api_key" pedantigo:"required,min=10"`
+			APIKey string `yaml:"api_key" validate:"required,min=10"`
 		}
 
 		config := &YamlConfig{APIKey: "short"}
@@ -73,8 +73,8 @@ func TestRegisterTagNameFunc(t *testing.T) {
 		})
 
 		type MixedStruct struct {
-			Field1 string `custom:"custom_name" pedantigo:"email"`
-			Field2 string `pedantigo:"email"` // No custom tag
+			Field1 string `custom:"custom_name" validate:"email"`
+			Field2 string `validate:"email"` // No custom tag
 		}
 
 		// Use invalid emails to trigger validation errors
@@ -92,7 +92,7 @@ func TestRegisterTagNameFunc_Default(t *testing.T) {
 	RegisterTagNameFunc(nil) // Assuming nil resets to default
 
 	type User struct {
-		Email string `json:"email_address" pedantigo:"email"`
+		Email string `json:"email_address" validate:"email"`
 	}
 
 	user := &User{Email: "invalid"}
@@ -124,8 +124,8 @@ func TestRegisterTagNameFunc_ComplexTags(t *testing.T) {
 	})
 
 	type ComplexUser struct {
-		Name  string `json:"user_name,omitempty" pedantigo:"required,min=2"`
-		Email string `json:"email_addr,omitempty" pedantigo:"email"`
+		Name  string `json:"user_name,omitempty" validate:"required,min=2"`
+		Email string `json:"email_addr,omitempty" validate:"email"`
 	}
 
 	user := &ComplexUser{Name: "J", Email: "invalid"}
@@ -151,7 +151,7 @@ func TestRegisterTagNameFunc_WithValidator(t *testing.T) {
 	})
 
 	type DBModel struct {
-		UserID string `db:"user_id" pedantigo:"required,uuid"`
+		UserID string `db:"user_id" validate:"required,uuid"`
 	}
 
 	v := New[DBModel]()
@@ -176,7 +176,7 @@ func TestRegisterTagNameFunc_MultipleRegistrations(t *testing.T) {
 	})
 
 	type TestStruct struct {
-		Value string `pedantigo:"email"`
+		Value string `validate:"email"`
 	}
 
 	data1 := &TestStruct{Value: "invalid"}
@@ -215,7 +215,7 @@ func TestRegisterTagNameFunc_EmptyString(t *testing.T) {
 	})
 
 	type EmptyNameStruct struct {
-		Field string `pedantigo:"email"`
+		Field string `validate:"email"`
 	}
 
 	data := &EmptyNameStruct{Field: "invalid"}
@@ -237,7 +237,7 @@ func TestRegisterTagNameFunc_SpecialCharacters(t *testing.T) {
 	})
 
 	type SpecialStruct struct {
-		Field string `special:"field.name.with.dots" pedantigo:"email"`
+		Field string `special:"field.name.with.dots" validate:"email"`
 	}
 
 	data := &SpecialStruct{Field: "invalid"}
@@ -267,8 +267,8 @@ func TestRegisterTagNameFunc_IgnoredTag(t *testing.T) {
 	})
 
 	type IgnoredFieldStruct struct {
-		Visible string `json:"visible" pedantigo:"email"`
-		Hidden  string `json:"-" pedantigo:"email"`
+		Visible string `json:"visible" validate:"email"`
+		Hidden  string `json:"-" validate:"email"`
 	}
 
 	data := &IgnoredFieldStruct{Visible: "invalid", Hidden: "invalid"}
@@ -289,11 +289,11 @@ func TestRegisterTagNameFunc_NestedStructs(t *testing.T) {
 	})
 
 	type Address struct {
-		City string `custom:"city_name" pedantigo:"email"`
+		City string `custom:"city_name" validate:"email"`
 	}
 
 	type Person struct {
-		Name    string  `custom:"person_name" pedantigo:"email"`
+		Name    string  `custom:"person_name" validate:"email"`
 		Address Address `custom:"person_address"`
 	}
 
@@ -323,7 +323,7 @@ func TestRegisterTagNameFunc_WithUnmarshal(t *testing.T) {
 	})
 
 	type APIRequest struct {
-		UserEmail string `json:"email" api:"user_email_address" pedantigo:"required,email"`
+		UserEmail string `json:"email" api:"user_email_address" validate:"required,email"`
 	}
 
 	jsonData := []byte(`{"email": "invalid"}`)
@@ -368,7 +368,7 @@ func TestRegisterTagNameFunc_ReflectStructField(t *testing.T) {
 	})
 
 	type TestStruct struct {
-		TestField string `json:"test_field" pedantigo:"email"`
+		TestField string `json:"test_field" validate:"email"`
 	}
 
 	data := &TestStruct{TestField: "invalid"}
@@ -394,7 +394,7 @@ func TestRegisterTagNameFunc_ValidationErrorFormat(t *testing.T) {
 	})
 
 	type ErrorTestStruct struct {
-		Field string `error_name:"CustomFieldName" pedantigo:"email,min=5"`
+		Field string `error_name:"CustomFieldName" validate:"email,min=5"`
 	}
 
 	tests := []struct {

--- a/registry_test.go
+++ b/registry_test.go
@@ -156,7 +156,7 @@ func TestConcurrentRegistration(t *testing.T) {
 // TestRegisterValidation_ConcurrentWithValidation tests concurrent registration and validation.
 func TestRegisterValidation_ConcurrentWithValidation(t *testing.T) {
 	type User struct {
-		Code string `json:"code" pedantigo:"custom_code"`
+		Code string `json:"code" validate:"custom_code"`
 	}
 
 	// First, register the validator
@@ -544,7 +544,7 @@ func TestRegisterAlias_ConcurrentWithValidation(t *testing.T) {
 	require.NoError(t, err)
 
 	type TestStruct struct {
-		Value string `json:"value" pedantigo:"concurrent_val_alias"`
+		Value string `json:"value" validate:"concurrent_val_alias"`
 	}
 
 	var wg sync.WaitGroup

--- a/required_dive_test.go
+++ b/required_dive_test.go
@@ -16,11 +16,11 @@ import (
 func TestRequiredZeroValueInNestedDiveStruct(t *testing.T) {
 	// Test struct matching the bug report
 	type Fact struct {
-		Content    string  `json:"content" pedantigo:"required"`
-		Importance float32 `json:"importance" pedantigo:"required"`
+		Content    string  `json:"content" validate:"required"`
+		Importance float32 `json:"importance" validate:"required"`
 	}
 	type Schema struct {
-		Facts []Fact `json:"facts" pedantigo:"required,dive"`
+		Facts []Fact `json:"facts" validate:"required,dive"`
 	}
 
 	validator := New[Schema]()
@@ -59,11 +59,11 @@ func TestRequiredZeroValueInNestedDiveStruct(t *testing.T) {
 // TestRequiredZeroValueIntInNestedDiveStruct tests zero int values.
 func TestRequiredZeroValueIntInNestedDiveStruct(t *testing.T) {
 	type Item struct {
-		Name  string `json:"name" pedantigo:"required"`
-		Count int    `json:"count" pedantigo:"required"`
+		Name  string `json:"name" validate:"required"`
+		Count int    `json:"count" validate:"required"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"required,dive"`
+		Items []Item `json:"items" validate:"required,dive"`
 	}
 
 	validator := New[Container]()
@@ -87,11 +87,11 @@ func TestRequiredZeroValueIntInNestedDiveStruct(t *testing.T) {
 // TestRequiredZeroValueBoolInNestedDiveStruct tests false bool values.
 func TestRequiredZeroValueBoolInNestedDiveStruct(t *testing.T) {
 	type Setting struct {
-		Name   string `json:"name" pedantigo:"required"`
-		Active bool   `json:"active" pedantigo:"required"`
+		Name   string `json:"name" validate:"required"`
+		Active bool   `json:"active" validate:"required"`
 	}
 	type Config struct {
-		Settings []Setting `json:"settings" pedantigo:"required,dive"`
+		Settings []Setting `json:"settings" validate:"required,dive"`
 	}
 
 	validator := New[Config]()
@@ -116,11 +116,11 @@ func TestRequiredZeroValueBoolInNestedDiveStruct(t *testing.T) {
 // Note: Empty string with key present should pass required validation.
 func TestRequiredEmptyStringInNestedDiveStruct(t *testing.T) {
 	type Note struct {
-		Title   string `json:"title" pedantigo:"required"`
-		Content string `json:"content" pedantigo:"required"`
+		Title   string `json:"title" validate:"required"`
+		Content string `json:"content" validate:"required"`
 	}
 	type Notebook struct {
-		Notes []Note `json:"notes" pedantigo:"required,dive"`
+		Notes []Note `json:"notes" validate:"required,dive"`
 	}
 
 	validator := New[Notebook]()
@@ -145,10 +145,10 @@ func TestRequiredEmptyStringInNestedDiveStruct(t *testing.T) {
 // TestRequiredZeroValueInNestedMapStruct tests required in map values.
 func TestRequiredZeroValueInNestedMapStruct(t *testing.T) {
 	type Data struct {
-		Value int `json:"value" pedantigo:"required"`
+		Value int `json:"value" validate:"required"`
 	}
 	type Registry struct {
-		Items map[string]Data `json:"items" pedantigo:"dive"`
+		Items map[string]Data `json:"items" validate:"dive"`
 	}
 
 	validator := New[Registry]()

--- a/schema.go
+++ b/schema.go
@@ -11,7 +11,7 @@ import (
 )
 
 // parseTagFunc creates a closure that parses tags using the validator's configured tag name.
-// This enables custom tag name support (e.g., "validate" or "binding" instead of "pedantigo").
+// This enables custom tag name support (e.g., overriding the default "validate" with "binding").
 func (v *Validator[T]) parseTagFunc() func(reflect.StructTag) map[string]string {
 	return func(tag reflect.StructTag) map[string]string {
 		return tags.ParseTagWithName(tag, v.tagName)
@@ -236,7 +236,7 @@ func (v *Validator[T]) SchemaJSONOpenAPI() ([]byte, error) {
 // enhanceSchemaWithDefs enhances both root schema and all definitions.
 func (v *Validator[T]) enhanceSchemaWithDefs(schema *jsonschema.Schema, typ reflect.Type) {
 	// Clear the required fields set by jsonschema library
-	// We'll add our own based on pedantigo:"required" tags (or custom tag name)
+	// We'll add our own based on validate:"required" tags (or custom tag name)
 	schema.Required = nil
 
 	// Get parse function once and reuse for all schemas

--- a/schema.go
+++ b/schema.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/invopop/jsonschema"
 
-	"github.com/SmrutAI/pedantigo/internal/schemagen"
-	"github.com/SmrutAI/pedantigo/internal/tags"
+	"github.com/SmrutAI/pedantigo/v2/internal/schemagen"
+	"github.com/SmrutAI/pedantigo/v2/internal/tags"
 )
 
 // parseTagFunc creates a closure that parses tags using the validator's configured tag name.

--- a/schema_compliance_test.go
+++ b/schema_compliance_test.go
@@ -47,8 +47,8 @@ func TestSchemaCompliance_BasicTypes(t *testing.T) {
 			name: "string fields",
 			setup: func() ([]byte, error) {
 				type User struct {
-					Name  string `json:"name" pedantigo:"required"`
-					Email string `json:"email" pedantigo:"email"`
+					Name  string `json:"name" validate:"required"`
+					Email string `json:"email" validate:"email"`
 				}
 				return New[User]().SchemaJSON()
 			},
@@ -57,9 +57,9 @@ func TestSchemaCompliance_BasicTypes(t *testing.T) {
 			name: "numeric fields",
 			setup: func() ([]byte, error) {
 				type Product struct {
-					Price    float64 `json:"price" pedantigo:"gt=0"`
-					Quantity int     `json:"quantity" pedantigo:"gte=0"`
-					Discount float32 `json:"discount" pedantigo:"min=0,max=100"`
+					Price    float64 `json:"price" validate:"gt=0"`
+					Quantity int     `json:"quantity" validate:"gte=0"`
+					Discount float32 `json:"discount" validate:"min=0,max=100"`
 				}
 				return New[Product]().SchemaJSON()
 			},
@@ -68,7 +68,7 @@ func TestSchemaCompliance_BasicTypes(t *testing.T) {
 			name: "boolean fields",
 			setup: func() ([]byte, error) {
 				type Config struct {
-					Enabled bool `json:"enabled" pedantigo:"required"`
+					Enabled bool `json:"enabled" validate:"required"`
 					Debug   bool `json:"debug"`
 				}
 				return New[Config]().SchemaJSON()
@@ -78,8 +78,8 @@ func TestSchemaCompliance_BasicTypes(t *testing.T) {
 			name: "array fields",
 			setup: func() ([]byte, error) {
 				type Tags struct {
-					Items []string `json:"items" pedantigo:"min=1"`
-					IDs   []int    `json:"ids" pedantigo:"required"`
+					Items []string `json:"items" validate:"min=1"`
+					IDs   []int    `json:"ids" validate:"required"`
 				}
 				return New[Tags]().SchemaJSON()
 			},
@@ -117,9 +117,9 @@ func TestSchemaCompliance_Constraints(t *testing.T) {
 			name: "string length constraints (minLength, maxLength)",
 			setup: func() ([]byte, error) {
 				type User struct {
-					Username string `json:"username" pedantigo:"min=3,max=20"`
-					Bio      string `json:"bio" pedantigo:"max=500"`
-					Code     string `json:"code" pedantigo:"len=6"`
+					Username string `json:"username" validate:"min=3,max=20"`
+					Bio      string `json:"bio" validate:"max=500"`
+					Code     string `json:"code" validate:"len=6"`
 				}
 				return New[User]().SchemaJSON()
 			},
@@ -128,8 +128,8 @@ func TestSchemaCompliance_Constraints(t *testing.T) {
 			name: "numeric range constraints (minimum, maximum)",
 			setup: func() ([]byte, error) {
 				type Product struct {
-					Price float64 `json:"price" pedantigo:"min=0,max=10000"`
-					Stock int     `json:"stock" pedantigo:"gte=0,lte=1000"`
+					Price float64 `json:"price" validate:"min=0,max=10000"`
+					Stock int     `json:"stock" validate:"gte=0,lte=1000"`
 				}
 				return New[Product]().SchemaJSON()
 			},
@@ -138,7 +138,7 @@ func TestSchemaCompliance_Constraints(t *testing.T) {
 			name: "exclusive range constraints (exclusiveMinimum, exclusiveMaximum)",
 			setup: func() ([]byte, error) {
 				type Range struct {
-					Value float64 `json:"value" pedantigo:"gt=0,lt=100"`
+					Value float64 `json:"value" validate:"gt=0,lt=100"`
 				}
 				return New[Range]().SchemaJSON()
 			},
@@ -147,11 +147,11 @@ func TestSchemaCompliance_Constraints(t *testing.T) {
 			name: "format constraints",
 			setup: func() ([]byte, error) {
 				type Contact struct {
-					Email    string `json:"email" pedantigo:"email"`
-					Website  string `json:"website" pedantigo:"url"`
-					ID       string `json:"id" pedantigo:"uuid"`
-					IPv4Addr string `json:"ipv4" pedantigo:"ipv4"`
-					IPv6Addr string `json:"ipv6" pedantigo:"ipv6"`
+					Email    string `json:"email" validate:"email"`
+					Website  string `json:"website" validate:"url"`
+					ID       string `json:"id" validate:"uuid"`
+					IPv4Addr string `json:"ipv4" validate:"ipv4"`
+					IPv6Addr string `json:"ipv6" validate:"ipv6"`
 				}
 				return New[Contact]().SchemaJSON()
 			},
@@ -160,8 +160,8 @@ func TestSchemaCompliance_Constraints(t *testing.T) {
 			name: "pattern constraint",
 			setup: func() ([]byte, error) {
 				type Code struct {
-					ZipCode string `json:"zipCode" pedantigo:"regexp=^[0-9]{5}$"`
-					SKU     string `json:"sku" pedantigo:"regexp=^[A-Z]{3}-[0-9]{4}$"`
+					ZipCode string `json:"zipCode" validate:"regexp=^[0-9]{5}$"`
+					SKU     string `json:"sku" validate:"regexp=^[A-Z]{3}-[0-9]{4}$"`
 				}
 				return New[Code]().SchemaJSON()
 			},
@@ -170,8 +170,8 @@ func TestSchemaCompliance_Constraints(t *testing.T) {
 			name: "enum constraint (oneof)",
 			setup: func() ([]byte, error) {
 				type Status struct {
-					State string `json:"state" pedantigo:"oneof=pending active completed"`
-					Role  string `json:"role" pedantigo:"oneof=admin user guest"`
+					State string `json:"state" validate:"oneof=pending active completed"`
+					Role  string `json:"role" validate:"oneof=admin user guest"`
 				}
 				return New[Status]().SchemaJSON()
 			},
@@ -180,8 +180,8 @@ func TestSchemaCompliance_Constraints(t *testing.T) {
 			name: "const constraint (eq)",
 			setup: func() ([]byte, error) {
 				type Fixed struct {
-					Type    string `json:"type" pedantigo:"eq=user"`
-					Version string `json:"version" pedantigo:"eq=1.0"`
+					Type    string `json:"type" validate:"eq=user"`
+					Version string `json:"version" validate:"eq=1.0"`
 				}
 				return New[Fixed]().SchemaJSON()
 			},
@@ -190,7 +190,7 @@ func TestSchemaCompliance_Constraints(t *testing.T) {
 			name: "not constraint (ne)",
 			setup: func() ([]byte, error) {
 				type Exclusion struct {
-					Status string `json:"status" pedantigo:"ne=deleted"`
+					Status string `json:"status" validate:"ne=deleted"`
 				}
 				return New[Exclusion]().SchemaJSON()
 			},
@@ -199,7 +199,7 @@ func TestSchemaCompliance_Constraints(t *testing.T) {
 			name: "multipleOf constraint",
 			setup: func() ([]byte, error) {
 				type Quantity struct {
-					Count int `json:"count" pedantigo:"multiple_of=5"`
+					Count int `json:"count" validate:"multiple_of=5"`
 				}
 				return New[Quantity]().SchemaJSON()
 			},
@@ -208,9 +208,9 @@ func TestSchemaCompliance_Constraints(t *testing.T) {
 			name: "default values",
 			setup: func() ([]byte, error) {
 				type Config struct {
-					Port    int    `json:"port" pedantigo:"default=8080"`
-					Host    string `json:"host" pedantigo:"default=localhost"`
-					Enabled bool   `json:"enabled" pedantigo:"default=true"`
+					Port    int    `json:"port" validate:"default=8080"`
+					Host    string `json:"host" validate:"default=localhost"`
+					Enabled bool   `json:"enabled" validate:"default=true"`
 				}
 				return New[Config]().SchemaJSON()
 			},
@@ -238,11 +238,11 @@ func TestSchemaCompliance_NestedStructs(t *testing.T) {
 			name: "simple nested struct",
 			setup: func() ([]byte, error) {
 				type Address struct {
-					City string `json:"city" pedantigo:"required"`
-					Zip  string `json:"zip" pedantigo:"min=5"`
+					City string `json:"city" validate:"required"`
+					Zip  string `json:"zip" validate:"min=5"`
 				}
 				type User struct {
-					Name    string  `json:"name" pedantigo:"required"`
+					Name    string  `json:"name" validate:"required"`
 					Address Address `json:"address"`
 				}
 				return New[User]().SchemaJSON()
@@ -252,7 +252,7 @@ func TestSchemaCompliance_NestedStructs(t *testing.T) {
 			name: "deeply nested structs",
 			setup: func() ([]byte, error) {
 				type Level3 struct {
-					Data string `json:"data" pedantigo:"required"`
+					Data string `json:"data" validate:"required"`
 				}
 				type Level2 struct {
 					Nested Level3 `json:"nested"`
@@ -267,7 +267,7 @@ func TestSchemaCompliance_NestedStructs(t *testing.T) {
 			name: "pointer to struct",
 			setup: func() ([]byte, error) {
 				type Config struct {
-					Key   string `json:"key" pedantigo:"required"`
+					Key   string `json:"key" validate:"required"`
 					Value string `json:"value"`
 				}
 				type Service struct {
@@ -281,7 +281,7 @@ func TestSchemaCompliance_NestedStructs(t *testing.T) {
 			name: "slice of structs",
 			setup: func() ([]byte, error) {
 				type Item struct {
-					ID   string `json:"id" pedantigo:"required"`
+					ID   string `json:"id" validate:"required"`
 					Name string `json:"name"`
 				}
 				type Order struct {
@@ -326,11 +326,11 @@ func TestSchemaCompliance_OpenAPI(t *testing.T) {
 			name: "schema with $defs (nested struct)",
 			setup: func() ([]byte, error) {
 				type Address struct {
-					City string `json:"city" pedantigo:"required"`
-					Zip  string `json:"zip" pedantigo:"min=5"`
+					City string `json:"city" validate:"required"`
+					Zip  string `json:"zip" validate:"min=5"`
 				}
 				type User struct {
-					Name    string  `json:"name" pedantigo:"required"`
+					Name    string  `json:"name" validate:"required"`
 					Address Address `json:"address"`
 				}
 				return New[User]().SchemaJSONOpenAPI()
@@ -340,13 +340,13 @@ func TestSchemaCompliance_OpenAPI(t *testing.T) {
 			name: "schema with multiple $defs",
 			setup: func() ([]byte, error) {
 				type Tag struct {
-					Name string `json:"name" pedantigo:"required"`
+					Name string `json:"name" validate:"required"`
 				}
 				type Author struct {
-					Email string `json:"email" pedantigo:"email"`
+					Email string `json:"email" validate:"email"`
 				}
 				type Article struct {
-					Title  string `json:"title" pedantigo:"required"`
+					Title  string `json:"title" validate:"required"`
 					Tags   []Tag  `json:"tags"`
 					Author Author `json:"author"`
 				}
@@ -357,14 +357,14 @@ func TestSchemaCompliance_OpenAPI(t *testing.T) {
 			name: "deeply nested with $defs",
 			setup: func() ([]byte, error) {
 				type Permission struct {
-					Name string `json:"name" pedantigo:"required"`
+					Name string `json:"name" validate:"required"`
 				}
 				type Role struct {
-					Title       string       `json:"title" pedantigo:"required"`
+					Title       string       `json:"title" validate:"required"`
 					Permissions []Permission `json:"permissions"`
 				}
 				type User struct {
-					Username string `json:"username" pedantigo:"required"`
+					Username string `json:"username" validate:"required"`
 					Roles    []Role `json:"roles"`
 				}
 				return New[User]().SchemaJSONOpenAPI()
@@ -401,7 +401,7 @@ func TestSchemaCompliance_Metadata(t *testing.T) {
 			name: "title and description",
 			setup: func() ([]byte, error) {
 				type User struct {
-					Name string `json:"name" pedantigo:"title=User Name,description=The user's full name"`
+					Name string `json:"name" validate:"title=User Name,description=The user's full name"`
 				}
 				return New[User]().SchemaJSON()
 			},
@@ -410,7 +410,7 @@ func TestSchemaCompliance_Metadata(t *testing.T) {
 			name: "examples",
 			setup: func() ([]byte, error) {
 				type Email struct {
-					Address string `json:"address" pedantigo:"email,examples=[\"user@example.com\",\"admin@test.org\"]"`
+					Address string `json:"address" validate:"email,examples=[\"user@example.com\",\"admin@test.org\"]"`
 				}
 				return New[Email]().SchemaJSON()
 			},
@@ -419,7 +419,7 @@ func TestSchemaCompliance_Metadata(t *testing.T) {
 			name: "deprecated",
 			setup: func() ([]byte, error) {
 				type Legacy struct {
-					OldField string `json:"old_field" pedantigo:"deprecated=Use newField instead"`
+					OldField string `json:"old_field" validate:"deprecated=Use newField instead"`
 				}
 				return New[Legacy]().SchemaJSON()
 			},
@@ -447,14 +447,14 @@ func TestSchemaCompliance_ComplexTypes(t *testing.T) {
 			name: "all constraint types combined",
 			setup: func() ([]byte, error) {
 				type ComplexUser struct {
-					ID        string   `json:"id" pedantigo:"required,uuid"`
-					Email     string   `json:"email" pedantigo:"required,email"`
-					Username  string   `json:"username" pedantigo:"required,min=3,max=20,alpha"`
-					Age       int      `json:"age" pedantigo:"gte=18,lte=120"`
-					Score     float64  `json:"score" pedantigo:"gt=0,lt=100"`
-					Status    string   `json:"status" pedantigo:"oneof=active inactive pending"`
-					Tags      []string `json:"tags" pedantigo:"min=1"`
-					CreatedAt string   `json:"created_at" pedantigo:"required"`
+					ID        string   `json:"id" validate:"required,uuid"`
+					Email     string   `json:"email" validate:"required,email"`
+					Username  string   `json:"username" validate:"required,min=3,max=20,alpha"`
+					Age       int      `json:"age" validate:"gte=18,lte=120"`
+					Score     float64  `json:"score" validate:"gt=0,lt=100"`
+					Status    string   `json:"status" validate:"oneof=active inactive pending"`
+					Tags      []string `json:"tags" validate:"min=1"`
+					CreatedAt string   `json:"created_at" validate:"required"`
 				}
 				return New[ComplexUser]().SchemaJSON()
 			},
@@ -463,23 +463,23 @@ func TestSchemaCompliance_ComplexTypes(t *testing.T) {
 			name: "nested with all features",
 			setup: func() ([]byte, error) {
 				type Address struct {
-					Street  string `json:"street" pedantigo:"required,min=5"`
-					City    string `json:"city" pedantigo:"required,min=2"`
-					ZipCode string `json:"zip_code" pedantigo:"regexp=^[0-9]{5}$"`
-					Country string `json:"country" pedantigo:"oneof=US CA UK"`
+					Street  string `json:"street" validate:"required,min=5"`
+					City    string `json:"city" validate:"required,min=2"`
+					ZipCode string `json:"zip_code" validate:"regexp=^[0-9]{5}$"`
+					Country string `json:"country" validate:"oneof=US CA UK"`
 				}
 				type Company struct {
-					Name    string `json:"name" pedantigo:"required,min=1,max=100"`
-					Website string `json:"website" pedantigo:"url"`
-					Size    int    `json:"size" pedantigo:"gte=1"`
+					Name    string `json:"name" validate:"required,min=1,max=100"`
+					Website string `json:"website" validate:"url"`
+					Size    int    `json:"size" validate:"gte=1"`
 				}
 				type Employee struct {
-					ID      string   `json:"id" pedantigo:"required,uuid"`
-					Name    string   `json:"name" pedantigo:"required,min=2"`
-					Email   string   `json:"email" pedantigo:"required,email"`
-					Address Address  `json:"address" pedantigo:"required"`
+					ID      string   `json:"id" validate:"required,uuid"`
+					Name    string   `json:"name" validate:"required,min=2"`
+					Email   string   `json:"email" validate:"required,email"`
+					Address Address  `json:"address" validate:"required"`
 					Company Company  `json:"company"`
-					Skills  []string `json:"skills" pedantigo:"min=1"`
+					Skills  []string `json:"skills" validate:"min=1"`
 				}
 				return New[Employee]().SchemaJSON()
 			},
@@ -500,9 +500,9 @@ func TestSchemaCompliance_ComplexTypes(t *testing.T) {
 // TestSchemaCompliance_ValidationWorks verifies the compiled schema can validate data.
 func TestSchemaCompliance_ValidationWorks(t *testing.T) {
 	type User struct {
-		Name  string `json:"name" pedantigo:"required,min=3"`
-		Email string `json:"email" pedantigo:"required,email"`
-		Age   int    `json:"age" pedantigo:"gte=18"`
+		Name  string `json:"name" validate:"required,min=3"`
+		Email string `json:"email" validate:"required,email"`
+		Age   int    `json:"age" validate:"gte=18"`
 	}
 
 	schemaBytes, err := New[User]().SchemaJSON()

--- a/schema_test.go
+++ b/schema_test.go
@@ -50,11 +50,11 @@ func TestSchema_TypeMapping(t *testing.T) {
 			name: "nested struct",
 			setup: func() (interface{}, *jsonschema.Schema) {
 				type Address struct {
-					City string `json:"city" pedantigo:"required"`
-					Zip  string `json:"zip" pedantigo:"min=5"`
+					City string `json:"city" validate:"required"`
+					Zip  string `json:"zip" validate:"min=5"`
 				}
 				type User struct {
-					Name    string  `json:"name" pedantigo:"required"`
+					Name    string  `json:"name" validate:"required"`
 					Address Address `json:"address"`
 				}
 				v := New[User]()
@@ -82,8 +82,8 @@ func TestSchema_TypeMapping(t *testing.T) {
 			name: "slice with item constraints",
 			setup: func() (interface{}, *jsonschema.Schema) {
 				type Config struct {
-					Tags   []string `json:"tags" pedantigo:"min=3"`
-					Admins []string `json:"admins" pedantigo:"email"`
+					Tags   []string `json:"tags" validate:"min=3"`
+					Admins []string `json:"admins" validate:"email"`
 				}
 				v := New[Config]()
 				return v, nil
@@ -107,8 +107,8 @@ func TestSchema_TypeMapping(t *testing.T) {
 			name: "map with value constraints",
 			setup: func() (interface{}, *jsonschema.Schema) {
 				type Config struct {
-					Settings map[string]string `json:"settings" pedantigo:"min=3"`
-					Contacts map[string]string `json:"contacts" pedantigo:"email"`
+					Settings map[string]string `json:"settings" validate:"min=3"`
+					Contacts map[string]string `json:"contacts" validate:"email"`
 				}
 				v := New[Config]()
 				return v, nil
@@ -156,8 +156,8 @@ func TestSchema_Constraints(t *testing.T) {
 			name: "required fields",
 			setup: func() interface{} {
 				type User struct {
-					Name  string `json:"name" pedantigo:"required"`
-					Email string `json:"email" pedantigo:"required"`
+					Name  string `json:"name" validate:"required"`
+					Email string `json:"email" validate:"required"`
 					Age   int    `json:"age"`
 				}
 				return New[User]()
@@ -176,9 +176,9 @@ func TestSchema_Constraints(t *testing.T) {
 			name: "numeric constraints (gt/lt/gte/lte/min/max)",
 			setup: func() interface{} {
 				type Product struct {
-					Price    float64 `json:"price" pedantigo:"gt=0,lt=10000"`
-					Stock    int     `json:"stock" pedantigo:"gte=0,lte=1000"`
-					Discount int     `json:"discount" pedantigo:"min=0,max=100"`
+					Price    float64 `json:"price" validate:"gt=0,lt=10000"`
+					Stock    int     `json:"stock" validate:"gte=0,lte=1000"`
+					Discount int     `json:"discount" validate:"min=0,max=100"`
 				}
 				return New[Product]()
 			},
@@ -200,8 +200,8 @@ func TestSchema_Constraints(t *testing.T) {
 			name: "string length constraints (min/max)",
 			setup: func() interface{} {
 				type User struct {
-					Username string `json:"username" pedantigo:"min=3,max=20"`
-					Bio      string `json:"bio" pedantigo:"max=500"`
+					Username string `json:"username" validate:"min=3,max=20"`
+					Bio      string `json:"bio" validate:"max=500"`
 				}
 				return New[User]()
 			},
@@ -221,11 +221,11 @@ func TestSchema_Constraints(t *testing.T) {
 			name: "format constraints (email, url, uuid, ipv4, ipv6)",
 			setup: func() interface{} {
 				type Contact struct {
-					Email    string `json:"email" pedantigo:"email"`
-					Website  string `json:"website" pedantigo:"url"`
-					ID       string `json:"id" pedantigo:"uuid"`
-					IPv4Addr string `json:"ipv4" pedantigo:"ipv4"`
-					IPv6Addr string `json:"ipv6" pedantigo:"ipv6"`
+					Email    string `json:"email" validate:"email"`
+					Website  string `json:"website" validate:"url"`
+					ID       string `json:"id" validate:"uuid"`
+					IPv4Addr string `json:"ipv4" validate:"ipv4"`
+					IPv6Addr string `json:"ipv6" validate:"ipv6"`
 				}
 				return New[Contact]()
 			},
@@ -251,7 +251,7 @@ func TestSchema_Constraints(t *testing.T) {
 			name: "regex pattern constraint",
 			setup: func() interface{} {
 				type Code struct {
-					ZipCode string `json:"zipCode" pedantigo:"regexp=^[0-9]{5}$"`
+					ZipCode string `json:"zipCode" validate:"regexp=^[0-9]{5}$"`
 				}
 				return New[Code]()
 			},
@@ -264,9 +264,9 @@ func TestSchema_Constraints(t *testing.T) {
 			name: "default values (int, string, bool)",
 			setup: func() interface{} {
 				type Config struct {
-					Port    int    `json:"port" pedantigo:"default=8080"`
-					Host    string `json:"host" pedantigo:"default=localhost"`
-					Enabled bool   `json:"enabled" pedantigo:"default=true"`
+					Port    int    `json:"port" validate:"default=8080"`
+					Host    string `json:"host" validate:"default=localhost"`
+					Enabled bool   `json:"enabled" validate:"default=true"`
 				}
 				return New[Config]()
 			},
@@ -315,9 +315,9 @@ func TestSchemaJSON_Serialization(t *testing.T) {
 			name: "SchemaJSON produces valid JSON",
 			setup: func() interface{} {
 				type User struct {
-					Name  string `json:"name" pedantigo:"required,min=3"`
-					Email string `json:"email" pedantigo:"required,email"`
-					Age   int    `json:"age" pedantigo:"gte=18,lte=120"`
+					Name  string `json:"name" validate:"required,min=3"`
+					Email string `json:"email" validate:"required,email"`
+					Age   int    `json:"age" validate:"gte=18,lte=120"`
 				}
 				return New[User]()
 			},
@@ -352,12 +352,12 @@ func TestSchemaJSON_Serialization(t *testing.T) {
 			name: "SchemaJSONOpenAPI with nested references and $defs",
 			setup: func() interface{} {
 				type Address struct {
-					City string `json:"city" pedantigo:"required"`
-					Zip  string `json:"zip" pedantigo:"min=5"`
+					City string `json:"city" validate:"required"`
+					Zip  string `json:"zip" validate:"min=5"`
 				}
 				type User struct {
-					Name    string  `json:"name" pedantigo:"required,min=3"`
-					Address Address `json:"address" pedantigo:"required"`
+					Name    string  `json:"name" validate:"required,min=3"`
+					Address Address `json:"address" validate:"required"`
 				}
 				return New[User]()
 			},
@@ -413,12 +413,12 @@ func TestSchemaJSON_Serialization(t *testing.T) {
 			name: "SchemaOpenAPI returns nested definitions with constraints",
 			setup: func() interface{} {
 				type Contact struct {
-					Email string `json:"email" pedantigo:"required,email"`
-					Phone string `json:"phone" pedantigo:"min=10"`
+					Email string `json:"email" validate:"required,email"`
+					Phone string `json:"phone" validate:"min=10"`
 				}
 				type Company struct {
-					Name    string  `json:"name" pedantigo:"required,min=3"`
-					Contact Contact `json:"contact" pedantigo:"required"`
+					Name    string  `json:"name" validate:"required,min=3"`
+					Contact Contact `json:"contact" validate:"required"`
 				}
 				return New[Company]()
 			},
@@ -478,8 +478,8 @@ func TestSchema_Caching(t *testing.T) {
 			name: "Schema() caches pointer on repeated calls",
 			setup: func() interface{} {
 				type Product struct {
-					Name  string  `json:"name" pedantigo:"required,min=3"`
-					Price float64 `json:"price" pedantigo:"gt=0"`
+					Name  string  `json:"name" validate:"required,min=3"`
+					Price float64 `json:"price" validate:"gt=0"`
 				}
 				return New[Product]()
 			},
@@ -496,8 +496,8 @@ func TestSchema_Caching(t *testing.T) {
 			name: "SchemaJSON() caches bytes on repeated calls",
 			setup: func() interface{} {
 				type Config struct {
-					Host string `json:"host" pedantigo:"required,min=1"`
-					Port int    `json:"port" pedantigo:"gt=0,lt=65536"`
+					Host string `json:"host" validate:"required,min=1"`
+					Port int    `json:"port" validate:"gt=0,lt=65536"`
 				}
 				return New[Config]()
 			},
@@ -516,8 +516,8 @@ func TestSchema_Caching(t *testing.T) {
 			name: "SchemaOpenAPI() caches pointer on repeated calls",
 			setup: func() interface{} {
 				type Item struct {
-					ID    string `json:"id" pedantigo:"required,uuid"`
-					Title string `json:"title" pedantigo:"required,min=5"`
+					ID    string `json:"id" validate:"required,uuid"`
+					Title string `json:"title" validate:"required,min=5"`
 				}
 				return New[Item]()
 			},
@@ -534,8 +534,8 @@ func TestSchema_Caching(t *testing.T) {
 			name: "SchemaJSONOpenAPI() caches bytes on repeated calls",
 			setup: func() interface{} {
 				type Event struct {
-					Name      string `json:"name" pedantigo:"required,min=1"`
-					Timestamp int64  `json:"timestamp" pedantigo:"required,gte=0"`
+					Name      string `json:"name" validate:"required,min=1"`
+					Timestamp int64  `json:"timestamp" validate:"required,gte=0"`
 				}
 				return New[Event]()
 			},
@@ -554,10 +554,10 @@ func TestSchema_Caching(t *testing.T) {
 			name: "independent validators have independent caches",
 			setup: func() interface{} {
 				type Cat struct {
-					Name string `json:"name" pedantigo:"required"`
+					Name string `json:"name" validate:"required"`
 				}
 				type Dog struct {
-					Name string `json:"name" pedantigo:"required"`
+					Name string `json:"name" validate:"required"`
 				}
 				// Return tuple of two validators
 				return struct {
@@ -603,8 +603,8 @@ func TestSchema_ConcurrencySafe(t *testing.T) {
 			name: "Schema() is thread-safe with 100 concurrent goroutines",
 			setup: func() interface{} {
 				type User struct {
-					Name  string `json:"name" pedantigo:"required"`
-					Email string `json:"email" pedantigo:"required,email"`
+					Name  string `json:"name" validate:"required"`
+					Email string `json:"email" validate:"required,email"`
 				}
 				return New[User]()
 			},
@@ -643,8 +643,8 @@ func TestSchema_ConcurrencySafe(t *testing.T) {
 			name: "SchemaJSON() is thread-safe with 100 concurrent goroutines",
 			setup: func() interface{} {
 				type Settings struct {
-					Timeout int `json:"timeout" pedantigo:"gt=0,lt=60000"`
-					Retries int `json:"retries" pedantigo:"gte=0,lte=10"`
+					Timeout int `json:"timeout" validate:"gt=0,lt=60000"`
+					Retries int `json:"retries" validate:"gte=0,lte=10"`
 				}
 				return New[Settings]()
 			},
@@ -713,13 +713,13 @@ func bytesEqual(a, b []byte) bool {
 // TestSchemaOpenAPI_SliceOfStructs tests SchemaOpenAPI sliceofstructs.
 func TestSchemaOpenAPI_SliceOfStructs(t *testing.T) {
 	type Author struct {
-		Name  string `json:"name" pedantigo:"required,min=2"`
-		Email string `json:"email" pedantigo:"email"`
+		Name  string `json:"name" validate:"required,min=2"`
+		Email string `json:"email" validate:"email"`
 	}
 
 	type Book struct {
-		Title   string   `json:"title" pedantigo:"required,min=1"`
-		Authors []Author `json:"authors" pedantigo:"required"`
+		Title   string   `json:"title" validate:"required,min=1"`
+		Authors []Author `json:"authors" validate:"required"`
 	}
 
 	validator := New[Book]()
@@ -754,12 +754,12 @@ func TestSchemaOpenAPI_SliceOfStructs(t *testing.T) {
 // TestSchemaOpenAPI_PointerSliceOfStructs tests SchemaOpenAPI pointersliceofstructs.
 func TestSchemaOpenAPI_PointerSliceOfStructs(t *testing.T) {
 	type Tag struct {
-		Name  string `json:"name" pedantigo:"required,min=1"`
-		Color string `json:"color" pedantigo:"regexp=^#[0-9a-fA-F]{6}$"`
+		Name  string `json:"name" validate:"required,min=1"`
+		Color string `json:"color" validate:"regexp=^#[0-9a-fA-F]{6}$"`
 	}
 
 	type Article struct {
-		Title string `json:"title" pedantigo:"required"`
+		Title string `json:"title" validate:"required"`
 		Tags  []*Tag `json:"tags"` // Pointer slice
 	}
 
@@ -781,12 +781,12 @@ func TestSchemaOpenAPI_PointerSliceOfStructs(t *testing.T) {
 // TestSchemaOpenAPI_MapOfStructs tests SchemaOpenAPI mapofstructs.
 func TestSchemaOpenAPI_MapOfStructs(t *testing.T) {
 	type Contact struct {
-		Email string `json:"email" pedantigo:"required,email"`
-		Phone string `json:"phone" pedantigo:"min=10,max=15"`
+		Email string `json:"email" validate:"required,email"`
+		Phone string `json:"phone" validate:"min=10,max=15"`
 	}
 
 	type Company struct {
-		Name     string             `json:"name" pedantigo:"required,min=1"`
+		Name     string             `json:"name" validate:"required,min=1"`
 		Contacts map[string]Contact `json:"contacts"`
 	}
 
@@ -822,13 +822,13 @@ func TestSchemaOpenAPI_MapOfStructs(t *testing.T) {
 // TestSchemaOpenAPI_PointerMapOfStructs tests SchemaOpenAPI pointermapofstructs.
 func TestSchemaOpenAPI_PointerMapOfStructs(t *testing.T) {
 	type Address struct {
-		Street  string `json:"street" pedantigo:"required,min=1"`
-		City    string `json:"city" pedantigo:"required,min=2"`
-		ZipCode string `json:"zipCode" pedantigo:"regexp=^[0-9]{5}$"`
+		Street  string `json:"street" validate:"required,min=1"`
+		City    string `json:"city" validate:"required,min=2"`
+		ZipCode string `json:"zipCode" validate:"regexp=^[0-9]{5}$"`
 	}
 
 	type Organization struct {
-		Name      string              `json:"name" pedantigo:"required"`
+		Name      string              `json:"name" validate:"required"`
 		Locations map[string]*Address `json:"locations"` // Pointer map values
 	}
 
@@ -855,16 +855,16 @@ func TestSchemaOpenAPI_PointerMapOfStructs(t *testing.T) {
 // TestSchemaOpenAPI_NestedStructInSlice tests SchemaOpenAPI nestedstructinslice.
 func TestSchemaOpenAPI_NestedStructInSlice(t *testing.T) {
 	type Permission struct {
-		Name string `json:"name" pedantigo:"required,min=1"`
+		Name string `json:"name" validate:"required,min=1"`
 	}
 
 	type Role struct {
-		Title       string       `json:"title" pedantigo:"required,min=1"`
+		Title       string       `json:"title" validate:"required,min=1"`
 		Permissions []Permission `json:"permissions"`
 	}
 
 	type User struct {
-		Username string `json:"username" pedantigo:"required,min=3"`
+		Username string `json:"username" validate:"required,min=3"`
 		Roles    []Role `json:"roles"`
 	}
 
@@ -896,17 +896,17 @@ func TestSchemaOpenAPI_NestedStructInSlice(t *testing.T) {
 // TestSchemaOpenAPI_NestedStructInMap tests SchemaOpenAPI nestedstructinmap.
 func TestSchemaOpenAPI_NestedStructInMap(t *testing.T) {
 	type Metadata struct {
-		Key   string `json:"key" pedantigo:"required,min=1"`
-		Value string `json:"value" pedantigo:"required"`
+		Key   string `json:"key" validate:"required,min=1"`
+		Value string `json:"value" validate:"required"`
 	}
 
 	type Resource struct {
-		Name     string              `json:"name" pedantigo:"required,min=1"`
+		Name     string              `json:"name" validate:"required,min=1"`
 		Metadata map[string]Metadata `json:"metadata"`
 	}
 
 	type Project struct {
-		Title     string              `json:"title" pedantigo:"required,min=1"`
+		Title     string              `json:"title" validate:"required,min=1"`
 		Resources map[string]Resource `json:"resources"`
 	}
 
@@ -936,13 +936,13 @@ func TestSchemaOpenAPI_NestedStructInMap(t *testing.T) {
 // TestSchemaOpenAPI_DirectTypeMatch tests findTypeForDefinition direct name matching.
 func TestSchemaOpenAPI_DirectTypeMatch(t *testing.T) {
 	type Address struct {
-		Street string `json:"street" pedantigo:"required"`
-		City   string `json:"city" pedantigo:"required,min=2"`
+		Street string `json:"street" validate:"required"`
+		City   string `json:"city" validate:"required,min=2"`
 	}
 
 	type Person struct {
-		Name    string  `json:"name" pedantigo:"required"`
-		Address Address `json:"address" pedantigo:"required"`
+		Name    string  `json:"name" validate:"required"`
+		Address Address `json:"address" validate:"required"`
 	}
 
 	validator := New[Person]()
@@ -965,12 +965,12 @@ func TestSchemaOpenAPI_DirectTypeMatch(t *testing.T) {
 // TestSchemaOpenAPI_PointerFieldType tests findTypeForDefinition with pointer field types.
 func TestSchemaOpenAPI_PointerFieldType(t *testing.T) {
 	type Config struct {
-		Key   string `json:"key" pedantigo:"required"`
-		Value string `json:"value" pedantigo:"min=1"`
+		Key   string `json:"key" validate:"required"`
+		Value string `json:"value" validate:"min=1"`
 	}
 
 	type Service struct {
-		Name   string  `json:"name" pedantigo:"required"`
+		Name   string  `json:"name" validate:"required"`
 		Config *Config `json:"config"` // Pointer to nested struct
 	}
 
@@ -994,16 +994,16 @@ func TestSchemaOpenAPI_PointerFieldType(t *testing.T) {
 // TestSchemaOpenAPI_DeeplyNestedStruct tests findTypeForDefinition recursive search.
 func TestSchemaOpenAPI_DeeplyNestedStruct(t *testing.T) {
 	type Level3 struct {
-		Data string `json:"data" pedantigo:"required,min=5"`
+		Data string `json:"data" validate:"required,min=5"`
 	}
 
 	type Level2 struct {
-		Info   string `json:"info" pedantigo:"required"`
+		Info   string `json:"info" validate:"required"`
 		Nested Level3 `json:"nested"`
 	}
 
 	type Level1 struct {
-		Title string `json:"title" pedantigo:"required"`
+		Title string `json:"title" validate:"required"`
 		Mid   Level2 `json:"mid"`
 	}
 
@@ -1027,19 +1027,19 @@ func TestSchemaOpenAPI_DeeplyNestedStruct(t *testing.T) {
 // TestSchemaOpenAPI_MixedNestedTypes tests all search paths together.
 func TestSchemaOpenAPI_MixedNestedTypes(t *testing.T) {
 	type Tag struct {
-		Name string `json:"name" pedantigo:"required,min=1"`
+		Name string `json:"name" validate:"required,min=1"`
 	}
 
 	type Metadata struct {
-		Key string `json:"key" pedantigo:"required"`
+		Key string `json:"key" validate:"required"`
 	}
 
 	type Comment struct {
-		Text string `json:"text" pedantigo:"required,min=3"`
+		Text string `json:"text" validate:"required,min=3"`
 	}
 
 	type Article struct {
-		Title    string              `json:"title" pedantigo:"required"`
+		Title    string              `json:"title" validate:"required"`
 		Tags     []Tag               `json:"tags"`     // Slice of structs
 		Meta     map[string]Metadata `json:"meta"`     // Map of structs
 		Comments []Comment           `json:"comments"` // Another slice
@@ -1071,8 +1071,8 @@ func TestSchemaOpenAPI_MixedNestedTypes(t *testing.T) {
 // TestSchemaJSON_Caching tests all caching paths in SchemaJSON.
 func TestSchemaJSON_Caching(t *testing.T) {
 	type Product struct {
-		Name  string `json:"name" pedantigo:"required,min=1"`
-		Price int    `json:"price" pedantigo:"gt=0"`
+		Name  string `json:"name" validate:"required,min=1"`
+		Price int    `json:"price" validate:"gt=0"`
 	}
 
 	t.Run("first call generates and caches", func(t *testing.T) {
@@ -1137,8 +1137,8 @@ func TestSchemaJSON_Caching(t *testing.T) {
 // TestSchemaJSONOpenAPI_CachingPaths tests all caching paths in SchemaJSONOpenAPI.
 func TestSchemaJSONOpenAPI_CachingPaths(t *testing.T) {
 	type Item struct {
-		Name  string `json:"name" pedantigo:"required,min=1"`
-		Value int    `json:"value" pedantigo:"gt=0"`
+		Name  string `json:"name" validate:"required,min=1"`
+		Value int    `json:"value" validate:"gt=0"`
 	}
 
 	t.Run("first call generates and caches both schema and JSON", func(t *testing.T) {
@@ -1259,8 +1259,8 @@ func TestSchemaJSON_DefinitionUnwrapping(t *testing.T) {
 	// This happens with certain struct configurations
 	// Config contains configuration settings
 	type Config struct {
-		Host string `json:"host" pedantigo:"required,url"`
-		Port int    `json:"port" pedantigo:"gte=1,lte=65535"`
+		Host string `json:"host" validate:"required,url"`
+		Port int    `json:"port" validate:"gte=1,lte=65535"`
 	}
 
 	validator := New[Config]()
@@ -1291,8 +1291,8 @@ func TestSchemaJSON_DefinitionUnwrapping(t *testing.T) {
 // TestSchemaLLM_NoSchemaField verifies that SchemaLLM() does NOT include $schema field.
 func TestSchemaLLM_NoSchemaField(t *testing.T) {
 	type User struct {
-		Name  string `json:"name" pedantigo:"required,min=2"`
-		Email string `json:"email" pedantigo:"email"`
+		Name  string `json:"name" validate:"required,min=2"`
+		Email string `json:"email" validate:"email"`
 	}
 
 	validator := New[User]()
@@ -1320,8 +1320,8 @@ func TestSchemaLLM_NoSchemaField(t *testing.T) {
 // TestSchemaJSONLLM_NoSchemaFieldInJSON verifies JSON output has no $schema.
 func TestSchemaJSONLLM_NoSchemaFieldInJSON(t *testing.T) {
 	type User struct {
-		Name  string `json:"name" pedantigo:"required,min=2"`
-		Email string `json:"email" pedantigo:"email"`
+		Name  string `json:"name" validate:"required,min=2"`
+		Email string `json:"email" validate:"email"`
 	}
 
 	validator := New[User]()
@@ -1356,16 +1356,16 @@ func TestSchemaJSONLLM_NoSchemaFieldInJSON(t *testing.T) {
 // from the schema object, including nested structs.
 func TestSchemaLLM_NoIDOrSchemaField(t *testing.T) {
 	type Address struct {
-		City    string `json:"city" pedantigo:"required"`
-		Country string `json:"country" pedantigo:"required"`
+		City    string `json:"city" validate:"required"`
+		Country string `json:"country" validate:"required"`
 	}
 	type Company struct {
-		Name    string  `json:"name" pedantigo:"required"`
-		Address Address `json:"address" pedantigo:"required"`
+		Name    string  `json:"name" validate:"required"`
+		Address Address `json:"address" validate:"required"`
 	}
 	type Employee struct {
-		Name    string  `json:"name" pedantigo:"required"`
-		Company Company `json:"company" pedantigo:"required"`
+		Name    string  `json:"name" validate:"required"`
+		Company Company `json:"company" validate:"required"`
 		Home    Address `json:"home"`
 	}
 
@@ -1409,16 +1409,16 @@ func TestSchemaLLM_NoIDOrSchemaField(t *testing.T) {
 // so both paths must be tested separately.
 func TestSchemaJSONLLM_NoIDOrSchemaFieldAnywhere(t *testing.T) {
 	type Address struct {
-		City    string `json:"city" pedantigo:"required"`
-		Country string `json:"country" pedantigo:"required"`
+		City    string `json:"city" validate:"required"`
+		Country string `json:"country" validate:"required"`
 	}
 	type Company struct {
-		Name    string  `json:"name" pedantigo:"required"`
-		Address Address `json:"address" pedantigo:"required"`
+		Name    string  `json:"name" validate:"required"`
+		Address Address `json:"address" validate:"required"`
 	}
 	type Employee struct {
-		Name    string  `json:"name" pedantigo:"required"`
-		Company Company `json:"company" pedantigo:"required"`
+		Name    string  `json:"name" validate:"required"`
+		Company Company `json:"company" validate:"required"`
 		Home    Address `json:"home"`
 	}
 
@@ -1466,8 +1466,8 @@ func TestSchemaJSONLLM_NoIDOrSchemaFieldAnywhere(t *testing.T) {
 // TestSchemaLLM_Caching verifies SchemaLLM() has independent caching.
 func TestSchemaLLM_Caching(t *testing.T) {
 	type Product struct {
-		Name  string `json:"name" pedantigo:"required,min=1"`
-		Price int    `json:"price" pedantigo:"gt=0"`
+		Name  string `json:"name" validate:"required,min=1"`
+		Price int    `json:"price" validate:"gt=0"`
 	}
 
 	t.Run("SchemaLLM caches pointer on repeated calls", func(t *testing.T) {
@@ -1541,8 +1541,8 @@ func TestSchemaLLM_Caching(t *testing.T) {
 // TestSchemaLLM_Concurrent verifies SchemaLLM is thread-safe.
 func TestSchemaLLM_Concurrent(t *testing.T) {
 	type User struct {
-		Name  string `json:"name" pedantigo:"required"`
-		Email string `json:"email" pedantigo:"email"`
+		Name  string `json:"name" validate:"required"`
+		Email string `json:"email" validate:"email"`
 	}
 
 	t.Run("SchemaLLM is thread-safe", func(t *testing.T) {
@@ -1613,13 +1613,13 @@ func TestSchemaLLM_Concurrent(t *testing.T) {
 // TestSchemaJSONLLM_Constraints verifies all constraints are in LLM schema.
 func TestSchemaJSONLLM_Constraints(t *testing.T) {
 	type ComplexModel struct {
-		Username string   `json:"username" pedantigo:"required,min=3,max=20"`
-		Email    string   `json:"email" pedantigo:"required,email"`
-		Age      int      `json:"age" pedantigo:"gte=18,lte=120"`
-		Price    float64  `json:"price" pedantigo:"gt=0,lt=10000"`
-		Tags     []string `json:"tags" pedantigo:"min=1"`
-		Website  string   `json:"website" pedantigo:"url"`
-		UUID     string   `json:"uuid" pedantigo:"uuid"`
+		Username string   `json:"username" validate:"required,min=3,max=20"`
+		Email    string   `json:"email" validate:"required,email"`
+		Age      int      `json:"age" validate:"gte=18,lte=120"`
+		Price    float64  `json:"price" validate:"gt=0,lt=10000"`
+		Tags     []string `json:"tags" validate:"min=1"`
+		Website  string   `json:"website" validate:"url"`
+		UUID     string   `json:"uuid" validate:"uuid"`
 	}
 
 	validator := New[ComplexModel]()
@@ -1675,8 +1675,8 @@ func TestSchemaJSONLLM_Constraints(t *testing.T) {
 // TestSchemaLLM_SimpleAPI tests simple API wrappers.
 func TestSchemaLLM_SimpleAPI(t *testing.T) {
 	type Config struct {
-		Host string `json:"host" pedantigo:"required,min=1"`
-		Port int    `json:"port" pedantigo:"gte=1,lte=65535"`
+		Host string `json:"host" validate:"required,min=1"`
+		Port int    `json:"port" validate:"gte=1,lte=65535"`
 	}
 
 	t.Run("SchemaLLM simple API returns schema without $schema", func(t *testing.T) {
@@ -1722,8 +1722,8 @@ func TestSchemaLLM_SimpleAPI(t *testing.T) {
 // TestSchemaLLM_VsSchemaJSON_Comparison verifies $schema difference.
 func TestSchemaLLM_VsSchemaJSON_Comparison(t *testing.T) {
 	type User struct {
-		Name  string `json:"name" pedantigo:"required,min=2"`
-		Email string `json:"email" pedantigo:"email"`
+		Name  string `json:"name" validate:"required,min=2"`
+		Email string `json:"email" validate:"email"`
 	}
 
 	// Get both schemas
@@ -1763,8 +1763,8 @@ func TestSchemaLLM_VsSchemaJSON_Comparison(t *testing.T) {
 
 func TestSchemaJSON_SchemaCachedJSONNotCached(t *testing.T) {
 	type Product struct {
-		Name  string `json:"name" pedantigo:"required,min=1"`
-		Price int    `json:"price" pedantigo:"gt=0"`
+		Name  string `json:"name" validate:"required,min=1"`
+		Price int    `json:"price" validate:"gt=0"`
 	}
 
 	validator := New[Product]()
@@ -1790,11 +1790,11 @@ func TestSchemaJSON_SchemaCachedJSONNotCached(t *testing.T) {
 
 func TestSchemaJSONOpenAPI_SchemaCachedJSONNotCached(t *testing.T) {
 	type NestedChild struct {
-		Value string `json:"value" pedantigo:"required"`
+		Value string `json:"value" validate:"required"`
 	}
 
 	type Parent struct {
-		Name  string       `json:"name" pedantigo:"required"`
+		Name  string       `json:"name" validate:"required"`
 		Child *NestedChild `json:"child"`
 	}
 
@@ -1819,8 +1819,8 @@ func TestSchemaJSONOpenAPI_SchemaCachedJSONNotCached(t *testing.T) {
 
 func TestSchemaJSONLLM_SchemaCachedJSONNotCached(t *testing.T) {
 	type Config struct {
-		Host string `json:"host" pedantigo:"required,min=1"`
-		Port int    `json:"port" pedantigo:"gte=1,lte=65535"`
+		Host string `json:"host" validate:"required,min=1"`
+		Port int    `json:"port" validate:"gte=1,lte=65535"`
 	}
 
 	validator := New[Config]()
@@ -1850,12 +1850,12 @@ func TestSchemaJSONLLM_SchemaCachedJSONNotCached(t *testing.T) {
 
 func TestFindTypeForDefinition_PointerTypes(t *testing.T) {
 	type Address struct {
-		Street string `json:"street" pedantigo:"required"`
-		City   string `json:"city" pedantigo:"required"`
+		Street string `json:"street" validate:"required"`
+		City   string `json:"city" validate:"required"`
 	}
 
 	type Person struct {
-		Name    string   `json:"name" pedantigo:"required"`
+		Name    string   `json:"name" validate:"required"`
 		Address *Address `json:"address"` // Pointer to nested struct
 	}
 
@@ -1881,7 +1881,7 @@ func TestFindTypeForDefinition_PointerTypes(t *testing.T) {
 
 func TestSchemaOpenAPI_NonStructTypes(t *testing.T) {
 	type SimpleModel struct {
-		Name   string         `json:"name" pedantigo:"required"`
+		Name   string         `json:"name" validate:"required"`
 		Tags   []string       `json:"tags"`   // Slice of non-struct (string)
 		Scores []int          `json:"scores"` // Slice of non-struct (int)
 		Labels []bool         `json:"labels"` // Slice of non-struct (bool)
@@ -1910,7 +1910,7 @@ func TestSchemaOpenAPI_NonStructTypes(t *testing.T) {
 // TestSchemaOpenAPI_DeepNesting tests deeply nested structures.
 func TestSchemaOpenAPI_DeepNesting(t *testing.T) {
 	type Level3 struct {
-		Data string `json:"data" pedantigo:"required"`
+		Data string `json:"data" validate:"required"`
 	}
 
 	type Level2 struct {
@@ -1922,7 +1922,7 @@ func TestSchemaOpenAPI_DeepNesting(t *testing.T) {
 	}
 
 	type Root struct {
-		Name   string  `json:"name" pedantigo:"required"`
+		Name   string  `json:"name" validate:"required"`
 		Level1 *Level1 `json:"level1"`
 	}
 
@@ -1948,7 +1948,7 @@ func TestSchemaOpenAPI_DeepNesting(t *testing.T) {
 // TestSchemaJSON_DirectCall tests SchemaJSON without prior Schema call.
 func TestSchemaJSON_DirectCall(t *testing.T) {
 	type Item struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	validator := New[Item]()
@@ -1967,7 +1967,7 @@ func TestSchemaJSON_DirectCall(t *testing.T) {
 // TestSchemaJSONLLM_DirectCall tests SchemaJSONLLM without prior SchemaLLM call.
 func TestSchemaJSONLLM_DirectCall(t *testing.T) {
 	type Item struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	validator := New[Item]()
@@ -1990,7 +1990,7 @@ func TestSchemaJSONLLM_DirectCall(t *testing.T) {
 // TestSchemaJSONOpenAPI_DirectCall tests SchemaJSONOpenAPI without prior SchemaOpenAPI call.
 func TestSchemaJSONOpenAPI_DirectCall(t *testing.T) {
 	type Item struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	validator := New[Item]()
@@ -2138,7 +2138,7 @@ func TestFindTypeForDefinition_TypeVariants(t *testing.T) {
 
 func TestValidateWithCache_NilCache_Simple(t *testing.T) {
 	type SimpleStruct struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	v := New[SimpleStruct]()
@@ -2158,7 +2158,7 @@ func TestValidateWithCache_NonStructKind(t *testing.T) {
 
 func TestValidateWithCache_PointerIndirection(t *testing.T) {
 	type NestedStruct struct {
-		Value string `json:"value" pedantigo:"required"`
+		Value string `json:"value" validate:"required"`
 	}
 
 	v := New[*NestedStruct]()
@@ -2174,8 +2174,8 @@ func TestValidateWithCache_PointerIndirection(t *testing.T) {
 
 func TestSchemaJSON_ConcurrentCachePaths(t *testing.T) {
 	type ConcurrentStruct struct {
-		Field1 string `json:"field1" pedantigo:"required"`
-		Field2 int    `json:"field2" pedantigo:"min=0"`
+		Field1 string `json:"field1" validate:"required"`
+		Field2 int    `json:"field2" validate:"min=0"`
 	}
 
 	v := New[ConcurrentStruct]()
@@ -2208,8 +2208,8 @@ func TestSchemaJSON_ConcurrentCachePaths(t *testing.T) {
 
 func TestSchemaJSON_CachedSchemaButNotJSON(t *testing.T) {
 	type TestStruct struct {
-		Name  string `json:"name" pedantigo:"required"`
-		Email string `json:"email" pedantigo:"email"`
+		Name  string `json:"name" validate:"required"`
+		Email string `json:"email" validate:"email"`
 	}
 
 	v := New[TestStruct]()
@@ -2228,8 +2228,8 @@ func TestSchemaJSON_CachedSchemaButNotJSON(t *testing.T) {
 
 func TestSchemaJSONOpenAPI_ConcurrentCachePaths(t *testing.T) {
 	type OpenAPIStruct struct {
-		ID   string `json:"id" pedantigo:"uuid"`
-		Name string `json:"name" pedantigo:"required"`
+		ID   string `json:"id" validate:"uuid"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	v := New[OpenAPIStruct]()
@@ -2262,11 +2262,11 @@ func TestSchemaJSONOpenAPI_ConcurrentCachePaths(t *testing.T) {
 
 func TestSchemaJSONOpenAPI_CachedSchemaButNotJSON(t *testing.T) {
 	type NestedType struct {
-		Value string `json:"value" pedantigo:"required"`
+		Value string `json:"value" validate:"required"`
 	}
 
 	type TestStruct struct {
-		Name   string     `json:"name" pedantigo:"required"`
+		Name   string     `json:"name" validate:"required"`
 		Nested NestedType `json:"nested"`
 	}
 
@@ -2287,7 +2287,7 @@ func TestSchemaJSONOpenAPI_CachedSchemaButNotJSON(t *testing.T) {
 func TestMarshalWithExtras_UnmarshalError(t *testing.T) {
 	type WithExtras struct {
 		Name   string         `json:"name"`
-		Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any `json:"-" validate:"extra_fields"`
 	}
 
 	v := New[WithExtras](ValidatorOptions{
@@ -2309,13 +2309,13 @@ func TestMarshalWithExtras_UnmarshalError(t *testing.T) {
 func TestMarshalWithExtras_NestedStructs(t *testing.T) {
 	type NestedWithExtras struct {
 		Field  string         `json:"field"`
-		Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any `json:"-" validate:"extra_fields"`
 	}
 
 	type ParentWithExtras struct {
 		Name   string           `json:"name"`
 		Nested NestedWithExtras `json:"nested"`
-		Extras map[string]any   `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any   `json:"-" validate:"extra_fields"`
 	}
 
 	v := New[ParentWithExtras](ValidatorOptions{
@@ -2344,12 +2344,12 @@ func TestMarshalWithExtras_NestedStructs(t *testing.T) {
 func TestMarshalWithExtras_SliceOfStructsWithExtras(t *testing.T) {
 	type ItemWithExtras struct {
 		Name   string         `json:"name"`
-		Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any `json:"-" validate:"extra_fields"`
 	}
 
 	type Container struct {
 		Items  []ItemWithExtras `json:"items"`
-		Extras map[string]any   `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any   `json:"-" validate:"extra_fields"`
 	}
 
 	v := New[Container](ValidatorOptions{
@@ -2388,13 +2388,13 @@ func TestMarshalWithExtras_SliceOfStructsWithExtras(t *testing.T) {
 func TestMarshalWithExtras_PointerFields(t *testing.T) {
 	type NestedWithExtras struct {
 		Value  string         `json:"value"`
-		Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any `json:"-" validate:"extra_fields"`
 	}
 
 	type WithPointerField struct {
 		Name   string            `json:"name"`
 		Nested *NestedWithExtras `json:"nested"`
-		Extras map[string]any    `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any    `json:"-" validate:"extra_fields"`
 	}
 
 	v := New[WithPointerField](ValidatorOptions{
@@ -2423,7 +2423,7 @@ func TestMarshalWithExtras_PointerFields(t *testing.T) {
 func TestMarshalWithExtras_NilExtrasField(t *testing.T) {
 	type WithExtras struct {
 		Name   string         `json:"name"`
-		Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any `json:"-" validate:"extra_fields"`
 	}
 
 	v := New[WithExtras](ValidatorOptions{
@@ -2446,7 +2446,7 @@ func TestMarshalWithExtras_NilExtrasField(t *testing.T) {
 
 func TestSchemaJSON_DoubleCheckCache(t *testing.T) {
 	type RaceStruct struct {
-		Field string `json:"field" pedantigo:"required"`
+		Field string `json:"field" validate:"required"`
 	}
 
 	v := New[RaceStruct]()
@@ -2468,7 +2468,7 @@ func TestSchemaJSON_DoubleCheckCache(t *testing.T) {
 
 func TestSchemaJSONOpenAPI_DoubleCheckCache(t *testing.T) {
 	type RaceStruct struct {
-		Field string `json:"field" pedantigo:"required"`
+		Field string `json:"field" validate:"required"`
 	}
 
 	v := New[RaceStruct]()
@@ -2491,7 +2491,7 @@ func TestSchemaJSONOpenAPI_DoubleCheckCache(t *testing.T) {
 func TestValidateWithCache_SkipConstraints(t *testing.T) {
 	type ConditionalValidation struct {
 		Role     string `json:"role"`
-		AdminKey string `json:"admin_key" pedantigo:"skip_unless=Role admin,required,min=10"`
+		AdminKey string `json:"admin_key" validate:"skip_unless=Role admin,required,min=10"`
 	}
 
 	v := New[ConditionalValidation]()
@@ -2520,7 +2520,7 @@ func TestValidateWithCache_SkipConstraints(t *testing.T) {
 
 func TestMarshalWithExtras_EmptyStruct(t *testing.T) {
 	type EmptyWithExtras struct {
-		Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any `json:"-" validate:"extra_fields"`
 	}
 
 	v := New[EmptyWithExtras](ValidatorOptions{
@@ -2556,7 +2556,7 @@ func TestSchemaJSONLLM_DefinitionsFallback(t *testing.T) {
 
 func TestSchemaJSONLLM_ConcurrentAccess(t *testing.T) {
 	type ConcurrentLLMStruct struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	v := New[ConcurrentLLMStruct]()

--- a/secret.go
+++ b/secret.go
@@ -14,7 +14,7 @@ import (
 // Example:
 //
 //	type Config struct {
-//	    APIKey SecretStr `json:"api_key" pedantigo:"required"`
+//	    APIKey SecretStr `json:"api_key" validate:"required"`
 //	}
 //
 //	// JSON output: {"api_key": "**********"}
@@ -65,7 +65,7 @@ func (s *SecretStr) UnmarshalJSON(data []byte) error {
 // Example:
 //
 //	type Config struct {
-//	    EncryptionKey SecretBytes `json:"encryption_key" pedantigo:"required"`
+//	    EncryptionKey SecretBytes `json:"encryption_key" validate:"required"`
 //	}
 type SecretBytes struct {
 	value []byte

--- a/simple_api.go
+++ b/simple_api.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/invopop/jsonschema"
 
-	"github.com/SmrutAI/pedantigo/internal/constraints"
-	"github.com/SmrutAI/pedantigo/internal/tags"
+	"github.com/SmrutAI/pedantigo/v2/internal/constraints"
+	"github.com/SmrutAI/pedantigo/v2/internal/tags"
 )
 
 var (

--- a/simple_api_test.go
+++ b/simple_api_test.go
@@ -19,9 +19,9 @@ import (
 func TestUnmarshal_Basic(t *testing.T) {
 	// Local struct to avoid cross-test pollution
 	type User struct {
-		Name  string `json:"name" pedantigo:"required"`
-		Email string `json:"email" pedantigo:"email"`
-		Age   int    `json:"age" pedantigo:"min=0"`
+		Name  string `json:"name" validate:"required"`
+		Email string `json:"email" validate:"email"`
+		Age   int    `json:"age" validate:"min=0"`
 	}
 
 	data := []byte(`{"name":"John Doe","email":"john@example.com","age":30}`)
@@ -37,8 +37,8 @@ func TestUnmarshal_Basic(t *testing.T) {
 
 func TestSimpleAPI_Unmarshal_ValidationError(t *testing.T) {
 	type User struct {
-		Email string `json:"email" pedantigo:"required"`
-		Age   int    `json:"age" pedantigo:"min=18"`
+		Email string `json:"email" validate:"required"`
+		Age   int    `json:"age" validate:"min=18"`
 	}
 
 	// Missing required email field and age below minimum
@@ -57,8 +57,8 @@ func TestSimpleAPI_Unmarshal_ValidationError(t *testing.T) {
 
 func TestValidate_Valid(t *testing.T) {
 	type Config struct {
-		Host string `pedantigo:"required"`
-		Port int    `pedantigo:"min=1,max=65535"`
+		Host string `validate:"required"`
+		Port int    `validate:"min=1,max=65535"`
 	}
 
 	config := &Config{
@@ -74,7 +74,7 @@ func TestValidate_Invalid(t *testing.T) {
 	// NOTE: 'required' is only checked during Unmarshal (missing JSON keys), not Validate()
 	// Validate() only checks value constraints (min, max, etc.)
 	type Config struct {
-		Port int `pedantigo:"min=1,max=65535"`
+		Port int `validate:"min=1,max=65535"`
 	}
 
 	config := &Config{
@@ -91,9 +91,9 @@ func TestValidate_Invalid(t *testing.T) {
 
 func TestNewModel_AllInputTypes(t *testing.T) {
 	type Person struct {
-		Name  string `json:"name" pedantigo:"required"`
-		Email string `json:"email" pedantigo:"email"`
-		Age   int    `json:"age" pedantigo:"min=0"`
+		Name  string `json:"name" validate:"required"`
+		Email string `json:"email" validate:"email"`
+		Age   int    `json:"age" validate:"min=0"`
 	}
 
 	tests := []struct {
@@ -164,9 +164,9 @@ func TestNewModel_AllInputTypes(t *testing.T) {
 
 func TestSchema_ReturnsCachedInstance(t *testing.T) {
 	type Product struct {
-		ID    string  `json:"id" pedantigo:"required"`
-		Name  string  `json:"name" pedantigo:"required"`
-		Price float64 `json:"price" pedantigo:"min=0"`
+		ID    string  `json:"id" validate:"required"`
+		Name  string  `json:"name" validate:"required"`
+		Price float64 `json:"price" validate:"min=0"`
 	}
 
 	// First call
@@ -182,9 +182,9 @@ func TestSchema_ReturnsCachedInstance(t *testing.T) {
 
 func TestSchemaJSON_ValidJSON(t *testing.T) {
 	type Article struct {
-		Title   string `json:"title" pedantigo:"required"`
-		Content string `json:"content" pedantigo:"required"`
-		Author  string `json:"author" pedantigo:"required"`
+		Title   string `json:"title" validate:"required"`
+		Content string `json:"content" validate:"required"`
+		Author  string `json:"author" validate:"required"`
 	}
 
 	schemaBytes, err := SchemaJSON[Article]()
@@ -203,9 +203,9 @@ func TestSchemaJSON_ValidJSON(t *testing.T) {
 
 func TestMarshal_Basic(t *testing.T) {
 	type Book struct {
-		ISBN   string `json:"isbn" pedantigo:"required"`
-		Title  string `json:"title" pedantigo:"required"`
-		Author string `json:"author" pedantigo:"required"`
+		ISBN   string `json:"isbn" validate:"required"`
+		Title  string `json:"title" validate:"required"`
+		Author string `json:"author" validate:"required"`
 	}
 
 	book := &Book{
@@ -229,11 +229,11 @@ func TestMarshal_Basic(t *testing.T) {
 }
 
 func TestMarshalWithOptions_ExcludeContext(t *testing.T) {
-	// Note: The library uses pedantigo:"exclude:context" format
+	// Note: The library uses validate:"exclude:context" format
 	type Account struct {
-		Username string `json:"username" pedantigo:"required"`
-		Email    string `json:"email" pedantigo:"email"`
-		Password string `json:"password" pedantigo:"exclude:response"`
+		Username string `json:"username" validate:"required"`
+		Email    string `json:"email" validate:"email"`
+		Password string `json:"password" validate:"exclude:response"`
 	}
 
 	account := &Account{
@@ -260,9 +260,9 @@ func TestMarshalWithOptions_ExcludeContext(t *testing.T) {
 
 func TestDict_Basic(t *testing.T) {
 	type Address struct {
-		Street  string `json:"street" pedantigo:"required"`
-		City    string `json:"city" pedantigo:"required"`
-		ZipCode string `json:"zip_code" pedantigo:"required"`
+		Street  string `json:"street" validate:"required"`
+		City    string `json:"city" validate:"required"`
+		ZipCode string `json:"zip_code" validate:"required"`
 	}
 
 	address := &Address{
@@ -286,8 +286,8 @@ func TestDict_Basic(t *testing.T) {
 
 func TestConcurrentUnmarshal(t *testing.T) {
 	type User struct {
-		Name  string `json:"name" pedantigo:"required"`
-		Email string `json:"email" pedantigo:"email"`
+		Name  string `json:"name" validate:"required"`
+		Email string `json:"email" validate:"email"`
 	}
 
 	data := []byte(`{"name":"John","email":"john@example.com"}`)
@@ -320,8 +320,8 @@ func TestConcurrentUnmarshal(t *testing.T) {
 
 func TestConcurrentValidate(t *testing.T) {
 	type Config struct {
-		Host string `pedantigo:"required"`
-		Port int    `pedantigo:"min=1,max=65535"`
+		Host string `validate:"required"`
+		Port int    `validate:"min=1,max=65535"`
 	}
 
 	config := &Config{
@@ -352,9 +352,9 @@ func TestConcurrentValidate(t *testing.T) {
 
 func TestConcurrentSchema(t *testing.T) {
 	type Product struct {
-		ID    string  `json:"id" pedantigo:"required"`
-		Name  string  `json:"name" pedantigo:"required"`
-		Price float64 `json:"price" pedantigo:"min=0"`
+		ID    string  `json:"id" validate:"required"`
+		Name  string  `json:"name" validate:"required"`
+		Price float64 `json:"price" validate:"min=0"`
 	}
 
 	var wg sync.WaitGroup
@@ -396,9 +396,9 @@ func TestConcurrentSchema(t *testing.T) {
 
 func TestConcurrentMixedOperations(t *testing.T) {
 	type Order struct {
-		OrderID  string  `json:"order_id" pedantigo:"required"`
-		Total    float64 `json:"total" pedantigo:"min=0"`
-		Customer string  `json:"customer" pedantigo:"required"`
+		OrderID  string  `json:"order_id" validate:"required"`
+		Total    float64 `json:"total" validate:"min=0"`
+		Customer string  `json:"customer" validate:"required"`
 	}
 
 	data := []byte(`{"order_id":"ORD123","total":99.99,"customer":"Alice"}`)
@@ -463,10 +463,10 @@ func TestConcurrentMixedOperations(t *testing.T) {
 
 func TestConcurrentCacheAccess(t *testing.T) {
 	type TypeA struct {
-		FieldA string `json:"field_a" pedantigo:"required"`
+		FieldA string `json:"field_a" validate:"required"`
 	}
 	type TypeB struct {
-		FieldB int `json:"field_b" pedantigo:"min=0"`
+		FieldB int `json:"field_b" validate:"min=0"`
 	}
 	type TypeC struct {
 		FieldC bool `json:"field_c"`
@@ -520,8 +520,8 @@ func TestSimpleAPI_ConcurrentCacheCreation(t *testing.T) {
 	// This test verifies that getOrCreateValidator is thread-safe
 	// when multiple goroutines try to create validators for the same type
 	type Service struct {
-		Name string `json:"name" pedantigo:"required"`
-		URL  string `json:"url" pedantigo:"url"`
+		Name string `json:"name" validate:"required"`
+		URL  string `json:"url" validate:"url"`
 	}
 
 	var wg sync.WaitGroup
@@ -568,8 +568,8 @@ func TestSimpleAPI_ConcurrentCacheCreation(t *testing.T) {
 
 func TestSchemaOpenAPI_SimpleAPI(t *testing.T) {
 	type OpenAPIModel struct {
-		ID     int    `json:"id" pedantigo:"required"`
-		Name   string `json:"name" pedantigo:"required,min=1,max=100"`
+		ID     int    `json:"id" validate:"required"`
+		Name   string `json:"name" validate:"required,min=1,max=100"`
 		Active bool   `json:"active"`
 	}
 
@@ -585,8 +585,8 @@ func TestSchemaOpenAPI_SimpleAPI(t *testing.T) {
 
 func TestSchemaJSONOpenAPI_SimpleAPI(t *testing.T) {
 	type OpenAPIJSONModel struct {
-		Email   string `json:"email" pedantigo:"required,email"`
-		Website string `json:"website" pedantigo:"url"`
+		Email   string `json:"email" validate:"required,email"`
+		Website string `json:"website" validate:"url"`
 	}
 
 	schemaBytes, err := SchemaJSONOpenAPI[OpenAPIJSONModel]()
@@ -605,7 +605,7 @@ func TestSchemaJSONOpenAPI_SimpleAPI(t *testing.T) {
 
 func TestUnmarshalCtx_SimpleAPI(t *testing.T) {
 	type CtxModel struct {
-		Name  string `json:"name" pedantigo:"required"`
+		Name  string `json:"name" validate:"required"`
 		Value int    `json:"value"`
 	}
 
@@ -621,7 +621,7 @@ func TestUnmarshalCtx_SimpleAPI(t *testing.T) {
 
 func TestUnmarshalCtx_ValidationError(t *testing.T) {
 	type CtxModelWithEmail struct {
-		Email string `json:"email" pedantigo:"required,email"`
+		Email string `json:"email" validate:"required,email"`
 	}
 
 	ctx := context.Background()
@@ -714,7 +714,7 @@ func TestAppendMapKey_AllKeyTypes(t *testing.T) {
 // TestValidate_MapValidationWithErrors tests map validation which exercises captureExtrasInField.
 func TestValidate_MapValidationWithErrors(t *testing.T) {
 	type Config struct {
-		Settings map[string]int `json:"settings" pedantigo:"dive,min=0,max=100"`
+		Settings map[string]int `json:"settings" validate:"dive,min=0,max=100"`
 	}
 
 	config := &Config{
@@ -734,12 +734,12 @@ func TestValidate_MapValidationWithErrors(t *testing.T) {
 // TestNewModel_MapInput tests the unmarshalFromMap path.
 func TestNewModel_MapInput_Comprehensive(t *testing.T) {
 	type Address struct {
-		Street string `json:"street" pedantigo:"required"`
+		Street string `json:"street" validate:"required"`
 		City   string `json:"city"`
 	}
 	type User struct {
-		Name    string   `json:"name" pedantigo:"required"`
-		Age     int      `json:"age" pedantigo:"min=0"`
+		Name    string   `json:"name" validate:"required"`
+		Age     int      `json:"age" validate:"min=0"`
 		Address *Address `json:"address"`
 	}
 
@@ -764,8 +764,8 @@ func TestNewModel_MapInput_Comprehensive(t *testing.T) {
 // TestValidateWithCache tests that cached validation works correctly.
 func TestValidate_CachedValidation(t *testing.T) {
 	type Product struct {
-		Name  string  `json:"name" pedantigo:"required"`
-		Price float64 `json:"price" pedantigo:"min=0"`
+		Name  string  `json:"name" validate:"required"`
+		Price float64 `json:"price" validate:"min=0"`
 	}
 
 	// First validation
@@ -901,9 +901,9 @@ func TestStructPartial_Coverage(t *testing.T) {
 	RegisterTagNameFunc(nil)
 
 	type Form struct {
-		Name  string `json:"name" pedantigo:"required,min=1"`
-		Email string `json:"email" pedantigo:"required,email"`
-		Age   int    `json:"age" pedantigo:"min=18"`
+		Name  string `json:"name" validate:"required,min=1"`
+		Email string `json:"email" validate:"required,email"`
+		Age   int    `json:"age" validate:"min=18"`
 	}
 
 	v := New[Form](DefaultValidatorOptions())
@@ -927,9 +927,9 @@ func TestStructExcept_Coverage(t *testing.T) {
 	RegisterTagNameFunc(nil)
 
 	type Form struct {
-		Name  string `json:"name" pedantigo:"required,min=1"`
-		Email string `json:"email" pedantigo:"required,email"`
-		Age   int    `json:"age" pedantigo:"min=18"`
+		Name  string `json:"name" validate:"required,min=1"`
+		Email string `json:"email" validate:"required,email"`
+		Age   int    `json:"age" validate:"min=18"`
 	}
 
 	v := New[Form](DefaultValidatorOptions())
@@ -950,14 +950,14 @@ func TestStructExcept_Coverage(t *testing.T) {
 // PtrNestedWithExtra has pointer struct fields with extras.
 type PtrNestedWithExtra struct {
 	Value  string         `json:"value"`
-	Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+	Extras map[string]any `json:"-" validate:"extra_fields"`
 }
 
 // PtrStructWithExtras has a pointer to nested struct with extras.
 type PtrStructWithExtras struct {
 	Name   string              `json:"name"`
 	Nested *PtrNestedWithExtra `json:"nested"`
-	Extras map[string]any      `json:"-" pedantigo:"extra_fields"`
+	Extras map[string]any      `json:"-" validate:"extra_fields"`
 }
 
 // TestExtraAllow_PointerStructField tests extra fields with pointer struct fields.
@@ -1010,7 +1010,7 @@ func TestExtraAllow_NilPointerStructField(t *testing.T) {
 // SlicePtrStructWithExtras has a slice of pointer structs with extras.
 type SlicePtrStructWithExtras struct {
 	Items  []*PtrNestedWithExtra `json:"items"`
-	Extras map[string]any        `json:"-" pedantigo:"extra_fields"`
+	Extras map[string]any        `json:"-" validate:"extra_fields"`
 }
 
 // TestExtraAllow_SlicePointerStruct tests extras with slice of pointer structs.
@@ -1097,13 +1097,13 @@ func TestMarshal_SlicePointerStructWithExtras(t *testing.T) {
 
 // NestedRequiredForNewModel has nested required fields.
 type NestedRequiredForNewModel struct {
-	Field1 string `json:"field1" pedantigo:"required"`
-	Field2 string `json:"field2" pedantigo:"required"`
+	Field1 string `json:"field1" validate:"required"`
+	Field2 string `json:"field2" validate:"required"`
 }
 
 // NewModelMultiRequired has nested struct with multiple required fields.
 type NewModelMultiRequired struct {
-	Name   string                    `json:"name" pedantigo:"required"`
+	Name   string                    `json:"name" validate:"required"`
 	Nested NestedRequiredForNewModel `json:"nested"`
 }
 
@@ -1147,7 +1147,7 @@ func TestNewModel_SingleRequiredError(t *testing.T) {
 // TestNewModel_OtherError tests NewModel with non-required errors.
 func TestNewModel_OtherError(t *testing.T) {
 	type EmailModel struct {
-		Email string `json:"email" pedantigo:"required,email"`
+		Email string `json:"email" validate:"required,email"`
 	}
 
 	v := New[EmailModel](DefaultValidatorOptions())
@@ -1199,7 +1199,7 @@ func TestValidate_SkipUnless_Coverage(t *testing.T) {
 	// This test ensures the HasSkipConstraints branch is covered
 	type SkipTest struct {
 		Type    string `json:"type"`
-		OtherID string `json:"other_id" pedantigo:"skip_unless=Type:other,required"`
+		OtherID string `json:"other_id" validate:"skip_unless=Type:other,required"`
 	}
 
 	v := New[SkipTest](DefaultValidatorOptions())
@@ -1242,8 +1242,8 @@ func TestMarshalWithOptions_Coverage(t *testing.T) {
 
 // DictModelWithExtras is for testing Dict with extras enabled.
 type DictModelWithExtras struct {
-	Name   string         `json:"name" pedantigo:"required,min=3"`
-	Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+	Name   string         `json:"name" validate:"required,min=3"`
+	Extras map[string]any `json:"-" validate:"extra_fields"`
 }
 
 // TestDict_ValidationError tests Dict with validation errors.
@@ -1340,7 +1340,7 @@ func TestSecretBytes_NewSecretBytes(t *testing.T) {
 // TestUnmarshalCtx_Context_Error tests UnmarshalCtx with context validation error.
 func TestUnmarshalCtx_Context_Error(t *testing.T) {
 	type CtxModel struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	v := New[CtxModel](DefaultValidatorOptions())
@@ -1357,7 +1357,7 @@ func TestUnmarshalCtx_Context_Error(t *testing.T) {
 func TestStructPartial_NilPointer(t *testing.T) {
 	RegisterTagNameFunc(nil)
 	type PartialModel struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	v := New[PartialModel](DefaultValidatorOptions())
@@ -1371,7 +1371,7 @@ func TestStructPartial_NilPointer(t *testing.T) {
 func TestStructExcept_NilPointer(t *testing.T) {
 	RegisterTagNameFunc(nil)
 	type ExceptModel struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	v := New[ExceptModel](DefaultValidatorOptions())
@@ -1387,7 +1387,7 @@ func TestStructExcept_NilPointer(t *testing.T) {
 type ExtraModelWithIgnored struct {
 	Name       string         `json:"name"`
 	Ignored    string         `json:"-"`
-	Extras     map[string]any `json:"-" pedantigo:"extra_fields"`
+	Extras     map[string]any `json:"-" validate:"extra_fields"`
 	unexported string         //nolint:unused
 }
 
@@ -1408,14 +1408,14 @@ func TestExtraAllow_WithIgnoredField(t *testing.T) {
 // NestedExtraForMerge has nested struct with extras for merge testing.
 type NestedExtraForMerge struct {
 	Value  string         `json:"value"`
-	Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+	Extras map[string]any `json:"-" validate:"extra_fields"`
 }
 
 // ParentExtraForMerge has nested struct and extras.
 type ParentExtraForMerge struct {
 	Name   string              `json:"name"`
 	Nested NestedExtraForMerge `json:"nested"`
-	Extras map[string]any      `json:"-" pedantigo:"extra_fields"`
+	Extras map[string]any      `json:"-" validate:"extra_fields"`
 }
 
 // TestMarshal_MergeExtras_Nested tests merging extras in nested structs.
@@ -1566,7 +1566,7 @@ func TestUnion_UnknownDiscriminator(t *testing.T) {
 func TestUnion_ValidationFailure(t *testing.T) {
 	type ValidatedCat struct {
 		Type string `json:"type"`
-		Name string `json:"name" pedantigo:"required,min=3"`
+		Name string `json:"name" validate:"required,min=3"`
 	}
 
 	u, err := NewUnion[any](UnionOptions{
@@ -1586,7 +1586,7 @@ func TestUnion_ValidationFailure(t *testing.T) {
 func TestUnion_WithValidation(t *testing.T) {
 	type WithEmail struct {
 		Type  string `json:"type"`
-		Email string `json:"email" pedantigo:"email"`
+		Email string `json:"email" validate:"email"`
 	}
 
 	u, err := NewUnion[any](UnionOptions{
@@ -1608,7 +1608,7 @@ func TestUnion_WithValidation(t *testing.T) {
 // TestValidate_NilPointer tests validation with nil pointer field.
 func TestValidate_NilPointer(t *testing.T) {
 	type Inner struct {
-		Value string `json:"value" pedantigo:"required"`
+		Value string `json:"value" validate:"required"`
 	}
 	type Outer struct {
 		Inner *Inner `json:"inner"`
@@ -1625,7 +1625,7 @@ func TestValidate_NilPointer(t *testing.T) {
 // TestValidate_NonStructField tests validation skips non-struct type.
 func TestValidate_NonStructField(t *testing.T) {
 	type Model struct {
-		Name  string `json:"name" pedantigo:"required"`
+		Name  string `json:"name" validate:"required"`
 		Count int    `json:"count"`
 	}
 
@@ -1642,10 +1642,10 @@ func TestStructPartial_NestedField(t *testing.T) {
 	RegisterTagNameFunc(nil) // Reset to use JSON tags
 
 	type Address struct {
-		City string `json:"city" pedantigo:"required"`
+		City string `json:"city" validate:"required"`
 	}
 	type Person struct {
-		Name    string  `json:"name" pedantigo:"required"`
+		Name    string  `json:"name" validate:"required"`
 		Address Address `json:"address"`
 	}
 
@@ -1662,10 +1662,10 @@ func TestStructExcept_NestedField(t *testing.T) {
 	RegisterTagNameFunc(nil) // Reset to use JSON tags
 
 	type Address struct {
-		City string `json:"city" pedantigo:"required"`
+		City string `json:"city" validate:"required"`
 	}
 	type Person struct {
-		Name    string  `json:"name" pedantigo:"required"`
+		Name    string  `json:"name" validate:"required"`
 		Address Address `json:"address"`
 	}
 
@@ -1683,11 +1683,11 @@ func TestStructExcept_NestedField(t *testing.T) {
 func TestMarshal_SliceWithExtras(t *testing.T) {
 	type Item struct {
 		Name   string         `json:"name"`
-		Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any `json:"-" validate:"extra_fields"`
 	}
 	type Container struct {
 		Items  []Item         `json:"items"`
-		Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any `json:"-" validate:"extra_fields"`
 	}
 
 	v := New[Container](ValidatorOptions{ExtraFields: ExtraAllow})
@@ -1725,7 +1725,7 @@ func TestMarshal_MapField(t *testing.T) {
 // TestUnmarshalCtx_Valid tests UnmarshalCtx with valid data.
 func TestUnmarshalCtx_Valid(t *testing.T) {
 	type Model struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -1741,8 +1741,8 @@ func TestUnmarshalCtx_Valid(t *testing.T) {
 // TestValidate_CrossFieldValidationError tests cross-field constraint returning ValidationError.
 func TestValidate_CrossFieldValidationError(t *testing.T) {
 	type DateRange struct {
-		StartDate string `json:"start_date" pedantigo:"required"`
-		EndDate   string `json:"end_date" pedantigo:"required,gtfield=StartDate"`
+		StartDate string `json:"start_date" validate:"required"`
+		EndDate   string `json:"end_date" validate:"required,gtfield=StartDate"`
 	}
 
 	v := New[DateRange](DefaultValidatorOptions())
@@ -1803,8 +1803,8 @@ func TestStructPartial_ConstraintError(t *testing.T) {
 	RegisterTagNameFunc(nil) // Reset to use JSON tags
 
 	type Model struct {
-		Email string `json:"email" pedantigo:"email"`
-		Age   int    `json:"age" pedantigo:"min=18"`
+		Email string `json:"email" validate:"email"`
+		Age   int    `json:"age" validate:"min=18"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -1824,8 +1824,8 @@ func TestStructPartial_CrossFieldValidationError(t *testing.T) {
 	RegisterTagNameFunc(nil) // Reset to use JSON tags
 
 	type DateRange struct {
-		Start string `json:"start" pedantigo:"required"`
-		End   string `json:"end" pedantigo:"required,gtfield=Start"`
+		Start string `json:"start" validate:"required"`
+		End   string `json:"end" validate:"required,gtfield=Start"`
 	}
 
 	v := New[DateRange](DefaultValidatorOptions())
@@ -1841,8 +1841,8 @@ func TestStructExcept_ConstraintError(t *testing.T) {
 	RegisterTagNameFunc(nil) // Reset to use JSON tags
 
 	type Model struct {
-		Email string `json:"email" pedantigo:"email"`
-		Age   int    `json:"age" pedantigo:"min=18"`
+		Email string `json:"email" validate:"email"`
+		Age   int    `json:"age" validate:"min=18"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -1861,8 +1861,8 @@ func TestStructExcept_CrossFieldValidationError(t *testing.T) {
 	RegisterTagNameFunc(nil) // Reset to use JSON tags
 
 	type DateRange struct {
-		Start string `json:"start" pedantigo:"required"`
-		End   string `json:"end" pedantigo:"required,gtfield=Start"`
+		Start string `json:"start" validate:"required"`
+		End   string `json:"end" validate:"required,gtfield=Start"`
 	}
 
 	v := New[DateRange](DefaultValidatorOptions())
@@ -1878,7 +1878,7 @@ func TestStructExcept_CrossFieldValidationError(t *testing.T) {
 // TestValidate_MapWithDive tests map validation with dive.
 func TestValidate_MapWithDive(t *testing.T) {
 	type Model struct {
-		Tags map[string]string `json:"tags" pedantigo:"dive,keys,min=1,endkeys,min=1"`
+		Tags map[string]string `json:"tags" validate:"dive,keys,min=1,endkeys,min=1"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -1900,11 +1900,11 @@ func TestValidate_MapWithDive(t *testing.T) {
 func TestMarshal_SlicePointerWithExtras(t *testing.T) {
 	type Item struct {
 		Name   string         `json:"name"`
-		Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any `json:"-" validate:"extra_fields"`
 	}
 	type Container struct {
 		Items  []*Item        `json:"items"`
-		Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any `json:"-" validate:"extra_fields"`
 	}
 
 	v := New[Container](ValidatorOptions{ExtraFields: ExtraAllow})
@@ -1931,7 +1931,7 @@ func TestMarshal_SlicePointerWithExtras(t *testing.T) {
 func TestUnion_TagsWithComma(t *testing.T) {
 	type WithOneof struct {
 		Type   string `json:"type"`
-		Status string `json:"status" pedantigo:"oneof=active,inactive,pending"`
+		Status string `json:"status" validate:"oneof=active,inactive,pending"`
 	}
 
 	u, err := NewUnion[any](UnionOptions{
@@ -1975,7 +1975,7 @@ func TestUnion_PointerVariant(t *testing.T) {
 // TestUnmarshalCtx_MissingRequired tests UnmarshalCtx with missing required field.
 func TestUnmarshalCtx_MissingRequired(t *testing.T) {
 	type Model struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -1993,7 +1993,7 @@ func TestValidate_SkipConstraints(t *testing.T) {
 	// Test that HasSkipConstraints returns true for fields with skip_unless
 	type Model struct {
 		Active  bool   `json:"active"`
-		Details string `json:"details" pedantigo:"skip_unless=Active,min=3"`
+		Details string `json:"details" validate:"skip_unless=Active,min=3"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -2013,10 +2013,10 @@ func TestValidate_SkipConstraints(t *testing.T) {
 // TestValidate_NestedStruct tests validation with nested struct.
 func TestValidate_NestedStruct(t *testing.T) {
 	type Inner struct {
-		Value string `json:"value" pedantigo:"min=3"`
+		Value string `json:"value" validate:"min=3"`
 	}
 	type Outer struct {
-		Name  string `json:"name" pedantigo:"required"`
+		Name  string `json:"name" validate:"required"`
 		Inner Inner  `json:"inner"`
 	}
 
@@ -2061,9 +2061,9 @@ func TestSecretBytes_UnmarshalJSON_InvalidJSON(t *testing.T) {
 // TestMarshal_ExtraFieldsCapture tests marshal with extra fields capture at top level.
 func TestMarshal_ExtraFieldsCapture(t *testing.T) {
 	type Model struct {
-		Name   string         `json:"name" pedantigo:"required"`
+		Name   string         `json:"name" validate:"required"`
 		Val    string         `json:"val"`
-		Extras map[string]any `json:"extras" pedantigo:"extra_fields"`
+		Extras map[string]any `json:"extras" validate:"extra_fields"`
 	}
 
 	opts := DefaultValidatorOptions()
@@ -2114,7 +2114,7 @@ func TestMarshal_SliceOfPointersWithNil(t *testing.T) {
 // TestSchemaJSON_CachingSimple tests that SchemaJSON uses caching correctly.
 func TestSchemaJSON_CachingSimple(t *testing.T) {
 	type SimpleModel struct {
-		Value string `json:"value" pedantigo:"required"`
+		Value string `json:"value" validate:"required"`
 	}
 
 	v := New[SimpleModel](DefaultValidatorOptions())
@@ -2134,7 +2134,7 @@ func TestSchemaJSON_CachingSimple(t *testing.T) {
 // TestSchemaJSON_NoCache tests SchemaJSON when schema is already cached but JSON is not.
 func TestSchemaJSON_NoCache(t *testing.T) {
 	type Model struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -2151,7 +2151,7 @@ func TestSchemaJSON_NoCache(t *testing.T) {
 // TestUnmarshalCtx_ContextCanceled tests context handling during unmarshal.
 func TestUnmarshalCtx_ContextCanceled(t *testing.T) {
 	type Model struct {
-		Value string `json:"value" pedantigo:"required"`
+		Value string `json:"value" validate:"required"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -2182,7 +2182,7 @@ func TestMarshalWithOptions_NilPointer(t *testing.T) {
 func TestUnion_SplitTags_QuotedComma(t *testing.T) {
 	type Variant struct {
 		Type string `json:"type"`
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	u, err := NewUnion[any](UnionOptions{
@@ -2243,8 +2243,8 @@ func TestDict_BasicConversion(t *testing.T) {
 // TestNewModel_ValidationFailure tests NewModel with validation failure.
 func TestNewModel_ValidationFailure(t *testing.T) {
 	type Model struct {
-		Name  string `json:"name" pedantigo:"required"`
-		Email string `json:"email" pedantigo:"email"`
+		Name  string `json:"name" validate:"required"`
+		Email string `json:"email" validate:"email"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -2257,7 +2257,7 @@ func TestNewModel_ValidationFailure(t *testing.T) {
 // TestValidate_MapField tests validation with map field and dive.
 func TestValidate_MapFieldDive(t *testing.T) {
 	type Model struct {
-		Tags map[string]string `json:"tags" pedantigo:"dive,keys,min=2,endkeys,min=3"`
+		Tags map[string]string `json:"tags" validate:"dive,keys,min=2,endkeys,min=3"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -2281,7 +2281,7 @@ func TestValidate_MapFieldDive(t *testing.T) {
 // TestValidate_PointerToStruct tests validation with pointer to nested struct.
 func TestValidate_PointerToStruct(t *testing.T) {
 	type Inner struct {
-		Value string `json:"value" pedantigo:"min=3"`
+		Value string `json:"value" validate:"min=3"`
 	}
 	type Outer struct {
 		Inner *Inner `json:"inner"`
@@ -2308,7 +2308,7 @@ func TestValidate_PointerToStruct(t *testing.T) {
 // TestSchemaOpenAPI_Caching tests SchemaOpenAPI caching.
 func TestSchemaOpenAPI_Caching(t *testing.T) {
 	type Model struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -2326,7 +2326,7 @@ func TestSchemaOpenAPI_Caching(t *testing.T) {
 // TestSchemaJSONOpenAPI_Caching tests SchemaJSONOpenAPI caching.
 func TestSchemaJSONOpenAPI_Caching(t *testing.T) {
 	type Model struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -2347,7 +2347,7 @@ func TestSchemaJSONOpenAPI_Caching(t *testing.T) {
 func TestUnion_ValidateVariant_PointerType(t *testing.T) {
 	type Variant struct {
 		Type  string `json:"type"`
-		Value int    `json:"value" pedantigo:"min=10"`
+		Value int    `json:"value" validate:"min=10"`
 	}
 
 	u, err := NewUnion[any](UnionOptions{
@@ -2373,7 +2373,7 @@ func TestUnion_ValidateVariant_PointerType(t *testing.T) {
 func TestUnion_VariantWithUnexportedFields(t *testing.T) {
 	type VariantWithUnexported struct {
 		Type   string `json:"type"`
-		Public string `json:"public" pedantigo:"required"`
+		Public string `json:"public" validate:"required"`
 	}
 
 	u, err := NewUnion[any](UnionOptions{
@@ -2415,10 +2415,10 @@ func TestUnion_VariantWithNoConstraints(t *testing.T) {
 // TestSchemaOpenAPI_NestedTypes tests SchemaOpenAPI with nested types that get definitions.
 func TestSchemaOpenAPI_NestedTypes(t *testing.T) {
 	type Inner struct {
-		Value string `json:"value" pedantigo:"required"`
+		Value string `json:"value" validate:"required"`
 	}
 	type Outer struct {
-		Name  string `json:"name" pedantigo:"required"`
+		Name  string `json:"name" validate:"required"`
 		Inner Inner  `json:"inner"`
 	}
 
@@ -2437,7 +2437,7 @@ func TestSchemaOpenAPI_NestedTypes(t *testing.T) {
 // TestSchemaJSON_AfterSchema tests SchemaJSON when Schema was called first (cached path).
 func TestSchemaJSON_AfterSchema(t *testing.T) {
 	type Model struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -2454,7 +2454,7 @@ func TestSchemaJSON_AfterSchema(t *testing.T) {
 // TestSchemaJSONOpenAPI_AfterSchemaOpenAPI tests caching path.
 func TestSchemaJSONOpenAPI_AfterSchemaOpenAPI(t *testing.T) {
 	type Model struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -2472,7 +2472,7 @@ func TestSchemaJSONOpenAPI_AfterSchemaOpenAPI(t *testing.T) {
 func TestValidate_CrossFieldConstraint(t *testing.T) {
 	type Model struct {
 		Field1 string `json:"field1"`
-		Field2 string `json:"field2" pedantigo:"eqfield=Field1"`
+		Field2 string `json:"field2" validate:"eqfield=Field1"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -2491,7 +2491,7 @@ func TestValidate_CrossFieldConstraint(t *testing.T) {
 // TestValidate_MapWithDiveAndKeys tests map validation with dive and key constraints.
 func TestValidate_MapWithDiveAndKeys(t *testing.T) {
 	type Model struct {
-		Data map[string]int `json:"data" pedantigo:"dive,keys,min=2,endkeys,min=1"`
+		Data map[string]int `json:"data" validate:"dive,keys,min=2,endkeys,min=1"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -2515,7 +2515,7 @@ func TestValidate_MapWithDiveAndKeys(t *testing.T) {
 // TestValidate_SliceWithDive tests slice validation with dive.
 func TestValidate_SliceWithDive(t *testing.T) {
 	type Model struct {
-		Items []string `json:"items" pedantigo:"dive,min=3"`
+		Items []string `json:"items" validate:"dive,min=3"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -2534,10 +2534,10 @@ func TestValidate_SliceWithDive(t *testing.T) {
 // TestValidate_SliceOfStructsWithDive tests slice of structs with dive and nested validation.
 func TestValidate_SliceOfStructsWithDive(t *testing.T) {
 	type Item struct {
-		Name string `json:"name" pedantigo:"min=2"`
+		Name string `json:"name" validate:"min=2"`
 	}
 	type Model struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -2576,7 +2576,7 @@ func TestSchema_WithSliceAndMapTypes(t *testing.T) {
 // TestUnmarshalCtx_NormalContext tests UnmarshalCtx with a normal context.
 func TestUnmarshalCtx_NormalContext(t *testing.T) {
 	type Model struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -2604,10 +2604,10 @@ func TestUnmarshalCtx_NilContext(t *testing.T) {
 // TestSchemaOpenAPI_WithPointerNestedFields tests schema with pointer nested fields.
 func TestSchemaOpenAPI_WithPointerNestedFields(t *testing.T) {
 	type InnerA struct {
-		Value string `json:"value" pedantigo:"required"`
+		Value string `json:"value" validate:"required"`
 	}
 	type OuterA struct {
-		Name   string             `json:"name" pedantigo:"required"`
+		Name   string             `json:"name" validate:"required"`
 		Inner  *InnerA            `json:"inner"`
 		Inners []*InnerA          `json:"inners"`
 		Map    map[string]*InnerA `json:"map"`
@@ -2626,7 +2626,7 @@ func TestSchemaOpenAPI_WithPointerNestedFields(t *testing.T) {
 func TestValidate_SkipUnlessActive(t *testing.T) {
 	type Model struct {
 		Active bool   `json:"active"`
-		Data   string `json:"data" pedantigo:"skip_unless=Active,min=5"`
+		Data   string `json:"data" validate:"skip_unless=Active,min=5"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -2646,8 +2646,8 @@ func TestValidate_SkipUnlessActive(t *testing.T) {
 // TestValidate_CrossFieldWithValidationError tests cross-field constraint returning ValidationError.
 func TestValidate_CrossFieldWithValidationError(t *testing.T) {
 	type Model struct {
-		Password        string `json:"password" pedantigo:"min=5"`
-		ConfirmPassword string `json:"confirm_password" pedantigo:"eqfield=Password"`
+		Password        string `json:"password" validate:"min=5"`
+		ConfirmPassword string `json:"confirm_password" validate:"eqfield=Password"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -2667,7 +2667,7 @@ func TestValidate_CrossFieldWithValidationError(t *testing.T) {
 func TestSchemaOpenAPI_WithSliceOfPointerStructs(t *testing.T) {
 	type ItemB struct {
 		ID   int    `json:"id"`
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 	type ContainerB struct {
 		Items []*ItemB `json:"items"`
@@ -2682,7 +2682,7 @@ func TestSchemaOpenAPI_WithSliceOfPointerStructs(t *testing.T) {
 // TestSchemaOpenAPI_WithMapOfPointerValues tests schema with map[string]*struct.
 func TestSchemaOpenAPI_WithMapOfPointerValues(t *testing.T) {
 	type ValueC struct {
-		Data string `json:"data" pedantigo:"required"`
+		Data string `json:"data" validate:"required"`
 	}
 	type ContainerC struct {
 		Mapping map[string]*ValueC `json:"mapping"`
@@ -2697,7 +2697,7 @@ func TestSchemaOpenAPI_WithMapOfPointerValues(t *testing.T) {
 // TestValidate_NestedStructWithPointer tests validation with pointer to nested struct.
 func TestValidate_NestedStructWithPointer(t *testing.T) {
 	type InnerD struct {
-		Value string `json:"value" pedantigo:"min=3"`
+		Value string `json:"value" validate:"min=3"`
 	}
 	type OuterD struct {
 		Name  string  `json:"name"`
@@ -2724,7 +2724,7 @@ func TestMarshal_ExtraFieldsInSlice(t *testing.T) {
 	}
 	type Model struct {
 		Items  []Item         `json:"items"`
-		Extras map[string]any `json:"extras" pedantigo:"extra_fields"`
+		Extras map[string]any `json:"extras" validate:"extra_fields"`
 	}
 
 	opts := DefaultValidatorOptions()
@@ -2746,7 +2746,7 @@ func TestMarshal_ExtraFieldsInSlice(t *testing.T) {
 // TestMarshalWithOptions_OmitZero tests MarshalWithOptions with OmitZero option.
 func TestMarshalWithOptions_OmitZero(t *testing.T) {
 	type Model struct {
-		Name  string `json:"name" pedantigo:"required"`
+		Name  string `json:"name" validate:"required"`
 		Count int    `json:"count,omitzero"`
 		Flag  bool   `json:"flag"`
 	}
@@ -2767,8 +2767,8 @@ func TestMarshalWithOptions_OmitZero(t *testing.T) {
 // TestDict_WithExtras tests Dict with extra fields enabled.
 func TestDict_WithExtras(t *testing.T) {
 	type Model struct {
-		Name   string         `json:"name" pedantigo:"required"`
-		Extras map[string]any `json:"extras" pedantigo:"extra_fields"`
+		Name   string         `json:"name" validate:"required"`
+		Extras map[string]any `json:"extras" validate:"extra_fields"`
 	}
 
 	opts := DefaultValidatorOptions()
@@ -2820,10 +2820,10 @@ func TestVar_MapLen(t *testing.T) {
 // TestValidate_MapWithDive tests map validation with dive tag.
 func TestValidate_MapWithDiveNestedStruct(t *testing.T) {
 	type Inner struct {
-		Value int `json:"value" pedantigo:"min=5"`
+		Value int `json:"value" validate:"min=5"`
 	}
 	type Model struct {
-		Data map[string]Inner `json:"data" pedantigo:"dive"`
+		Data map[string]Inner `json:"data" validate:"dive"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -2842,7 +2842,7 @@ func TestValidate_MapWithDiveNestedStruct(t *testing.T) {
 // TestSchemaJSON_Concurrent tests concurrent SchemaJSON calls to exercise caching.
 func TestSchemaJSON_Concurrent(t *testing.T) {
 	type Model struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -2863,7 +2863,7 @@ func TestSchemaJSON_Concurrent(t *testing.T) {
 // TestSchemaJSONOpenAPI_Concurrent tests concurrent SchemaJSONOpenAPI calls.
 func TestSchemaJSONOpenAPI_Concurrent(t *testing.T) {
 	type Model struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -2887,7 +2887,7 @@ func TestSchemaJSONOpenAPI_Concurrent(t *testing.T) {
 func TestValidate_SkipConstraint_FieldPath(t *testing.T) {
 	type Model struct {
 		Enabled bool   `json:"enabled"`
-		Data    string `json:"data" pedantigo:"skip_unless=Enabled,min=3"`
+		Data    string `json:"data" validate:"skip_unless=Enabled,min=3"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -2902,7 +2902,7 @@ func TestValidate_SkipConstraint_FieldPath(t *testing.T) {
 func TestUnion_VariantWithConstraints(t *testing.T) {
 	type VariantA struct {
 		Type  string `json:"type"`
-		Email string `json:"email" pedantigo:"email"`
+		Email string `json:"email" validate:"email"`
 	}
 
 	u, err := NewUnion[any](UnionOptions{
@@ -2927,7 +2927,7 @@ func TestUnion_VariantWithConstraints(t *testing.T) {
 func TestUnion_VariantWithRequiredMissing(t *testing.T) {
 	type VariantB struct {
 		Type string `json:"type"`
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	u, err := NewUnion[any](UnionOptions{
@@ -2947,7 +2947,7 @@ func TestUnion_VariantWithRequiredMissing(t *testing.T) {
 func TestUnion_SplitTagsQuoted(t *testing.T) {
 	type VariantC struct {
 		Type   string `json:"type"`
-		Status string `json:"status" pedantigo:"oneof=a b c"`
+		Status string `json:"status" validate:"oneof=a b c"`
 	}
 
 	u, err := NewUnion[any](UnionOptions{
@@ -2968,11 +2968,11 @@ func TestUnion_SplitTagsQuoted(t *testing.T) {
 func TestMarshal_ExtrasInNestedPointerSlice(t *testing.T) {
 	type Inner struct {
 		Val    string         `json:"val"`
-		Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any `json:"-" validate:"extra_fields"`
 	}
 	type Outer struct {
 		Items  []*Inner       `json:"items"`
-		Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any `json:"-" validate:"extra_fields"`
 	}
 
 	v := New[Outer](ValidatorOptions{ExtraFields: ExtraAllow})
@@ -2996,7 +2996,7 @@ func TestMarshal_ExtrasInNestedPointerSlice(t *testing.T) {
 func TestMarshal_ExtrasNotStructSlice(t *testing.T) {
 	type Model struct {
 		Names  []string       `json:"names"`
-		Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any `json:"-" validate:"extra_fields"`
 	}
 
 	v := New[Model](ValidatorOptions{ExtraFields: ExtraAllow})
@@ -3014,7 +3014,7 @@ func TestMarshal_ExtrasNotStructSlice(t *testing.T) {
 // TestSchemaJSON_CachePathSchemaOnly tests SchemaJSON when schema is cached but JSON is not.
 func TestSchemaJSON_CachePathSchemaOnly(t *testing.T) {
 	type CacheTestModel struct {
-		ID string `json:"id" pedantigo:"required,uuid"`
+		ID string `json:"id" validate:"required,uuid"`
 	}
 
 	v := New[CacheTestModel](DefaultValidatorOptions())
@@ -3036,7 +3036,7 @@ func TestSchemaJSON_CachePathSchemaOnly(t *testing.T) {
 // TestSchemaJSONOpenAPI_CachePathSchemaOnly tests SchemaJSONOpenAPI when OpenAPI schema cached but JSON not.
 func TestSchemaJSONOpenAPI_CachePathSchemaOnly(t *testing.T) {
 	type CacheTestModel2 struct {
-		Value int `json:"value" pedantigo:"min=0"`
+		Value int `json:"value" validate:"min=0"`
 	}
 
 	v := New[CacheTestModel2](DefaultValidatorOptions())
@@ -3058,7 +3058,7 @@ func TestSchemaJSONOpenAPI_CachePathSchemaOnly(t *testing.T) {
 // TestValidate_NonStructField tests validation skipping non-struct top-level.
 func TestValidate_MapDiveWithKeysEndkeys(t *testing.T) {
 	type Model struct {
-		Tags map[string]int `json:"tags" pedantigo:"dive,keys,min=2,endkeys,min=0"`
+		Tags map[string]int `json:"tags" validate:"dive,keys,min=2,endkeys,min=0"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -3077,7 +3077,7 @@ func TestValidate_MapDiveWithKeysEndkeys(t *testing.T) {
 // TestUnmarshalCtx_InvalidJSON tests UnmarshalCtx with invalid JSON.
 func TestUnmarshalCtx_InvalidJSON(t *testing.T) {
 	type Model struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -3090,7 +3090,7 @@ func TestUnmarshalCtx_InvalidJSON(t *testing.T) {
 // TestFindTypeForDefinition_DeepNested tests findTypeForDefinition with deeply nested types.
 func TestFindTypeForDefinition_DeepNested(t *testing.T) {
 	type Level3 struct {
-		Value string `json:"value" pedantigo:"required"`
+		Value string `json:"value" validate:"required"`
 	}
 	type Level2 struct {
 		Level3 Level3 `json:"level3"`
@@ -3109,10 +3109,10 @@ func TestFindTypeForDefinition_DeepNested(t *testing.T) {
 // TestValidate_SliceWithDiveNestedStruct tests slice validation with dive to nested struct.
 func TestValidate_SliceWithDiveNestedStruct(t *testing.T) {
 	type Item struct {
-		Name string `json:"name" pedantigo:"min=2"`
+		Name string `json:"name" validate:"min=2"`
 	}
 	type Container struct {
-		Items []Item `json:"items" pedantigo:"dive"`
+		Items []Item `json:"items" validate:"dive"`
 	}
 
 	v := New[Container](DefaultValidatorOptions())
@@ -3131,8 +3131,8 @@ func TestValidate_SliceWithDiveNestedStruct(t *testing.T) {
 // TestMarshal_NilExtrasField tests marshal when extras field is nil.
 func TestMarshal_NilExtrasField(t *testing.T) {
 	type Model struct {
-		Name   string         `json:"name" pedantigo:"required"`
-		Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+		Name   string         `json:"name" validate:"required"`
+		Extras map[string]any `json:"-" validate:"extra_fields"`
 	}
 
 	v := New[Model](ValidatorOptions{ExtraFields: ExtraAllow})
@@ -3147,8 +3147,8 @@ func TestMarshal_NilExtrasField(t *testing.T) {
 // TestValidate_CrossFieldWithValidationErrorReturn tests cross-field returning ValidationError.
 func TestValidate_CrossFieldEqFieldFail(t *testing.T) {
 	type Model struct {
-		Password string `json:"password" pedantigo:"required"`
-		Confirm  string `json:"confirm" pedantigo:"eqfield=Password"`
+		Password string `json:"password" validate:"required"`
+		Confirm  string `json:"confirm" validate:"eqfield=Password"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -3162,8 +3162,8 @@ func TestValidate_CrossFieldEqFieldFail(t *testing.T) {
 // TestMarshalWithOptions_ContextExclusion tests context-based field exclusion.
 func TestMarshalWithOptions_ContextExclusion(t *testing.T) {
 	type Model struct {
-		Name     string `json:"name" pedantigo:"required"`
-		Internal string `json:"internal" pedantigo:"exclude:api"`
+		Name     string `json:"name" validate:"required"`
+		Internal string `json:"internal" validate:"exclude:api"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -3224,7 +3224,7 @@ func TestUnion_SplitTagsWithQuotes(t *testing.T) {
 	// Test variant with complex tag containing equals sign in value
 	type VariantComplex struct {
 		Type  string `json:"type"`
-		Email string `json:"email" pedantigo:"required,email"`
+		Email string `json:"email" validate:"required,email"`
 	}
 
 	u, err := NewUnion[any](UnionOptions{
@@ -3259,7 +3259,7 @@ func TestMarshal_FieldWithJSONOmitempty(t *testing.T) {
 // TestValidate_NestedPointerNil tests validation with nil nested pointer.
 func TestValidate_NestedPointerNil(t *testing.T) {
 	type Inner struct {
-		Value string `json:"value" pedantigo:"required"`
+		Value string `json:"value" validate:"required"`
 	}
 	type Outer struct {
 		Inner *Inner `json:"inner"`
@@ -3276,7 +3276,7 @@ func TestValidate_NestedPointerNil(t *testing.T) {
 // TestValidate_CacheNilField tests validation when cache field is nil.
 func TestValidate_CacheNilField(t *testing.T) {
 	type Model struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -3341,11 +3341,11 @@ func TestMarshal_NestedPointerStruct(t *testing.T) {
 func TestMarshal_ExtrasWithNestedPointer(t *testing.T) {
 	type Inner struct {
 		Value  string         `json:"value"`
-		Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any `json:"-" validate:"extra_fields"`
 	}
 	type Outer struct {
 		Inner  *Inner         `json:"inner"`
-		Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any `json:"-" validate:"extra_fields"`
 	}
 
 	v := New[Outer](ValidatorOptions{ExtraFields: ExtraAllow})
@@ -3364,7 +3364,7 @@ func TestMarshal_ExtrasWithNestedPointer(t *testing.T) {
 // TestSchemaJSON_NilDefCheck tests SchemaJSON with type that has definitions.
 func TestSchemaJSON_NilDefCheck(t *testing.T) {
 	type Inner struct {
-		ID string `json:"id" pedantigo:"required"`
+		ID string `json:"id" validate:"required"`
 	}
 	type Outer struct {
 		Items []Inner `json:"items"`
@@ -3381,7 +3381,7 @@ func TestSchemaJSON_NilDefCheck(t *testing.T) {
 // TestMarshalWithOptions_ValidStruct tests MarshalWithOptions with valid struct.
 func TestMarshalWithOptions_ValidStruct(t *testing.T) {
 	type Model struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	v := New[Model](DefaultValidatorOptions())
@@ -3416,7 +3416,7 @@ func TestUnion_PointerTypeVariant(t *testing.T) {
 // TestSchema_SliceOfPointers tests schema with slice of pointer structs.
 func TestSchema_SliceOfPointers(t *testing.T) {
 	type Item struct {
-		ID string `json:"id" pedantigo:"required,uuid"`
+		ID string `json:"id" validate:"required,uuid"`
 	}
 	type Container struct {
 		Items []*Item `json:"items"`
@@ -3431,8 +3431,8 @@ func TestSchema_SliceOfPointers(t *testing.T) {
 func TestUnion_VariantRequiredEmpty(t *testing.T) {
 	type RequiredVariant struct {
 		Type  string `json:"type"`
-		Name  string `json:"name" pedantigo:"required"`
-		Value int    `json:"value" pedantigo:"min=0"`
+		Name  string `json:"name" validate:"required"`
+		Value int    `json:"value" validate:"min=0"`
 	}
 
 	u, err := NewUnion[any](UnionOptions{
@@ -3451,8 +3451,8 @@ func TestUnion_VariantRequiredEmpty(t *testing.T) {
 // TestValidate_CrossFieldConstraintError tests eqfield constraint failure.
 func TestValidate_CrossFieldConstraintError(t *testing.T) {
 	type PasswordForm struct {
-		Password string `json:"password" pedantigo:"required,min=6"`
-		Confirm  string `json:"confirm" pedantigo:"required,eqfield=Password"`
+		Password string `json:"password" validate:"required,min=6"`
+		Confirm  string `json:"confirm" validate:"required,eqfield=Password"`
 	}
 
 	v := New[PasswordForm](DefaultValidatorOptions())
@@ -3502,7 +3502,7 @@ func TestSchemaJSON_CacheHitPath(t *testing.T) {
 // TestSchemaJSON_GenerateWithCachedSchema tests path where schema cached but not JSON.
 func TestSchemaJSON_GenerateWithCachedSchema(t *testing.T) {
 	type SchemaFirst struct {
-		Value int `json:"value" pedantigo:"min=0"`
+		Value int `json:"value" validate:"min=0"`
 	}
 
 	v := New[SchemaFirst](DefaultValidatorOptions())
@@ -3521,11 +3521,11 @@ func TestSchemaJSON_GenerateWithCachedSchema(t *testing.T) {
 func TestMarshalExtras_MapWithNestedStruct(t *testing.T) {
 	type Inner struct {
 		ID     string         `json:"id"`
-		Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any `json:"-" validate:"extra_fields"`
 	}
 	type Outer struct {
 		Items  map[string]*Inner `json:"items"`
-		Extras map[string]any    `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any    `json:"-" validate:"extra_fields"`
 	}
 
 	v := New[Outer](ValidatorOptions{ExtraFields: ExtraAllow})
@@ -3576,7 +3576,7 @@ func TestSchemaJSONOpenAPI_CacheHit(t *testing.T) {
 // TestSchemaJSONOpenAPI_WithCachedOpenAPI tests path where OpenAPI cached but not JSON.
 func TestSchemaJSONOpenAPI_WithCachedOpenAPI(t *testing.T) {
 	type OpenAPIFirst struct {
-		ID string `json:"id" pedantigo:"uuid"`
+		ID string `json:"id" validate:"uuid"`
 	}
 
 	v := New[OpenAPIFirst](DefaultValidatorOptions())
@@ -3609,11 +3609,11 @@ func TestFindTypeForDefinition_MapValueType(t *testing.T) {
 func TestMarshalWithExtras_SliceOfStructs(t *testing.T) {
 	type Item struct {
 		Name   string         `json:"name"`
-		Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any `json:"-" validate:"extra_fields"`
 	}
 	type Container struct {
 		Items  []Item         `json:"items"`
-		Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any `json:"-" validate:"extra_fields"`
 	}
 
 	v := New[Container](ValidatorOptions{ExtraFields: ExtraAllow})
@@ -3634,7 +3634,7 @@ func TestUnion_SplitTagsWithQuotedComma(t *testing.T) {
 	// Direct test of splitTags behavior via variant with complex tag
 	type ComplexVariant struct {
 		Type   string `json:"type"`
-		Status string `json:"status" pedantigo:"oneof=pending active done"`
+		Status string `json:"status" validate:"oneof=pending active done"`
 	}
 
 	u, err := NewUnion[any](UnionOptions{
@@ -3672,7 +3672,7 @@ func TestDict_WithNestedMap(t *testing.T) {
 // TestNewModel_WithMapData tests NewModel creates from map.
 func TestNewModel_WithMapData(t *testing.T) {
 	type User struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 		Age  int    `json:"age"`
 	}
 
@@ -3814,7 +3814,7 @@ func TestExtraAllow_JsonTagWithOptions(t *testing.T) {
 	type Item struct {
 		Name   string         `json:"name,omitempty"`
 		Active bool           `json:"active,omitempty"`
-		Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any `json:"-" validate:"extra_fields"`
 	}
 
 	v := New[Item](ValidatorOptions{ExtraFields: ExtraAllow})
@@ -3831,7 +3831,7 @@ func TestExtraAllow_JsonTagWithOptions(t *testing.T) {
 func TestExtraAllow_FieldWithNoJsonTag(t *testing.T) {
 	type Item struct {
 		Title  string         // No json tag, uses field name "Title"
-		Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any `json:"-" validate:"extra_fields"`
 	}
 
 	v := New[Item](ValidatorOptions{ExtraFields: ExtraAllow})
@@ -3861,8 +3861,8 @@ func TestValidateWithCache_NilCache(t *testing.T) {
 // TestValidate_CrossFieldErrorAsValidationError tests cross-field returns ValidationError.
 func TestValidate_CrossFieldErrorAsValidationError(t *testing.T) {
 	type Form struct {
-		Password        string `json:"password" pedantigo:"required,min=3"`
-		ConfirmPassword string `json:"confirm_password" pedantigo:"required,eqfield=Password"`
+		Password        string `json:"password" validate:"required,min=3"`
+		ConfirmPassword string `json:"confirm_password" validate:"required,eqfield=Password"`
 	}
 
 	v := New[Form](DefaultValidatorOptions())
@@ -3878,11 +3878,11 @@ func TestValidate_CrossFieldErrorAsValidationError(t *testing.T) {
 func TestMarshalExtras_NilSliceElement(t *testing.T) {
 	type Item struct {
 		Name   string         `json:"name"`
-		Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any `json:"-" validate:"extra_fields"`
 	}
 	type Container struct {
 		Items  []*Item        `json:"items"`
-		Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+		Extras map[string]any `json:"-" validate:"extra_fields"`
 	}
 
 	v := New[Container](ValidatorOptions{ExtraFields: ExtraAllow})
@@ -3902,7 +3902,7 @@ func TestMarshalExtras_NilSliceElement(t *testing.T) {
 func TestUnion_SplitTagsQuotedComma(t *testing.T) {
 	type QuotedVariant struct {
 		Type    string `json:"type"`
-		Pattern string `json:"pattern" pedantigo:"oneof=\"red,green\",\"blue\""`
+		Pattern string `json:"pattern" validate:"oneof=\"red,green\",\"blue\""`
 	}
 
 	u, err := NewUnion[any](UnionOptions{
@@ -3925,7 +3925,7 @@ func TestUnion_SplitTagsQuotedComma(t *testing.T) {
 func TestUnion_PointerVariantType(t *testing.T) {
 	type UserVariant struct {
 		Type string `json:"type"`
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	// Create union with pointer to variant
@@ -3948,7 +3948,7 @@ func TestUnion_PointerVariantType(t *testing.T) {
 func TestUnion_VariantUnexportedFieldSkipped(t *testing.T) {
 	type VariantWithUnexported struct {
 		Type     string `json:"type"`
-		Name     string `json:"name" pedantigo:"required"`
+		Name     string `json:"name" validate:"required"`
 		internal string //nolint:unused // unexported, should be skipped
 	}
 
@@ -3981,9 +3981,9 @@ func TestUnmarshalCtx_BadJSON(t *testing.T) {
 // TestStructPartial_WithExtraAllow tests StructPartial with ExtraAllow mode.
 func TestStructPartial_WithExtraAllow(t *testing.T) {
 	type Item struct {
-		Name   string         `json:"name" pedantigo:"required"`
-		Value  int            `json:"value" pedantigo:"min=0"`
-		Extras map[string]any `json:"-" pedantigo:"extra_fields"`
+		Name   string         `json:"name" validate:"required"`
+		Value  int            `json:"value" validate:"min=0"`
+		Extras map[string]any `json:"-" validate:"extra_fields"`
 	}
 
 	v := New[Item](ValidatorOptions{ExtraFields: ExtraAllow})
@@ -4041,7 +4041,7 @@ func TestUnion_EmptyDiscriminatorField(t *testing.T) {
 // TestValidate_NonPointerStruct tests Validate with non-pointer struct.
 func TestValidate_NonPointerStruct(t *testing.T) {
 	type Simple struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	v := New[Simple](DefaultValidatorOptions())
@@ -4110,7 +4110,7 @@ func TestSchemaJSONOpenAPI_CachePathTest(t *testing.T) {
 // TestUnmarshalCtx_WithValidData tests UnmarshalCtx success path.
 func TestUnmarshalCtx_WithValidData(t *testing.T) {
 	type Simple struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	v := New[Simple](DefaultValidatorOptions())
@@ -4226,7 +4226,7 @@ func TestUnion_StringVariantTypeNonStruct(t *testing.T) {
 // TestSchema_CacheThenJSON tests calling Schema() then SchemaJSON() uses cached schema.
 func TestSchema_CacheThenJSON(t *testing.T) {
 	type CacheTestStruct struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	v := New[CacheTestStruct]()
@@ -4243,7 +4243,7 @@ func TestSchema_CacheThenJSON(t *testing.T) {
 // TestSchemaOpenAPI_ThenSchemaJSONOpenAPI tests cache path for OpenAPI schemas.
 func TestSchemaOpenAPI_CacheThenJSON(t *testing.T) {
 	type OpenAPICacheStruct struct {
-		ID int `json:"id" pedantigo:"min=1"`
+		ID int `json:"id" validate:"min=1"`
 	}
 
 	v := New[OpenAPICacheStruct]()
@@ -4261,7 +4261,7 @@ func TestSchemaOpenAPI_CacheThenJSON(t *testing.T) {
 // This covers findTypeForDefinition pointer handling (lines 260-262).
 func TestSchemaOpenAPI_WithNestedPointerTypes(t *testing.T) {
 	type InnerPointer struct {
-		Value string `json:"value" pedantigo:"required"`
+		Value string `json:"value" validate:"required"`
 	}
 	type OuterPointerStruct struct {
 		Inner *InnerPointer `json:"inner"`
@@ -4278,7 +4278,7 @@ func TestSchemaOpenAPI_WithNestedPointerTypes(t *testing.T) {
 // This helps cover searchSliceType (lines 313-327).
 func TestSchemaOpenAPI_WithSliceOfStructs(t *testing.T) {
 	type ItemStruct struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 	type ContainerSlice struct {
 		Items []ItemStruct `json:"items"`
@@ -4293,7 +4293,7 @@ func TestSchemaOpenAPI_WithSliceOfStructs(t *testing.T) {
 // This helps cover searchMapType (lines 330-343).
 func TestSchemaOpenAPI_WithMapOfStructs(t *testing.T) {
 	type MapValueStruct struct {
-		Data int `json:"data" pedantigo:"min=0"`
+		Data int `json:"data" validate:"min=0"`
 	}
 	type ContainerMap struct {
 		Lookup map[string]MapValueStruct `json:"lookup"`
@@ -4327,7 +4327,7 @@ func TestUnmarshal_BadJSON_NoStrictFields(t *testing.T) {
 // TestUnmarshal_ValidJSON_NoStrictFields tests valid JSON with StrictMissingFields=false.
 func TestUnmarshal_ValidJSON_NoStrictFields(t *testing.T) {
 	type SimpleStructNoStrict struct {
-		Value int `json:"value" pedantigo:"min=1"`
+		Value int `json:"value" validate:"min=1"`
 	}
 
 	v := New[SimpleStructNoStrict](ValidatorOptions{

--- a/stream_test.go
+++ b/stream_test.go
@@ -10,9 +10,9 @@ import (
 
 // StreamTestUser is a test struct for streaming tests.
 type StreamTestUser struct {
-	Name  string `json:"name" pedantigo:"required"`
-	Email string `json:"email" pedantigo:"email"`
-	Age   int    `json:"age" pedantigo:"min=0"`
+	Name  string `json:"name" validate:"required"`
+	Email string `json:"email" validate:"email"`
+	Age   int    `json:"age" validate:"min=0"`
 }
 
 // NestedStreamTest is a test struct with nested fields.
@@ -23,8 +23,8 @@ type NestedStreamTest struct {
 
 // Address is a nested struct for testing.
 type Address struct {
-	Street string `json:"street" pedantigo:"required"`
-	City   string `json:"city" pedantigo:"required"`
+	Street string `json:"street" validate:"required"`
+	City   string `json:"city" validate:"required"`
 }
 
 // ==================== Parser Creation Tests ====================

--- a/union.go
+++ b/union.go
@@ -38,7 +38,7 @@ type UnionOptions struct {
 // Stub: not yet implemented.
 type UnionValidator[T any] struct {
 	options  UnionOptions
-	tagName  string                  // Resolved tag name (global or "pedantigo")
+	tagName  string                  // Resolved tag name (global or "validate")
 	variants map[string]reflect.Type // discriminator value -> variant type
 }
 

--- a/union.go
+++ b/union.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/invopop/jsonschema"
 
-	"github.com/SmrutAI/pedantigo/internal/constraints"
-	"github.com/SmrutAI/pedantigo/internal/schemagen"
+	"github.com/SmrutAI/pedantigo/v2/internal/constraints"
+	"github.com/SmrutAI/pedantigo/v2/internal/schemagen"
 )
 
 // UnionVariant represents a variant type in a discriminated union.

--- a/union_test.go
+++ b/union_test.go
@@ -19,20 +19,20 @@ const (
 
 // Cat represents a cat variant in the pet union.
 type Cat struct {
-	Name  string `json:"name" pedantigo:"required"`
-	Lives int    `json:"lives" pedantigo:"min=1,max=9"`
+	Name  string `json:"name" validate:"required"`
+	Lives int    `json:"lives" validate:"min=1,max=9"`
 }
 
 // Dog represents a dog variant in the pet union.
 type Dog struct {
-	Name  string `json:"name" pedantigo:"required"`
+	Name  string `json:"name" validate:"required"`
 	Breed string `json:"breed"`
 }
 
 // Bird represents a bird variant in the pet union.
 type Bird struct {
-	Name string `json:"name" pedantigo:"required"`
-	Eggs int    `json:"eggs" pedantigo:"min=0"`
+	Name string `json:"name" validate:"required"`
+	Eggs int    `json:"eggs" validate:"min=0"`
 }
 
 // Pet is the union container type (for type parameter T).
@@ -1137,7 +1137,7 @@ func TestUnionValidator_Schema_VariantConstraintsApplied(t *testing.T) {
 	require.NotNil(t, catSchema, "cat schema should exist")
 	require.NotNil(t, catSchema.Properties)
 
-	// Check that name is in required (from pedantigo:"required")
+	// Check that name is in required (from validate:"required")
 	// and lives has min/max constraints
 	livesSchema, ok := catSchema.Properties.Get("lives")
 	require.True(t, ok, "lives property should exist")

--- a/validator.go
+++ b/validator.go
@@ -12,10 +12,10 @@ import (
 
 	"github.com/invopop/jsonschema"
 
-	"github.com/SmrutAI/pedantigo/internal/constraints"
-	"github.com/SmrutAI/pedantigo/internal/deserialize"
-	"github.com/SmrutAI/pedantigo/internal/serialize"
-	"github.com/SmrutAI/pedantigo/internal/tags"
+	"github.com/SmrutAI/pedantigo/v2/internal/constraints"
+	"github.com/SmrutAI/pedantigo/v2/internal/deserialize"
+	"github.com/SmrutAI/pedantigo/v2/internal/serialize"
+	"github.com/SmrutAI/pedantigo/v2/internal/tags"
 )
 
 // Validator validates structs of type T.

--- a/validator_partial_test.go
+++ b/validator_partial_test.go
@@ -5,10 +5,10 @@ import (
 )
 
 type PartialTestUser struct {
-	Email    string `json:"email" pedantigo:"required,email"`
-	Name     string `json:"name" pedantigo:"required,min=2"`
-	Age      int    `json:"age" pedantigo:"min=18"`
-	Password string `json:"password" pedantigo:"required,min=8"`
+	Email    string `json:"email" validate:"required,email"`
+	Name     string `json:"name" validate:"required,min=2"`
+	Age      int    `json:"age" validate:"min=18"`
+	Password string `json:"password" validate:"required,min=8"`
 }
 
 func TestValidator_StructPartial(t *testing.T) {

--- a/validator_test.go
+++ b/validator_test.go
@@ -22,7 +22,7 @@ const testMsgIsRequired = "is required"
 // TestValidator_Required_Present tests Validator required present.
 func TestValidator_Required_Present(t *testing.T) {
 	type User struct {
-		Email string `pedantigo:"required"`
+		Email string `validate:"required"`
 	}
 
 	validator := New[User]()
@@ -34,7 +34,7 @@ func TestValidator_Required_Present(t *testing.T) {
 
 func TestValidator_Min_BelowMinimum(t *testing.T) {
 	type User struct {
-		Age int `pedantigo:"min=18"`
+		Age int `validate:"min=18"`
 	}
 
 	validator := New[User]()
@@ -46,7 +46,7 @@ func TestValidator_Min_BelowMinimum(t *testing.T) {
 
 func TestValidator_Min_AtMinimum(t *testing.T) {
 	type User struct {
-		Age int `pedantigo:"min=18"`
+		Age int `validate:"min=18"`
 	}
 
 	validator := New[User]()
@@ -58,7 +58,7 @@ func TestValidator_Min_AtMinimum(t *testing.T) {
 
 func TestValidator_Max_AboveMaximum(t *testing.T) {
 	type User struct {
-		Age int `pedantigo:"max=120"`
+		Age int `validate:"max=120"`
 	}
 
 	validator := New[User]()
@@ -70,7 +70,7 @@ func TestValidator_Max_AboveMaximum(t *testing.T) {
 
 func TestValidator_Max_AtMaximum(t *testing.T) {
 	type User struct {
-		Age int `pedantigo:"max=120"`
+		Age int `validate:"max=120"`
 	}
 
 	validator := New[User]()
@@ -82,7 +82,7 @@ func TestValidator_Max_AtMaximum(t *testing.T) {
 
 func TestValidator_MinMax_InRange(t *testing.T) {
 	type User struct {
-		Age int `pedantigo:"min=18,max=120"`
+		Age int `validate:"min=18,max=120"`
 	}
 
 	validator := New[User]()
@@ -94,8 +94,8 @@ func TestValidator_MinMax_InRange(t *testing.T) {
 
 // Test type for cross-field validation.
 type testPasswordChange struct {
-	Password string `pedantigo:"required"`
-	Confirm  string `pedantigo:"required"`
+	Password string `validate:"required"`
+	Confirm  string `validate:"required"`
 }
 
 func (vpc *testPasswordChange) Validate() error {
@@ -137,9 +137,9 @@ func TestValidator_CrossField_PasswordConfirmation(t *testing.T) {
 // TestMarshal_Valid verifies that Marshal returns JSON for valid structs.
 func TestMarshal_Valid(t *testing.T) {
 	type User struct {
-		Name  string `json:"name" pedantigo:"min=2"`
-		Email string `json:"email" pedantigo:"email"`
-		Age   int    `json:"age" pedantigo:"min=18,max=120"`
+		Name  string `json:"name" validate:"min=2"`
+		Email string `json:"email" validate:"email"`
+		Age   int    `json:"age" validate:"min=18,max=120"`
 	}
 
 	validator := New[User]()
@@ -164,9 +164,9 @@ func TestMarshal_Valid(t *testing.T) {
 // TestMarshal_Invalid verifies that Marshal returns validation errors for invalid structs.
 func TestMarshal_Invalid(t *testing.T) {
 	type User struct {
-		Name  string `json:"name" pedantigo:"min=2"`
-		Email string `json:"email" pedantigo:"email"`
-		Age   int    `json:"age" pedantigo:"min=18"`
+		Name  string `json:"name" validate:"min=2"`
+		Email string `json:"email" validate:"email"`
+		Age   int    `json:"age" validate:"min=18"`
 	}
 
 	validator := New[User]()
@@ -202,7 +202,7 @@ func TestMarshal_Invalid(t *testing.T) {
 // TestMarshal_Nil verifies that Marshal handles nil pointer appropriately.
 func TestMarshal_Nil(t *testing.T) {
 	type User struct {
-		Name string `json:"name" pedantigo:"min=2"`
+		Name string `json:"name" validate:"min=2"`
 	}
 
 	validator := New[User]()
@@ -226,8 +226,8 @@ func TestMarshal_Nil(t *testing.T) {
 // TestUnmarshal_ValidJSON tests Unmarshal validjson.
 func TestUnmarshal_ValidJSON(t *testing.T) {
 	type User struct {
-		Email string `json:"email" pedantigo:"required"`
-		Age   int    `json:"age" pedantigo:"min=18"`
+		Email string `json:"email" validate:"required"`
+		Age   int    `json:"age" validate:"min=18"`
 	}
 
 	validator := New[User]()
@@ -243,7 +243,7 @@ func TestUnmarshal_ValidJSON(t *testing.T) {
 
 func TestUnmarshal_InvalidJSON(t *testing.T) {
 	type User struct {
-		Email string `json:"email" pedantigo:"required"`
+		Email string `json:"email" validate:"required"`
 	}
 
 	validator := New[User]()
@@ -256,8 +256,8 @@ func TestUnmarshal_InvalidJSON(t *testing.T) {
 
 func TestUnmarshal_ValidationError(t *testing.T) {
 	type User struct {
-		Email string `json:"email" pedantigo:"required,email"`
-		Age   int    `json:"age" pedantigo:"min=18"`
+		Email string `json:"email" validate:"required,email"`
+		Age   int    `json:"age" validate:"min=18"`
 	}
 
 	validator := New[User]()
@@ -297,9 +297,9 @@ func TestUnmarshal_ValidationError(t *testing.T) {
 
 func TestUnmarshal_DefaultValues(t *testing.T) {
 	type User struct {
-		Email  string `json:"email" pedantigo:"required"`
-		Role   string `json:"role" pedantigo:"default=user"`
-		Status string `json:"status" pedantigo:"default=active"`
+		Email  string `json:"email" validate:"required"`
+		Role   string `json:"role" validate:"default=user"`
+		Status string `json:"status" validate:"default=active"`
 	}
 
 	validator := New[User]()
@@ -318,8 +318,8 @@ func TestUnmarshal_DefaultValues(t *testing.T) {
 // fields inside nested structs during Unmarshal. Regression test for #17.
 func TestUnmarshal_NestedStructDefaults(t *testing.T) {
 	type FactConfig struct {
-		MaxPasses int `json:"max_passes" pedantigo:"default=1,gte=0,lte=5"`
-		MaxTokens int `json:"max_tokens" pedantigo:"default=2048,gte=100,lte=16384"`
+		MaxPasses int `json:"max_passes" validate:"default=1,gte=0,lte=5"`
+		MaxTokens int `json:"max_tokens" validate:"default=2048,gte=100,lte=16384"`
 	}
 
 	type ExtractionConfig struct {
@@ -327,8 +327,8 @@ func TestUnmarshal_NestedStructDefaults(t *testing.T) {
 	}
 
 	type CreateAppRequest struct {
-		Name             string            `json:"name" pedantigo:"required,min=1,max=255"`
-		ExtractionConfig *ExtractionConfig `json:"extraction_config,omitempty" pedantigo:"omitempty"`
+		Name             string            `json:"name" validate:"required,min=1,max=255"`
+		ExtractionConfig *ExtractionConfig `json:"extraction_config,omitempty" validate:"omitempty"`
 	}
 
 	t.Run("top-level defaults work", func(t *testing.T) {
@@ -397,14 +397,14 @@ func TestUnmarshal_NestedStructDefaults(t *testing.T) {
 	t.Run("deeply nested struct defaults", func(t *testing.T) {
 		// Non-pointer nested struct (direct embedding)
 		type Inner struct {
-			Timeout int    `json:"timeout" pedantigo:"default=30"`
-			Mode    string `json:"mode" pedantigo:"default=auto"`
+			Timeout int    `json:"timeout" validate:"default=30"`
+			Mode    string `json:"mode" validate:"default=auto"`
 		}
 		type Middle struct {
 			Inner Inner `json:"inner"`
 		}
 		type Outer struct {
-			Name   string `json:"name" pedantigo:"required"`
+			Name   string `json:"name" validate:"required"`
 			Middle Middle `json:"middle"`
 		}
 
@@ -425,11 +425,11 @@ func TestUnmarshal_NestedStructDefaults(t *testing.T) {
 
 func TestUnmarshal_NestedValidation(t *testing.T) {
 	type Address struct {
-		City string `json:"city" pedantigo:"required,min=1"` // min=1 for non-empty string
+		City string `json:"city" validate:"required,min=1"` // min=1 for non-empty string
 	}
 
 	type User struct {
-		Email   string  `json:"email" pedantigo:"required"`
+		Email   string  `json:"email" validate:"required"`
 		Address Address `json:"address"`
 	}
 
@@ -546,7 +546,7 @@ func TestPointer_Missing(t *testing.T) {
 // TestPointer_RequiredWithValue tests Pointer requiredwithvalue.
 func TestPointer_RequiredWithValue(t *testing.T) {
 	type User struct {
-		Name *string `json:"name" pedantigo:"required"`
+		Name *string `json:"name" validate:"required"`
 	}
 
 	validator := New[User]()
@@ -563,7 +563,7 @@ func TestPointer_RequiredWithValue(t *testing.T) {
 // TestPointer_RequiredMissing tests Pointer requiredmissing.
 func TestPointer_RequiredMissing(t *testing.T) {
 	type User struct {
-		Name *string `json:"name" pedantigo:"required"`
+		Name *string `json:"name" validate:"required"`
 	}
 
 	validator := New[User]()
@@ -590,7 +590,7 @@ func TestPointer_RequiredMissing(t *testing.T) {
 // TestPointer_RequiredWithNull tests Pointer requiredwithnull.
 func TestPointer_RequiredWithNull(t *testing.T) {
 	type User struct {
-		Name *string `json:"name" pedantigo:"required"`
+		Name *string `json:"name" validate:"required"`
 	}
 
 	validator := New[User]()
@@ -607,7 +607,7 @@ func TestPointer_RequiredWithNull(t *testing.T) {
 // TestPointer_WithDefault tests Pointer withdefault.
 func TestPointer_WithDefault(t *testing.T) {
 	type Config struct {
-		Port *int `json:"port" pedantigo:"default=8080"`
+		Port *int `json:"port" validate:"default=8080"`
 	}
 
 	validator := New[Config]()
@@ -625,7 +625,7 @@ func TestPointer_WithDefault(t *testing.T) {
 // TestPointer_ExplicitZeroWithDefault tests Pointer explicitzerowithdefault.
 func TestPointer_ExplicitZeroWithDefault(t *testing.T) {
 	type Config struct {
-		Port *int `json:"port" pedantigo:"default=8080"`
+		Port *int `json:"port" validate:"default=8080"`
 	}
 
 	validator := New[Config]()
@@ -672,9 +672,9 @@ func TestPointer_NestedStruct(t *testing.T) {
 // Test type for defaultUsingMethod
 // UserWithTimestamp represents the data structure.
 type UserWithTimestamp struct {
-	Email     string    `json:"email" pedantigo:"required"`
-	Role      string    `json:"role" pedantigo:"default=user"`
-	CreatedAt time.Time `json:"created_at" pedantigo:"defaultUsingMethod=SetCreationTime"`
+	Email     string    `json:"email" validate:"required"`
+	Role      string    `json:"role" validate:"default=user"`
+	CreatedAt time.Time `json:"created_at" validate:"defaultUsingMethod=SetCreationTime"`
 }
 
 // Method that provides dynamic default value
@@ -688,7 +688,7 @@ func (u *UserWithTimestamp) SetCreationTime() (time.Time, error) {
 // InvalidMethodType represents the data structure.
 type InvalidMethodType struct {
 	Email     string    `json:"email"`
-	CreatedAt time.Time `json:"created_at" pedantigo:"defaultUsingMethod=WrongSignature"`
+	CreatedAt time.Time `json:"created_at" validate:"defaultUsingMethod=WrongSignature"`
 }
 
 // Wrong signature: returns only value, no error
@@ -701,7 +701,7 @@ func (i *InvalidMethodType) WrongSignature() time.Time {
 // NonExistentMethodType represents the data structure.
 type NonExistentMethodType struct {
 	Email     string    `json:"email"`
-	CreatedAt time.Time `json:"created_at" pedantigo:"defaultUsingMethod=DoesNotExist"`
+	CreatedAt time.Time `json:"created_at" validate:"defaultUsingMethod=DoesNotExist"`
 }
 
 // TestDeserializer_UnmarshalBehavior validates deserializer behavior across various scenarios:
@@ -709,14 +709,14 @@ type NonExistentMethodType struct {
 // TestDeserializer_UnmarshalBehavior tests Deserializer unmarshalbehavior.
 func TestDeserializer_UnmarshalBehavior(t *testing.T) {
 	type Config struct {
-		Name    string `json:"name" pedantigo:"required"`
-		Port    int    `json:"port" pedantigo:"default=8080"`
-		Timeout int    `json:"timeout" pedantigo:"default=30"`
+		Name    string `json:"name" validate:"required"`
+		Port    int    `json:"port" validate:"default=8080"`
+		Timeout int    `json:"timeout" validate:"default=30"`
 	}
 
 	type Settings struct {
-		Name   string `json:"name" pedantigo:"required"`
-		Active bool   `json:"active" pedantigo:"required"`
+		Name   string `json:"name" validate:"required"`
+		Active bool   `json:"active" validate:"required"`
 	}
 
 	tests := []struct {
@@ -841,8 +841,8 @@ func TestDeserializer_UnmarshalBehavior(t *testing.T) {
 			jsonData: []byte(`{"name":"myapp","age":0}`),
 			validatorFn: func() (any, error) {
 				type Profile struct {
-					Name string `json:"name" pedantigo:"required"`
-					Age  int    `json:"age" pedantigo:"min=1"`
+					Name string `json:"name" validate:"required"`
+					Age  int    `json:"age" validate:"min=1"`
 				}
 				v := New[Profile](ValidatorOptions{StrictMissingFields: false})
 				return v.Unmarshal([]byte(`{"name":"myapp","age":0}`))
@@ -930,9 +930,9 @@ func TestDeserializer_ValidatorSetup(t *testing.T) {
 // TestValidatorOptions_StrictMissingFields tests ValidatorOptions strictmissingfields.
 func TestValidatorOptions_StrictMissingFields(t *testing.T) {
 	type User struct {
-		Name  string `json:"name" pedantigo:"required,min=2"`
-		Email string `json:"email" pedantigo:"required,email"`
-		Age   int    `json:"age" pedantigo:"required,min=18"`
+		Name  string `json:"name" validate:"required,min=2"`
+		Email string `json:"email" validate:"required,email"`
+		Age   int    `json:"age" validate:"required,min=18"`
 	}
 
 	tests := []struct {
@@ -1012,9 +1012,9 @@ func TestValidatorOptions_StrictMissingFields(t *testing.T) {
 // TestValidatorOptions_PointerFields tests ValidatorOptions pointerfields.
 func TestValidatorOptions_PointerFields(t *testing.T) {
 	type Settings struct {
-		Port    *int   `json:"port" pedantigo:"min=1024"`
+		Port    *int   `json:"port" validate:"min=1024"`
 		Enabled *bool  `json:"enabled"`
-		Name    string `json:"name" pedantigo:"min=3"`
+		Name    string `json:"name" validate:"min=3"`
 	}
 
 	tests := []struct {
@@ -1157,7 +1157,7 @@ func TestValidatorOptions_PanicOnIncompatibleTags(t *testing.T) {
 			switch tt.testCase {
 			case "single_default":
 				type Settings struct {
-					Theme    string `json:"theme" pedantigo:"default=dark"`
+					Theme    string `json:"theme" validate:"default=dark"`
 					Language string `json:"language"`
 				}
 				_ = New[Settings](ValidatorOptions{
@@ -1166,9 +1166,9 @@ func TestValidatorOptions_PanicOnIncompatibleTags(t *testing.T) {
 
 			case "multiple_defaults":
 				type Config struct {
-					Name    string `json:"name" pedantigo:"default=unnamed"`
-					Port    int    `json:"port" pedantigo:"default=8080"`
-					Enabled bool   `json:"enabled" pedantigo:"default=true"`
+					Name    string `json:"name" validate:"default=unnamed"`
+					Port    int    `json:"port" validate:"default=8080"`
+					Enabled bool   `json:"enabled" validate:"default=true"`
 				}
 				_ = New[Config](ValidatorOptions{
 					StrictMissingFields: false,
@@ -1176,7 +1176,7 @@ func TestValidatorOptions_PanicOnIncompatibleTags(t *testing.T) {
 
 			case "default_using_method":
 				type Product struct {
-					ID   string `json:"id" pedantigo:"defaultUsingMethod=GenerateID"`
+					ID   string `json:"id" validate:"defaultUsingMethod=GenerateID"`
 					Name string `json:"name"`
 				}
 				_ = New[Product](ValidatorOptions{
@@ -1368,7 +1368,7 @@ func TestValidator_Dict_UnmarshalableType(t *testing.T) {
 // TestExtraFields_DefaultBehavior tests that default behavior ignores unknown fields.
 func TestExtraFields_DefaultBehavior(t *testing.T) {
 	type User struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	// Default options (ExtraIgnore)
@@ -1385,7 +1385,7 @@ func TestExtraFields_DefaultBehavior(t *testing.T) {
 // TestExtraFields_Ignore tests ExtraIgnore explicitly ignores unknown fields.
 func TestExtraFields_Ignore(t *testing.T) {
 	type User struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	validator := New[User](ValidatorOptions{
@@ -1404,7 +1404,7 @@ func TestExtraFields_Ignore(t *testing.T) {
 // TestExtraFields_Forbid tests ExtraForbid rejects unknown fields.
 func TestExtraFields_Forbid(t *testing.T) {
 	type User struct {
-		Name string `json:"name" pedantigo:"required"`
+		Name string `json:"name" validate:"required"`
 	}
 
 	validator := New[User](ValidatorOptions{
@@ -1465,10 +1465,10 @@ func TestExtraFields_Forbid(t *testing.T) {
 // TestExtraFields_Forbid_NestedStruct tests ExtraForbid with nested structs.
 func TestExtraFields_Forbid_NestedStruct(t *testing.T) {
 	type Address struct {
-		City string `json:"city" pedantigo:"required"`
+		City string `json:"city" validate:"required"`
 	}
 	type User struct {
-		Name    string  `json:"name" pedantigo:"required"`
+		Name    string  `json:"name" validate:"required"`
 		Address Address `json:"address"`
 	}
 
@@ -1551,21 +1551,21 @@ func TestExtraFields_Forbid_WithStrictMissingFieldsFalse(t *testing.T) {
 
 // Test types for marshal options.
 type UserWithSensitiveData struct {
-	ID       int    `json:"id" pedantigo:"min=1"`
-	Name     string `json:"name" pedantigo:"min=2"`
-	Email    string `json:"email" pedantigo:"email"`
-	Password string `json:"password" pedantigo:"exclude:response,log,min=8"`
-	Token    string `json:"token" pedantigo:"exclude:log"`
-	Port     int    `json:"port" pedantigo:"omitzero"`
-	Debug    bool   `json:"debug" pedantigo:"omitzero"`
+	ID       int    `json:"id" validate:"min=1"`
+	Name     string `json:"name" validate:"min=2"`
+	Email    string `json:"email" validate:"email"`
+	Password string `json:"password" validate:"exclude:response,log,min=8"`
+	Token    string `json:"token" validate:"exclude:log"`
+	Port     int    `json:"port" validate:"omitzero"`
+	Debug    bool   `json:"debug" validate:"omitzero"`
 }
 
 func TestValidator_MarshalWithOptions_ExcludeContext(t *testing.T) {
 	type User struct {
 		ID       int    `json:"id"`
 		Name     string `json:"name"`
-		Password string `json:"password" pedantigo:"exclude:response"`
-		Token    string `json:"token" pedantigo:"exclude:log"`
+		Password string `json:"password" validate:"exclude:response"`
+		Token    string `json:"token" validate:"exclude:log"`
 	}
 
 	validator := New[User]()
@@ -1618,9 +1618,9 @@ func TestValidator_MarshalWithOptions_ExcludeContext(t *testing.T) {
 
 func TestValidator_MarshalWithOptions_OmitZero(t *testing.T) {
 	type Config struct {
-		Name    string `json:"name" pedantigo:"min=2"`
-		Port    int    `json:"port" pedantigo:"omitzero"`
-		Timeout int    `json:"timeout" pedantigo:"omitzero"`
+		Name    string `json:"name" validate:"min=2"`
+		Port    int    `json:"port" validate:"omitzero"`
+		Timeout int    `json:"timeout" validate:"omitzero"`
 		Retries int    `json:"retries"`
 	}
 
@@ -1740,9 +1740,9 @@ func TestValidator_MarshalWithOptions_CombinedExcludeAndOmitZero(t *testing.T) {
 
 func TestValidator_MarshalWithOptions_ValidationErrors(t *testing.T) {
 	type User struct {
-		Name  string `json:"name" pedantigo:"min=2"`
-		Email string `json:"email" pedantigo:"email"`
-		Age   int    `json:"age" pedantigo:"min=18"`
+		Name  string `json:"name" validate:"min=2"`
+		Email string `json:"email" validate:"email"`
+		Age   int    `json:"age" validate:"min=18"`
 	}
 
 	validator := New[User]()
@@ -1769,8 +1769,8 @@ func TestValidator_MarshalWithOptions_ValidationErrors(t *testing.T) {
 func TestValidator_MarshalWithOptions_PointerFields(t *testing.T) {
 	type Config struct {
 		Name    string `json:"name"`
-		Port    *int   `json:"port" pedantigo:"omitzero"`
-		Enabled *bool  `json:"enabled" pedantigo:"omitzero"`
+		Port    *int   `json:"port" validate:"omitzero"`
+		Enabled *bool  `json:"enabled" validate:"omitzero"`
 	}
 
 	validator := New[Config]()
@@ -1821,12 +1821,12 @@ func TestValidator_MarshalWithOptions_NestedStructs(t *testing.T) {
 	type Address struct {
 		Street     string `json:"street"`
 		City       string `json:"city"`
-		PostalCode string `json:"postal_code" pedantigo:"exclude:summary"`
+		PostalCode string `json:"postal_code" validate:"exclude:summary"`
 	}
 
 	type User struct {
 		Name     string  `json:"name"`
-		Password string  `json:"password" pedantigo:"exclude:response"`
+		Password string  `json:"password" validate:"exclude:response"`
 		Address  Address `json:"address"`
 	}
 
@@ -1880,9 +1880,9 @@ func TestValidator_MarshalWithOptions_NestedStructs(t *testing.T) {
 
 func TestValidator_Marshal_BackwardCompatible(t *testing.T) {
 	type User struct {
-		ID       int    `json:"id" pedantigo:"min=1"`
-		Name     string `json:"name" pedantigo:"min=2"`
-		Password string `json:"password" pedantigo:"exclude:response"`
+		ID       int    `json:"id" validate:"min=1"`
+		Name     string `json:"name" validate:"min=2"`
+		Password string `json:"password" validate:"exclude:response"`
 	}
 
 	validator := New[User]()
@@ -1928,7 +1928,7 @@ func TestValidator_MarshalWithOptions_MultipleExclusionContexts(t *testing.T) {
 	type User struct {
 		ID       int    `json:"id"`
 		Name     string `json:"name"`
-		Password string `json:"password" pedantigo:"exclude:response|log|audit"`
+		Password string `json:"password" validate:"exclude:response|log|audit"`
 	}
 
 	validator := New[User]()
@@ -1959,8 +1959,8 @@ func TestValidator_MarshalWithOptions_MultipleExclusionContexts(t *testing.T) {
 // TestNewModel_JSON tests NewModel with JSON byte input.
 func TestNewModel_JSON(t *testing.T) {
 	type User struct {
-		Name  string `json:"name" pedantigo:"required"`
-		Email string `json:"email" pedantigo:"required,email"`
+		Name  string `json:"name" validate:"required"`
+		Email string `json:"email" validate:"required,email"`
 	}
 
 	validator := New[User]()
@@ -1974,8 +1974,8 @@ func TestNewModel_JSON(t *testing.T) {
 // TestNewModel_Struct tests NewModel with struct input.
 func TestNewModel_Struct(t *testing.T) {
 	type User struct {
-		Name  string `json:"name" pedantigo:"required,min=2"`
-		Email string `json:"email" pedantigo:"email"`
+		Name  string `json:"name" validate:"required,min=2"`
+		Email string `json:"email" validate:"email"`
 	}
 
 	validator := New[User]()
@@ -1989,8 +1989,8 @@ func TestNewModel_Struct(t *testing.T) {
 // TestNewModel_StructPointer tests NewModel with pointer to struct input.
 func TestNewModel_StructPointer(t *testing.T) {
 	type User struct {
-		Name  string `json:"name" pedantigo:"required,min=2"`
-		Email string `json:"email" pedantigo:"email"`
+		Name  string `json:"name" validate:"required,min=2"`
+		Email string `json:"email" validate:"email"`
 	}
 
 	validator := New[User]()
@@ -2005,9 +2005,9 @@ func TestNewModel_StructPointer(t *testing.T) {
 // TestNewModel_Map tests NewModel with map[string]any input (kwargs).
 func TestNewModel_Map(t *testing.T) {
 	type User struct {
-		Name  string `json:"name" pedantigo:"required"`
-		Email string `json:"email" pedantigo:"required,email"`
-		Age   int    `json:"age" pedantigo:"min=18"`
+		Name  string `json:"name" validate:"required"`
+		Email string `json:"email" validate:"required,email"`
+		Age   int    `json:"age" validate:"min=18"`
 	}
 
 	validator := New[User]()
@@ -2026,8 +2026,8 @@ func TestNewModel_Map(t *testing.T) {
 // TestNewModel_MapWithDefaults tests NewModel with map input using defaults.
 func TestNewModel_MapWithDefaults(t *testing.T) {
 	type Config struct {
-		Host string `json:"host" pedantigo:"default=localhost"`
-		Port int    `json:"port" pedantigo:"default=8080"`
+		Host string `json:"host" validate:"default=localhost"`
+		Port int    `json:"port" validate:"default=8080"`
 	}
 
 	validator := New[Config]()
@@ -2042,8 +2042,8 @@ func TestNewModel_MapWithDefaults(t *testing.T) {
 // TestNewModel_ValidationError tests NewModel returns validation errors.
 func TestNewModel_ValidationError(t *testing.T) {
 	type User struct {
-		Name  string `json:"name" pedantigo:"required,min=2"`
-		Email string `json:"email" pedantigo:"required,email"`
+		Name  string `json:"name" validate:"required,min=2"`
+		Email string `json:"email" validate:"required,email"`
 	}
 
 	validator := New[User]()
@@ -2098,7 +2098,7 @@ func TestNewModel_NilPointer(t *testing.T) {
 // TestStringTransformations_StripWhitespace tests strip_whitespace during Unmarshal.
 func TestStringTransformations_StripWhitespace(t *testing.T) {
 	type User struct {
-		Name string `json:"name" pedantigo:"strip_whitespace"`
+		Name string `json:"name" validate:"strip_whitespace"`
 	}
 
 	validator := New[User]()
@@ -2152,7 +2152,7 @@ func TestStringTransformations_StripWhitespace(t *testing.T) {
 // TestStringTransformations_ToLower tests to_lower during Unmarshal.
 func TestStringTransformations_ToLower(t *testing.T) {
 	type User struct {
-		Email string `json:"email" pedantigo:"to_lower"`
+		Email string `json:"email" validate:"to_lower"`
 	}
 
 	validator := New[User]()
@@ -2191,7 +2191,7 @@ func TestStringTransformations_ToLower(t *testing.T) {
 // TestStringTransformations_ToUpper tests to_upper during Unmarshal.
 func TestStringTransformations_ToUpper(t *testing.T) {
 	type Product struct {
-		Code string `json:"code" pedantigo:"to_upper"`
+		Code string `json:"code" validate:"to_upper"`
 	}
 
 	validator := New[Product]()
@@ -2230,7 +2230,7 @@ func TestStringTransformations_ToUpper(t *testing.T) {
 // TestStringTransformations_Combined tests multiple transformations together.
 func TestStringTransformations_Combined(t *testing.T) {
 	type User struct {
-		Email string `json:"email" pedantigo:"strip_whitespace,to_lower"`
+		Email string `json:"email" validate:"strip_whitespace,to_lower"`
 	}
 
 	validator := New[User]()
@@ -2264,7 +2264,7 @@ func TestStringTransformations_Combined(t *testing.T) {
 // TestStringTransformations_StripAndToUpper tests strip_whitespace with to_upper.
 func TestStringTransformations_StripAndToUpper(t *testing.T) {
 	type Product struct {
-		Code string `json:"code" pedantigo:"strip_whitespace,to_upper"`
+		Code string `json:"code" validate:"strip_whitespace,to_upper"`
 	}
 
 	validator := New[Product]()
@@ -2277,7 +2277,7 @@ func TestStringTransformations_StripAndToUpper(t *testing.T) {
 // TestStringTransformations_WithPointerField tests transformations with pointer fields.
 func TestStringTransformations_WithPointerField(t *testing.T) {
 	type User struct {
-		Email *string `json:"email" pedantigo:"strip_whitespace,to_lower"`
+		Email *string `json:"email" validate:"strip_whitespace,to_lower"`
 	}
 
 	validator := New[User]()
@@ -2297,7 +2297,7 @@ func TestStringTransformations_WithPointerField(t *testing.T) {
 // TestStringTransformations_WithDefaults tests transformations with default values.
 func TestStringTransformations_WithDefaults(t *testing.T) {
 	type Config struct {
-		Mode string `json:"mode" pedantigo:"default=DEBUG,to_lower"`
+		Mode string `json:"mode" validate:"default=DEBUG,to_lower"`
 	}
 
 	validator := New[Config]()
@@ -2317,7 +2317,7 @@ func TestStringTransformations_WithDefaults(t *testing.T) {
 // checks format but does NOT mutate the value.
 func TestStringTransformations_Validate_NoMutation(t *testing.T) {
 	type User struct {
-		Email string `json:"email" pedantigo:"to_lower"`
+		Email string `json:"email" validate:"to_lower"`
 	}
 
 	validator := New[User]()
@@ -2339,7 +2339,7 @@ func TestStringTransformations_Validate_NoMutation(t *testing.T) {
 // TestStringTransformations_Validate_StripWhitespace tests strip_whitespace in Validate mode.
 func TestStringTransformations_Validate_StripWhitespace(t *testing.T) {
 	type User struct {
-		Name string `json:"name" pedantigo:"strip_whitespace"`
+		Name string `json:"name" validate:"strip_whitespace"`
 	}
 
 	validator := New[User]()
@@ -2361,7 +2361,7 @@ func TestStringTransformations_Validate_StripWhitespace(t *testing.T) {
 // TestStringTransformations_NewModel_Map tests transformations with map input.
 func TestStringTransformations_NewModel_Map(t *testing.T) {
 	type User struct {
-		Email string `json:"email" pedantigo:"strip_whitespace,to_lower"`
+		Email string `json:"email" validate:"strip_whitespace,to_lower"`
 	}
 
 	validator := New[User]()
@@ -2376,7 +2376,7 @@ func TestStringTransformations_NewModel_Map(t *testing.T) {
 // TestStringTransformations_WithValidation tests transformations with additional validation.
 func TestStringTransformations_WithValidation(t *testing.T) {
 	type User struct {
-		Email string `json:"email" pedantigo:"strip_whitespace,to_lower,email"`
+		Email string `json:"email" validate:"strip_whitespace,to_lower,email"`
 	}
 
 	validator := New[User]()
@@ -2407,12 +2407,12 @@ func TestStringTransformations_WithValidation(t *testing.T) {
 
 // circularConversation references circularMessage, which references back.
 type circularConversation struct {
-	ID       string            `json:"id" pedantigo:"required"`
-	Messages []circularMessage `json:"messages" pedantigo:"dive"`
+	ID       string            `json:"id" validate:"required"`
+	Messages []circularMessage `json:"messages" validate:"dive"`
 }
 
 type circularMessage struct {
-	ID           string                `json:"id" pedantigo:"required"`
+	ID           string                `json:"id" validate:"required"`
 	Conversation *circularConversation `json:"conversation"`
 }
 
@@ -2480,8 +2480,8 @@ func TestCircularReference_Unmarshal(t *testing.T) {
 
 // Self-referencing type (tree structure).
 type circularTreeNode struct {
-	Name     string              `json:"name" pedantigo:"required"`
-	Children []*circularTreeNode `json:"children" pedantigo:"dive"`
+	Name     string              `json:"name" validate:"required"`
+	Children []*circularTreeNode `json:"children" validate:"dive"`
 }
 
 // TestCircularReference_SelfReferencing tests self-referencing types (trees).
@@ -2506,7 +2506,7 @@ func TestCircularReference_SelfReferencing(t *testing.T) {
 
 // validatableApp is a type that implements Validatable by calling back into pedantigo.
 type validatableApp struct {
-	Name string `json:"name" pedantigo:"required"`
+	Name string `json:"name" validate:"required"`
 }
 
 var (


### PR DESCRIPTION
## Summary

Pedantigo's zero-config default struct tag changes from `pedantigo` to `validate`, and the module bumps to v2 to reflect this breaking change. Together these align the library with the tag name already used by `go-playground/validator` and read by tooling across the Go ecosystem, so structs written for those tools now validate correctly under Pedantigo with no tag changes at all.

### Why `validate`

- **go-playground/validator** is the tag's origin and the most widely used Go validation library. Pedantigo already tracks its constraint syntax closely (~127/147 tags identical); matching the tag name too means existing structs need zero edits to adopt Pedantigo.
- **swaggo/swag**, the standard tool for generating OpenAPI/Swagger specs from Go source, reads `validate:"required"` to mark fields required in the generated schema. It has partial support for pulling `oneof`, `min`, and `max` into the schema as well (tracked upstream: swaggo/swag#995). Structs tagged `pedantigo:"..."` were invisible to swag; tagged `validate:"..."`, the same struct now produces a more accurate OpenAPI spec — and, by extension, more accurate generated client SDKs — without any extra annotation work.
- Unrecognized tag keys are silently ignored by Pedantigo's constraint parser, so any validator-only tag not supported here (`omitnil`, `structonly`, etc.) is a harmless no-op rather than an error.

### Core Changes

- `DefaultTagName` changed from `"pedantigo"` to `"validate"` (`config.go`, `internal/tags/parser.go`)
- All tests, examples, and internal usages updated to read `validate:"..."` tags by default
- Test suite hardened against the rename: tests that specifically exercise custom/non-default tag names now use distinct example tag names, so they can't silently start testing the wrong thing if the default changes again

### Module Version

- Module path bumped to `github.com/SmrutAI/pedantigo/v2`, per [Go's semantic import versioning rules](https://go.dev/ref/mod) — required for any major version 2+ release, not optional
- All internal self-imports (23 files) updated to the `/v2` path
- Added `docs/migration/v1-to-v2.md`: why the default changed, the dangerous silent-failure mode (old `pedantigo:"..."` tags stop being enforced with no error, not a compile break), the import path change, and both migration options — rename tags to `validate:"..."` (recommended), or call `SetTagName("pedantigo")` to preserve v1 behavior without touching structs
- Added v2 callouts to `docs/intro.md` and `docs/api/initialization.md`, and a breaking-change note + updated `go get` path in `README.md`

### Documentation

- `docs/migration/from-validator.md` rewritten: previously described a one-line `SetTagName("validate")` opt-in; now explains that migration needs no tag changes at all, and restructures the remaining real differences (validator construction, `omitempty` semantics, custom validator registration) into a two-step path — the zero-setup Simple API first, with the Core API (`pedantigo.New[T]()`) as an optional, benchmarked upgrade for high-throughput code paths
- Corrected every remaining doc comment and example across the library and docs that still described `pedantigo` as the default tag name

## Test Plan

- [x] `make test` (race detector enabled) — all packages pass
- [x] `make vet` — clean
