### PR TITLE
docs(readme): fix badges and Go version compatibility claim

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,31 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+
+      - name: Install golangci-lint
+        # GOTOOLCHAIN=go1.25.12 matches the Go version upstream's official
+        # v2.12.2 release binaries are built with (see the GOTOOLCHAIN scoping
+        # in the Makefile's lint target), so this build stays equivalent to
+        # the release binary the official installer would have fetched.
+        run: GOTOOLCHAIN=go1.25.12 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+
+      - name: Run golangci-lint (validator)
+        run: make lint-core
+
+      - name: Run golangci-lint (plugins)
+        run: make lint-plugins

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Pedantigo
 
 [![CI](https://github.com/SmrutAI/pedantigo/actions/workflows/ci.yml/badge.svg)](https://github.com/SmrutAI/pedantigo/actions/workflows/ci.yml)
+[![Lint](https://github.com/SmrutAI/pedantigo/actions/workflows/lint.yml/badge.svg)](https://github.com/SmrutAI/pedantigo/actions/workflows/lint.yml)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/tushar2708/67408111d1830ed523e2661d9ee2a442/raw/pedantigo-coverage.json)](https://github.com/SmrutAI/pedantigo)
-[![Go Report Card](https://goreportcard.com/badge/github.com/SmrutAI/pedantigo)](https://goreportcard.com/report/github.com/SmrutAI/pedantigo)
 
 Type-safe JSON validation and schema generation for Go.
 
@@ -17,7 +17,7 @@ Type-safe JSON validation and schema generation for Go.
 go get github.com/SmrutAI/pedantigo/v2/validator
 ```
 
-Requires Go 1.21+
+Requires Go 1.21+ ([nuances](contrib-docs/nuances/go_version_behavior.md))
 
 ## Quick Example
 

--- a/contrib-docs/nuances/go_version_behavior.md
+++ b/contrib-docs/nuances/go_version_behavior.md
@@ -1,0 +1,43 @@
+# Go Version Behavior Nuances
+
+Cases where Pedantigo's behavior depends on the Go toolchain version used to *build*
+your application, not on anything declared in Pedantigo's own `go.mod`.
+
+## `mac` constraint and `net.ParseMAC` (Go 1.26+)
+
+**What changed:** Go's standard library `net.ParseMAC` gained support for parsing
+MAC addresses with no separators (e.g. `001A2B3C4D5E`, IEEE EUI-48 base-16 form)
+in Go 1.26. See the upstream tracking issue:
+[golang/go#66682](https://github.com/golang/go/issues/66682).
+
+**Why this matters for Pedantigo:** the `mac` constraint (used via `validate:"mac"`)
+calls `net.ParseMAC` directly. Its behavior is therefore determined by the actual Go
+toolchain used to compile *your* application — not by Pedantigo's `go.mod`, and not
+by which Pedantigo version you're on.
+
+**This does not affect whether Pedantigo builds or runs.** `go.mod`'s `go 1.21` line
+is a minimum toolchain floor, not a behavior guarantee — any toolchain at or above
+that floor (1.21, 1.23, 1.25, 1.26, ...) builds and runs Pedantigo identically in
+every other respect.
+
+A project on Go 1.21 can depend on, build, and run Pedantigo
+in production with no issues. The *only* thing that differs is the validation
+*result* of one specific input value on one specific constraint, at request-handling
+time — same category of outcome as any other input a user submits that fails
+validation, not a build or dependency problem:
+
+| Toolchain used to build your app | `validate:"mac"` on the value `"001A2B3C4D5E"` (no separators) |
+|---|---|
+| Go 1.21 – 1.25 | Validation fails (treated as an invalid MAC address) |
+| Go 1.26+ | Validation passes |
+
+Colon-, hyphen-, and dot-separated MAC formats (`00:1A:2B:3C:4D:5E`,
+`00-1A-2B-3C-4D-5E`, `001A.2B3C.4D5E`) are unaffected — they've always been
+supported and behave identically across all Go versions Pedantigo supports. If your
+application never validates MAC addresses, or never needs to accept the
+no-separator form, this nuance has no effect on you at all.
+
+**If you do rely on the `mac` constraint accepting no-separator input**, build your
+application with Go 1.26 or later. If you're on an older toolchain, either add
+separators to input before validation, or avoid the no-separator MAC form in data
+you expect the `mac` constraint to accept.


### PR DESCRIPTION
## Summary

Fixes two misleading README badges and documents a real Go-version-dependent behavior difference in the `mac` validation constraint.

### Badges

- Remove the Go Report Card badge — the service itself has been sunset by its maintainers ("After more than a decade of serving the ecosystem, Go Report Card has been sunset"), so the badge is permanently dead across every project that used it, not specific to this repo.
- Add a dedicated `Lint` GitHub Actions workflow (`.github/workflows/lint.yml`) and badge, split out from the main `CI` job, so lint status is visible independently of the rest of CI.

### Documentation

- Add `contrib-docs/nuances/go_version_behavior.md` documenting that the `mac` constraint's handling of no-separator MAC addresses (e.g. `001A2B3C4D5E`) depends on the Go toolchain used to build the *consuming* application, not on pedantigo's own `go.mod` floor. `net.ParseMAC` only gained support for that format in Go 1.26 ([golang/go#66682](https://github.com/golang/go/issues/66682)); `go.mod`'s `go 1.21` line is a minimum toolchain floor, not a behavior guarantee. This does not affect whether pedantigo builds or runs on Go 1.21 — only the validation result of that one specific input on that one constraint.
- Link this from the README's "Requires Go 1.21+" line so the version claim isn't misread as a stronger compatibility guarantee than it actually is.

## Test Plan
- [x] New `lint.yml` mirrors CI's exact golangci-lint version/toolchain pinning (`v2.12.2`, `GOTOOLCHAIN=go1.25.12`) so results stay equivalent to the existing `make lint-core`/`make lint-plugins` targets
- [x] Confirmed no existing doc in `contrib-docs/nuances/` already covered this Go-version nuance before adding the new file
- [x] Lint and tests passed via local pre-commit before committing
